### PR TITLE
Adding compute_psd and plot_psd functions to lightcurve.py

### DIFF
--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -330,7 +330,17 @@ class Lightcurve(object):
 
         #Now we're going
 
-        
+    def compute_psd(means, f, scales, weights):
+        c = np.zeros((len(means),) + f.shape, ) #mean = mean of each gaussian in the psd (the kernel we use uses only gaussians).
+        for i, m in enumerate(means): #f = array of frequencies that we want to plot
+            s = scales[i] #s.d
+            w = weights[i] #how much power is given to each gaussian
+            c[i] = np.sqrt(w) * (norm.pdf(f, m, s) - norm.pdf(-f, m, s))  #subtracting negative side of psd - otherwise it would cause interference
+            # Each component of the PSD is the weight times the difference of the forward and reverse PDFs
+            # In this case, the weights are square-rooted, because the original AGW formula for the kernel uses weights**2 while gpytorch implements weights, and therefore we must adjust our interpretation of the output.
+        # Now we just have to some over the components
+        psd = np.sum(c, axis=0)
+
     def plot(self):
         with torch.no_grad(), gpytorch.settings.fast_pred_var():
             # Get into evaluation (predictive posterior) mode

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -330,16 +330,28 @@ class Lightcurve(object):
 
         #Now we're going
 
-    def compute_psd(means, f, scales, weights):
-        c = np.zeros((len(means),) + f.shape, ) #mean = mean of each gaussian in the psd (the kernel we use uses only gaussians).
+    def plot_psd(self, means, freq, scales, weights):
+        #Computing the psd for frequencies f
+        psd = compute_psd(means, freq, scales, weights)
+
+        # Initialize plot
+        fig, ax = plt.subplots(1, 1, figsize=(8, 6))
+
+        #plotting psd
+        ax.plot(freq, psd)
+        plt.show()
+
+    def compute_psd(means, freq, scales, weights):
+        c = np.zeros((len(means),) + freq.shape, ) #mean = mean of each gaussian in the psd (the kernel we use uses only gaussians).
         for i, m in enumerate(means): #f = array of frequencies that we want to plot
             s = scales[i] #s.d
             w = weights[i] #how much power is given to each gaussian
-            c[i] = np.sqrt(w) * (norm.pdf(f, m, s) - norm.pdf(-f, m, s))  #subtracting negative side of psd - otherwise it would cause interference
+            c[i] = np.sqrt(w) * (norm.pdf(freq, m, s) - norm.pdf(-freq, m, s))  #subtracting negative side of psd - otherwise it would cause interference
             # Each component of the PSD is the weight times the difference of the forward and reverse PDFs
             # In this case, the weights are square-rooted, because the original AGW formula for the kernel uses weights**2 while gpytorch implements weights, and therefore we must adjust our interpretation of the output.
         # Now we just have to some over the components
         psd = np.sum(c, axis=0)
+        return psd
 
     def plot(self):
         with torch.no_grad(), gpytorch.settings.fast_pred_var():


### PR DESCRIPTION
Adding compute_psd and plot_psd functions to lightcurve.py.

So far all of the variables (e.g freq, means, etc.) all need to be given to the plot_psd function (and therefore need to be calculated somewhere else).