### PR TITLE
Converting everything to `gpytorch.Module`

### DIFF
--- a/.github/workflows/paper-draft-tex-and-pdf.yml
+++ b/.github/workflows/paper-draft-tex-and-pdf.yml
@@ -29,7 +29,7 @@ jobs:
           GIT_SHA: $GITHUB_SHA
           JOURNAL: joss
       - name: Upload
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: paper
           path: paper/

--- a/.github/workflows/paper-draft.yml
+++ b/.github/workflows/paper-draft.yml
@@ -19,7 +19,7 @@ jobs:
           # This should be the path to the paper within your repo.
           paper-path: paper.md
       - name: Upload
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: paper
           # This is the output path where Pandoc will write the compiled

--- a/.github/workflows/publish-package-pypi.yml
+++ b/.github/workflows/publish-package-pypi.yml
@@ -1,0 +1,119 @@
+name: Publish Python 🐍 distribution 📦 to PyPI and TestPyPI
+
+on: 
+    push:
+        tags:
+            - "v*"
+    release:
+        types: [created]
+
+jobs:
+  build:
+    name: Build distribution 📦
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.x"
+    - name: Install pypa/build
+      run: >-
+        python3 -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  publish-to-pypi:
+    name: >-
+      Publish Python 🐍 distribution 📦 to PyPI
+    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pgmuvi  # Replace <package-name> with your PyPI project name
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: >-
+      Sign the Python 🐍 distribution 📦 with Sigstore
+      and upload them to GitHub Release
+    needs:
+    - publish-to-pypi
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write  # IMPORTANT: mandatory for making GitHub Releases
+      id-token: write  # IMPORTANT: mandatory for sigstore
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Sign the dists with Sigstore
+      uses: sigstore/gh-action-sigstore-python@v1.2.3
+      with:
+        inputs: >-
+          ./dist/*.tar.gz
+          ./dist/*.whl
+    - name: Create GitHub Release
+      run: >-
+        gh release create
+        '${{ github.ref_name }}'
+        --notes ""
+    - name: Upload artifact signatures to GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      # Upload to GitHub Release using the `gh` CLI.
+      # `dist/` contains the built packages, and the
+      # sigstore-produced signatures and certificates.
+      run: >-
+        gh release upload
+        '${{ github.ref_name }}' dist/**
+        --repo '${{ github.repository }}'
+
+  publish-to-testpypi:
+    name: Publish Python 🐍 distribution 📦 to TestPyPI
+    needs:
+    - build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/<package-name>
+
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution 📦 to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -13,4 +13,4 @@ jobs:
       with:
         # version: "latest"
         src: "./pgmuvi"
-        args: "check -v --show-source"
+        args: "check -v --output-format=full --show-fixes"

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -1182,7 +1182,11 @@ class Lightcurve(torch.nn.Module):
                              disable_progbar=disable_progbar)
         import linear_operator.utils.errors as linear
         try:
-            self.mcmc_run.run(self._xdata_transformed, self._ydata_transformed)
+            if cuda:
+                self.mcmc_run.run(self._xdata_transformed.cuda(),
+                                  self._ydata_transformed.cuda())
+            else:
+                self.mcmc_run.run(self._xdata_transformed, self._ydata_transformed)
         except linear.NanError as e:
             print("NaNError encountered, returning None")
             print(list(model.named_parameters()))

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -1325,7 +1325,7 @@ class Lightcurve(torch.nn.Module):
                     p = 1/self.model.covar_module.mixture_means[i]
                 else:
                     p = self.xtransform.inverse(1/self.model.covar_module.mixture_means[i],  # noqa: E501
-                                                shift=False).detach().numpy()[0]
+                                                shift=False)..cpu().detach().numpy()[0]
                 print(f"Period {i}: "
                       f"{p}"
                       f" weight: {self.model.covar_module.mixture_weights[i]}")
@@ -1335,7 +1335,7 @@ class Lightcurve(torch.nn.Module):
                     p = 1/self.model.covar_module.mixture_means[i, 0]
                 else:
                     p = self.xtransform.inverse(1/self.model.covar_module.mixture_means[i, 0],  # noqa: E501
-                                                shift=False).detach().numpy()[0, 0]
+                                                shift=False)..cpu().detach().numpy()[0, 0]
                 print(f"Period {i}: "
                       f"{p}"
                       f" weight: {self.model.covar_module.mixture_weights[i]}")
@@ -1355,9 +1355,9 @@ class Lightcurve(torch.nn.Module):
                     scales.append(1/(2*torch.pi*self.model.sci_kernel.mixture_scales[i]))
                 else:
                     p = self.xtransform.inverse(1/self.model.sci_kernel.mixture_means[i],  # noqa: E501
-                                                shift=False).detach().numpy()[0]
+                                                shift=False)..cpu().detach().numpy()[0]
                     scales.append(self.xtransform.inverse(1/(2*torch.pi*self.model.sci_kernel.mixture_scales[i]),
-                                                          shift=False).detach().numpy()[0])
+                                                          shift=False)..cpu().detach().numpy()[0])
                 periods.append(p)
                 weights.append(self.model.sci_kernel.mixture_weights[i])
         elif self.ndim == 2:
@@ -1367,9 +1367,9 @@ class Lightcurve(torch.nn.Module):
                     scales.append(1/(2*torch.pi*self.model.sci_kernel.mixture_scales[i, 0]))  # noqa: E501
                 else:
                     p = self.xtransform.inverse(1/self.model.sci_kernel.mixture_means[i, 0],  # noqa: E501
-                                                shift=False).detach().numpy()[0, 0]
+                                                shift=False)..cpu().detach().numpy()[0, 0]
                     scales.append(self.xtransform.inverse(1/(2*torch.pi*self.model.sci_kernel.mixture_scales[i, 0]),  # noqa: E501
-                                                shift=False).detach().numpy()[0, 0])
+                                                shift=False)..cpu().detach().numpy()[0, 0])
                 periods.append(p)
                 weights.append(self.model.sci_kernel.mixture_weights[i])
 
@@ -1788,7 +1788,7 @@ class Lightcurve(torch.nn.Module):
         if debug:
             print(psd.shape)
         if not log:
-            psd = psd.exp().detach().numpy()
+            psd = psd.exp()..cpu().detach().numpy()
         return psd
 
     def plot(self, ylim=None, show=True,
@@ -2045,16 +2045,16 @@ class Lightcurve(torch.nn.Module):
             try:
                 t['weights'] = [np.asarray(weights)]
             except RuntimeError:
-                t['weights'] = [torch.as_tensor(weights).detach().numpy()]
+                t['weights'] = [torch.as_tensor(weights)..cpu().detach().numpy()]
             try:
                 t['scales'] = [np.asarray(scales)]
             except RuntimeError:
-                t['scales'] = [torch.as_tensor(scales).detach().numpy()]
+                t['scales'] = [torch.as_tensor(scales)..cpu().detach().numpy()]
             for key, value in self.results.items():
                 try:
                     t[key] = [np.asarray(value)]
                 except RuntimeError:
-                    t[key] = [torch.as_tensor(value).detach().numpy()]
+                    t[key] = [torch.as_tensor(value)..cpu().detach().numpy()]
             if self.__FITTED_MAP:
                 # Loss isn't relevant for MCMC, I think
                 t['loss'] = [np.asarray(self.results['loss'])]

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -51,11 +51,11 @@ def dict_walk_generator(indict, pre=None):
     if isinstance(indict, dict):
         for key, value in indict.items():
             if isinstance(value, dict):
-                for d in dict_generator(value, pre + [key]):
+                for d in dict_walk_generator(value, pre + [key]):
                     yield d
             elif isinstance(value, list) or isinstance(value, tuple):
                 for v in value:
-                    for d in dict_generator(v, pre + [key]):
+                    for d in dict_walk_generator(v, pre + [key]):
                         yield d
             else:
                 yield pre + [key, value]

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -45,7 +45,7 @@ def _reraise_with_note(e, note):
     raise e
 
 
-class Transformer(object):
+class Transformer(torch.nn.Module):
     def transform(self, data, **kwargs):
         """ Transform some data and return it, storing the parameters required
         to repeat or reverse the transform
@@ -208,7 +208,7 @@ def minmax(data, dim=0):
     return (data-m)/r, m, r
 
 
-class Lightcurve(object):
+class Lightcurve(torch.nn.Module):
     """ A class for storing, manipulating and fitting light curves
 
     This class is designed to be a convenient way to store and manipulate

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -1164,7 +1164,7 @@ class Lightcurve(torch.nn.Module):
 
         model = self.model
 
-        mll = gpytorch.mlls.ExactMarginalLogLikelihood(likelihood, model)
+        mll = gpytorch.mlls.ExactMarginalLogLikelihood(self.likelihood, model)
 
         def pyro_model(x, y):
             model.pyro_sample_from_prior()

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -1184,9 +1184,12 @@ class Lightcurve(torch.nn.Module):
                     #self.state_dict()[key] = self.state_dict()[key].cuda()
                 for param_name, param in self.model.named_parameters():
                     print(f'Parameter name: {param_name:42} value = {param.data}, device = {param.data.device}')  # noqa: E501
+                print('----')
+                print("Lookup dict:")
                 for param_name, param in self._model_pars.items():
                     print(param)
-                    print(f'Parameter name: {param_name:42} value = {param["module"].raw_value}, device = {param["module"].raw_value.device}')  # noqa: E501
+                    print('----')
+                    #print(f'Parameter name: {param_name:42} value = {param["module"].value}, device = {param["module"].value.device}')  # noqa: E501
                 sampled_model = model.pyro_sample_from_prior()  # .detatch()
                 output = sampled_model.likelihood(sampled_model(x))  # .detatch()
                 pyro.sample("obs", output, obs=y)

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -1898,7 +1898,7 @@ class Lightcurve(torch.nn.Module):
         if self.xtransform is None:
             self.x_fine_transformed = x_fine_raw
         elif isinstance(self.xtransform, Transformer):
-            self.x_fine_transformed = self.xtransform.transform(x_fine_raw)
+            self.x_fine_transformed = self.xtransform.transform(x_fine_raw.to(self.xtransform.min.device))  # noqa: E501
 
         self.expanded_test_x = self.x_fine_transformed.unsqueeze(0).repeat(self.num_samples, 1, 1)  # .unsqueeze(0)  # noqa: E501
         print(self.x_fine_transformed.shape)
@@ -1910,7 +1910,8 @@ class Lightcurve(torch.nn.Module):
             ax.plot(self.xdata.cpu().numpy(), self.ydata.cpu().numpy(), 'k*')
             for i in range(min(n_samples_to_plot, self.num_samples)):
                 # Plot predictive samples as colored lines
-                ax.plot(x_fine_raw.cpu().numpy(), output[i].sample().cpu().numpy(), 'b', alpha=0.2)
+                ax.plot(x_fine_raw.cpu().numpy(), output[i].sample().cpu().numpy(), 'b',
+                        alpha=0.2)
 
             ax.legend(['Observed Data', 'Sample means'])
             if ylim is not None:
@@ -1926,7 +1927,7 @@ class Lightcurve(torch.nn.Module):
         if self.xtransform is None:
             x_fine_transformed = x_fine_raw
         elif isinstance(self.xtransform, Transformer):
-            x_fine_transformed = self.xtransform.transform(x_fine_raw)
+            x_fine_transformed = self.xtransform.transform(x_fine_raw.to(self.xtransform.min.device))  # noqa: E501
 
         # Make predictions
         observed_pred = self.likelihood(self.model(x_fine_transformed))
@@ -1961,7 +1962,7 @@ class Lightcurve(torch.nn.Module):
         if self.xtransform is None:
             x_fine_transformed = x_fine_raw
         elif isinstance(self.xtransform, Transformer):
-            x_fine_transformed = self.xtransform.transform(x_fine_raw,
+            x_fine_transformed = self.xtransform.transform(x_fine_raw.to(self.xtransform.min.device), # noqa: E501
                                                            apply_to=(0, 0))
         unique_values_axis2 = torch.unique(self.xdata[:,1])
         figs = []
@@ -2078,7 +2079,7 @@ class Lightcurve(torch.nn.Module):
                     if self.xtransform is None:
                         x_fine_transformed = x_fine_raw
                     elif isinstance(self.xtransform, Transformer):
-                        x_fine_transformed = self.xtransform.transform(x_fine_raw)
+                        x_fine_transformed = self.xtransform.transform(x_fine_raw.to(self.xtransform.min.device))  # noqa: E501
 
                     # Make predictions
                     observed_pred = self.likelihood(self.model(x_fine_transformed))

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -1104,6 +1104,7 @@ class Lightcurve(torch.nn.Module):
              warmup_steps=100, num_chains=1,
              disable_progbar=False,
              max_cg_iterations=None,
+             cuda=False,
              **kwargs):
         '''Run an MCMC sampler on the model
 
@@ -1155,6 +1156,9 @@ class Lightcurve(torch.nn.Module):
 
         if max_cg_iterations is None:
             max_cg_iterations = 10000
+
+        if cuda:
+            self.cuda()
 
         model = self.model
 

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -1164,21 +1164,21 @@ class Lightcurve(torch.nn.Module):
 
         model = self.model
 
-        mll = gpytorch.mlls.ExactMarginalLogLikelihood(self.likelihood, model)
-
-        def pyro_model(x, y):
-            model.pyro_sample_from_prior()
-            output = model(x)
-            loss = mll.pyro_factor(output, y)
-            return y
+        # mll = gpytorch.mlls.ExactMarginalLogLikelihood(self.likelihood, model)
 
         # def pyro_model(x, y):
-        #     with (gpytorch.settings.fast_computations(False, False, False),
-        #           gpytorch.settings.max_cg_iterations(max_cg_iterations)):
-        #         sampled_model = model.pyro_sample_from_prior()  # .detatch()
-        #         output = sampled_model.likelihood(sampled_model(x))  # .detatch()
-        #         pyro.sample("obs", output, obs=y)
+        #     model.pyro_sample_from_prior()
+        #     output = model(x)
+        #     loss = mll.pyro_factor(output, y)
         #     return y
+
+        def pyro_model(x, y):
+            with (gpytorch.settings.fast_computations(False, False, False),
+                  gpytorch.settings.max_cg_iterations(max_cg_iterations)):
+                sampled_model = model.pyro_sample_from_prior()  # .detatch()
+                output = sampled_model.likelihood(sampled_model(x))  # .detatch()
+                pyro.sample("obs", output, obs=y)
+            return y
 
         self.num_samples = num_samples
 

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -1164,13 +1164,21 @@ class Lightcurve(torch.nn.Module):
 
         model = self.model
 
+        mll = gpytorch.mlls.ExactMarginalLogLikelihood(likelihood, model)
+
         def pyro_model(x, y):
-            with (gpytorch.settings.fast_computations(False, False, False),
-                  gpytorch.settings.max_cg_iterations(max_cg_iterations)):
-                sampled_model = model.pyro_sample_from_prior()  # .detatch()
-                output = sampled_model.likelihood(sampled_model(x))  # .detatch()
-                pyro.sample("obs", output, obs=y)
+            model.pyro_sample_from_prior()
+            output = model(x)
+            loss = mll.pyro_factor(output, y)
             return y
+
+        # def pyro_model(x, y):
+        #     with (gpytorch.settings.fast_computations(False, False, False),
+        #           gpytorch.settings.max_cg_iterations(max_cg_iterations)):
+        #         sampled_model = model.pyro_sample_from_prior()  # .detatch()
+        #         output = sampled_model.likelihood(sampled_model(x))  # .detatch()
+        #         pyro.sample("obs", output, obs=y)
+        #     return y
 
         self.num_samples = num_samples
 

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -1229,10 +1229,10 @@ class Lightcurve(torch.nn.Module):
                     #self.state_dict()[key] = self.state_dict()[key].cuda()
                 for param_name, param in self.model.named_parameters():
                     print(f'Parameter name: {param_name:42} value = {param.data}, device = {param.data.device}')  # noqa: E501
-                print(self.model.mixture_means)
-                print(self.model.mixture_scales)
-                print(self.model.mixture_weights)
-                # print(self.model.mixture_means_prior)
+                print(self.model.covar_module.mixture_means)
+                print(self.model.covar_module.mixture_scales)
+                print(self.model.covar_module.mixture_weights)
+                print(self.model.covar_module.mixture_means_prior)
                 print('----')
                 print("Lookup dict:")
                 for param_name, param in self._model_pars.items():

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -109,10 +109,9 @@ class MinMax(Transformer):
             only the range needs to be applied.
         """
         if recalc or not hasattr(self, "min"):
-            self.min = torch.min(data, dim=dim, keepdim=True)[0]
-            self.register_buffer('min', self.min)
-            self.range = torch.max(data, dim=dim, keepdim=True)[0] - self.min
-            self.register_buffer('range', self.range)
+            self.register_buffer('min', torch.min(data, dim=dim, keepdim=True)[0])
+            self.register_buffer('range', torch.max(data, dim=dim, keepdim=True)[0]
+                                 - self.min)
             shift = True  # if we're recalculating, we need to shift
         if apply_to is not None:
             return (data-(shift*self.min[apply_to]))/self.range[apply_to]

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -318,13 +318,14 @@ class Lightcurve(torch.nn.Module):
     @xdata.setter
     def xdata(self, values):
         # first, store the raw data internally
-        self._xdata_raw = values
+        self.register_buffer('_xdata_raw', values)
         # then, apply the transformation to the values, so it can be used to
         # train the GP
         if self.xtransform is None:
-            self._xdata_transformed = values
+            self.register_buffer('_xdata_transformed', values)
         elif isinstance(self.xtransform, Transformer):
-            self._xdata_transformed = self.xtransform.transform(values)
+            self.register_buffer('_xdata_transformed',
+                                 self.xtransform.transform(values))
 
     @property
     def ydata(self):
@@ -340,12 +341,13 @@ class Lightcurve(torch.nn.Module):
     @ydata.setter
     def ydata(self, values):
         # first, store the raw data internally
-        self._ydata_raw = values
+        self.register_buffer('_ydata_raw', values)
         # then, apply the transformation to the values
         if self.ytransform is None:
-            self._ydata_transformed = values
+            self.register_buffer('_ydata_transformed', values)
         elif isinstance(self.ytransform, Transformer):
-            self._ydata_transformed = self.ytransform.transform(values)
+            self.register_buffer('_ydata_transformed',
+                                 self.ytransform.transform(values))
 
     @property
     def yerr(self):
@@ -361,12 +363,14 @@ class Lightcurve(torch.nn.Module):
 
     @yerr.setter
     def yerr(self, values):
-        self._yerr_raw = values
+        # first, store the raw data internally
+        self.register_buffer('_yerr_raw', values)
         # now apply the same transformation that was applied to the ydata
         if self.ytransform is None:
-            self._yerr_transformed = values
+            self.register_buffer('_yerr_transformed', values)
         elif isinstance(self.ytransform, Transformer):
-            self._yerr_transformed = self.ytransform.transform(values)
+            self.register_buffer('_yerr_transformed',
+                                 self.ytransform.transform(values))
 
     def append_data(self, new_values_x, new_values_y):
         pass
@@ -909,13 +913,13 @@ class Lightcurve(torch.nn.Module):
     def _set_hypers_raw(self, hypers=None, **kwargs):
         pass
 
-    def cuda(self):
-        try:
-            self.model.cuda()
-            self.likelihood.cuda()
-        except AttributeError as e:
-            errmsg = "You must first set the model and likelihood"
-            _reraise_with_note(e, errmsg)
+    # def cuda(self):
+    #     try:
+    #         self.model.cuda()
+    #         self.likelihood.cuda()
+    #     except AttributeError as e:
+    #         errmsg = "You must first set the model and likelihood"
+    #         _reraise_with_note(e, errmsg)
 
     def _train(self):
         try:

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -1325,7 +1325,7 @@ class Lightcurve(torch.nn.Module):
                     p = 1/self.model.covar_module.mixture_means[i]
                 else:
                     p = self.xtransform.inverse(1/self.model.covar_module.mixture_means[i],  # noqa: E501
-                                                shift=False)..cpu().detach().numpy()[0]
+                                                shift=False).cpu().detach().numpy()[0]
                 print(f"Period {i}: "
                       f"{p}"
                       f" weight: {self.model.covar_module.mixture_weights[i]}")
@@ -1335,7 +1335,7 @@ class Lightcurve(torch.nn.Module):
                     p = 1/self.model.covar_module.mixture_means[i, 0]
                 else:
                     p = self.xtransform.inverse(1/self.model.covar_module.mixture_means[i, 0],  # noqa: E501
-                                                shift=False)..cpu().detach().numpy()[0, 0]
+                                                shift=False).cpu().detach().numpy()[0, 0]
                 print(f"Period {i}: "
                       f"{p}"
                       f" weight: {self.model.covar_module.mixture_weights[i]}")
@@ -1355,9 +1355,9 @@ class Lightcurve(torch.nn.Module):
                     scales.append(1/(2*torch.pi*self.model.sci_kernel.mixture_scales[i]))
                 else:
                     p = self.xtransform.inverse(1/self.model.sci_kernel.mixture_means[i],  # noqa: E501
-                                                shift=False)..cpu().detach().numpy()[0]
+                                                shift=False).cpu().detach().numpy()[0]
                     scales.append(self.xtransform.inverse(1/(2*torch.pi*self.model.sci_kernel.mixture_scales[i]),
-                                                          shift=False)..cpu().detach().numpy()[0])
+                                                          shift=False).cpu().detach().numpy()[0])
                 periods.append(p)
                 weights.append(self.model.sci_kernel.mixture_weights[i])
         elif self.ndim == 2:
@@ -1367,9 +1367,9 @@ class Lightcurve(torch.nn.Module):
                     scales.append(1/(2*torch.pi*self.model.sci_kernel.mixture_scales[i, 0]))  # noqa: E501
                 else:
                     p = self.xtransform.inverse(1/self.model.sci_kernel.mixture_means[i, 0],  # noqa: E501
-                                                shift=False)..cpu().detach().numpy()[0, 0]
+                                                shift=False).cpu().detach().numpy()[0, 0]
                     scales.append(self.xtransform.inverse(1/(2*torch.pi*self.model.sci_kernel.mixture_scales[i, 0]),  # noqa: E501
-                                                shift=False)..cpu().detach().numpy()[0, 0])
+                                                shift=False).cpu().detach().numpy()[0, 0])
                 periods.append(p)
                 weights.append(self.model.sci_kernel.mixture_weights[i])
 
@@ -1788,7 +1788,7 @@ class Lightcurve(torch.nn.Module):
         if debug:
             print(psd.shape)
         if not log:
-            psd = psd.exp()..cpu().detach().numpy()
+            psd = psd.exp().cpu().detach().numpy()
         return psd
 
     def plot(self, ylim=None, show=True,
@@ -2045,16 +2045,16 @@ class Lightcurve(torch.nn.Module):
             try:
                 t['weights'] = [np.asarray(weights)]
             except RuntimeError:
-                t['weights'] = [torch.as_tensor(weights)..cpu().detach().numpy()]
+                t['weights'] = [torch.as_tensor(weights).cpu().detach().numpy()]
             try:
                 t['scales'] = [np.asarray(scales)]
             except RuntimeError:
-                t['scales'] = [torch.as_tensor(scales)..cpu().detach().numpy()]
+                t['scales'] = [torch.as_tensor(scales).cpu().detach().numpy()]
             for key, value in self.results.items():
                 try:
                     t[key] = [np.asarray(value)]
                 except RuntimeError:
-                    t[key] = [torch.as_tensor(value)..cpu().detach().numpy()]
+                    t[key] = [torch.as_tensor(value).cpu().detach().numpy()]
             if self.__FITTED_MAP:
                 # Loss isn't relevant for MCMC, I think
                 t['loss'] = [np.asarray(self.results['loss'])]

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -1161,7 +1161,6 @@ class Lightcurve(torch.nn.Module):
             self.cuda()
 
         model = self.model
-        print(model.device)
 
         def pyro_model(x, y):
             with (gpytorch.settings.fast_computations(False, False, False),

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -90,7 +90,9 @@ class MinMax(Transformer):
         """
         if recalc or not hasattr(self, "min"):
             self.min = torch.min(data, dim=dim, keepdim=True)[0]
+            self.register_buffer('min', self.min)
             self.range = torch.max(data, dim=dim, keepdim=True)[0] - self.min
+            self.register_buffer('range', self.range)
             shift = True  # if we're recalculating, we need to shift
         if apply_to is not None:
             return (data-(shift*self.min[apply_to]))/self.range[apply_to]
@@ -136,7 +138,9 @@ class ZScore(Transformer):
         """
         if recalc or not hasattr(self, 'mean'):
             self.mean = torch.mean(data, dim=dim, keepdim=True)[0]
+            self.register_buffer('mean', self.mean)
             self.sd = torch.std(data, dim=dim, keepdim=True)[0]
+            self.register_buffer('sd', self.sd)
             shift = True  # if we're recalculating, we need to shift
         if apply_to is not None:
             return (data-(shift*self.mean[apply_to]))/self.sd[apply_to]
@@ -181,8 +185,10 @@ class RobustZScore(Transformer):
         """
         if recalc or not hasattr(self, 'mad'):
             self.median = torch.median(data, dim=dim, keepdim=True)[0]
+            self.register_buffer('median', self.median)
             self.mad = torch.median(torch.abs(data - self.median),
                                     dim=dim, keepdim=True)[0]
+            self.register_buffer('mad', self.mad)
             shift = True  # if we're recalculating, we need to shift
         if apply_to is not None:
             return (data-shift*self.median[apply_to])/self.mad[apply_to]

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -1153,6 +1153,13 @@ class Lightcurve(torch.nn.Module):
 
         if cuda:
             self.cuda()
+            for key in self.state_dict().keys():
+                print(key)
+                try:
+                    print(self.state_dict()[key].device)
+                #self.state_dict()[key] = self.state_dict()[key].cuda()
+            for param_name, param in self.model.named_parameters():
+                print(f'Parameter name: {param_name:42} value = {param.data}, device = {param.data.device}')  # noqa: E501
 
         if not self.__PRIORS_SET:
             self.set_default_priors()

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -1175,6 +1175,15 @@ class Lightcurve(torch.nn.Module):
         def pyro_model(x, y):
             with (gpytorch.settings.fast_computations(False, False, False),
                   gpytorch.settings.max_cg_iterations(max_cg_iterations)):
+                for key in self.state_dict().keys():
+                    print(key)
+                    try:
+                        print(self.state_dict()[key].device)
+                    except AttributeError:
+                        pass
+                    #self.state_dict()[key] = self.state_dict()[key].cuda()
+                for param_name, param in self.model.named_parameters():
+                    print(f'Parameter name: {param_name:42} value = {param.data}, device = {param.data.device}')  # noqa: E501
                 sampled_model = model.pyro_sample_from_prior()  # .detatch()
                 output = sampled_model.likelihood(sampled_model(x))  # .detatch()
                 pyro.sample("obs", output, obs=y)

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -452,7 +452,7 @@ class Lightcurve(gpytorch.Module):
             self.likelihood = gpytorch.likelihoods.FixedNoiseGaussianLikelihood(self._yerr_transformed)  # noqa: E501
         elif hasattr(self, '_yerr_transformed') and likelihood == "learn":
             self.likelihood = gpytorch.likelihoods.FixedNoiseGaussianLikelihood(self._yerr_transformed,  # noqa: E501
-                                                                                learn_additional_noise=True)  # noqa: E501
+                                                                                learn_additional_noise=True)
         elif likelihood == "learn":
             self.likelihood = gpytorch.likelihoods.GaussianLikelihood(learn_additional_noise=True)  # noqa: E501
         elif "Constraint" in [t.__name__ for t in type(likelihood).__mro__]:
@@ -701,8 +701,8 @@ class Lightcurve(gpytorch.Module):
                                                                     apply_to=[0],
                                                                     shift=False))
                             constraint[key].lower_bound = torch.tensor(1./self.xtransform.transform(1./constraint[key].lower_bound,  # noqa: E501
-                                                                                                    apply_to=[0],  # noqa: E501
-                                                                                                    shift=False).item())  # noqa: E501
+                                                                                                    apply_to=[0],
+                                                                                                    shift=False).item())
                             if debug:
                                 print(constraint[key].lower_bound)
                                 print(constraint[key])
@@ -710,8 +710,8 @@ class Lightcurve(gpytorch.Module):
                             not in [torch.tensor(0), torch.tensor(torch.inf)]):
                             # we need to transform the upper bound
                             constraint[key].upper_bound = torch.tensor(1./self.xtransform.transform(1./constraint[key].upper_bound,  # noqa: E501
-                                                                                                    apply_to=[0],  # noqa: E501
-                                                                                                    shift=False).item())  # noqa: E501
+                                                                                                    apply_to=[0],
+                                                                                                    shift=False).item())
                             if debug:
                                 print(constraint[key].upper_bound)
                                 print(constraint[key])
@@ -978,7 +978,7 @@ class Lightcurve(gpytorch.Module):
 
         # for key in self._model_pars:
         #     with contextlib.suppress(AttributeError):
-        #         self._model_pars[key]['param'] = self._model_pars[key]['param'].cuda(device=device)
+        #         self._model_pars[key]['param'] = self._model_pars[key]['param'].cuda(device=device) # noqa: E501
         # try:
         #     self.model.cuda()
         #     self.likelihood.cuda()
@@ -1218,15 +1218,12 @@ class Lightcurve(gpytorch.Module):
         #     return y
 
         def pyro_model(x, y):
-            with (gpytorch.settings.fast_computations(False, False, False),
-                  gpytorch.settings.max_cg_iterations(max_cg_iterations)):
+            with (gpytorch.settings.fast_computations(False, False, False), gpytorch.settings.max_cg_iterations(max_cg_iterations)):  # noqa: E501
                 for key in self.state_dict().keys():
                     print(key)
-                    try:
+                    with contextlib.suppress(AttributeError):
                         print(self.state_dict()[key].device)
-                    except AttributeError:
-                        pass
-                    #self.state_dict()[key] = self.state_dict()[key].cuda()
+                                #self.state_dict()[key] = self.state_dict()[key].cuda()
                 for param_name, param in self.model.named_parameters():
                     print(f'Parameter name: {param_name:42} value = {param.data}, device = {param.data.device}')  # noqa: E501
                 print(self.model.covar_module.mixture_means)
@@ -1255,11 +1252,9 @@ class Lightcurve(gpytorch.Module):
         import linear_operator.utils.errors as linear
         for key in self.state_dict().keys():
             print(key)
-            try:
+            with contextlib.suppress(AttributeError):
                 print(self.state_dict()[key].device)
-            except AttributeError:
-                pass
-            #self.state_dict()[key] = self.state_dict()[key].cuda()
+                #self.state_dict()[key] = self.state_dict()[key].cuda()
         for param_name, param in self.model.named_parameters():
             print(f'Parameter name: {param_name:42} value = {param.data}, device = {param.data.device}')  # noqa: E501
 
@@ -1293,14 +1288,14 @@ class Lightcurve(gpytorch.Module):
 
         self.inference_data.posterior['transformed_periods'] = transformed_mcmc_periods
         self.inference_data.posterior['raw_periods'] = xr.DataArray(raw_mcmc_periods.reshape(self.post['covar_module.mixture_means_prior'].shape),  # noqa: E501
-                                                                    coords=self.inference_data.posterior['covar_module.mixture_means_prior'].indexes)  # noqa: E501
+                                                                    coords=self.inference_data.posterior['covar_module.mixture_means_prior'].indexes)
         self.inference_data.posterior['raw_frequencies'] = xr.DataArray(raw_mcmc_frequencies.reshape(self.post['covar_module.mixture_means_prior'].shape),  # noqa: E501
-                                                                        coords=self.inference_data.posterior['covar_module.mixture_means_prior'].indexes) # noqa: E501
+                                                                        coords=self.inference_data.posterior['covar_module.mixture_means_prior'].indexes)
         self.inference_data.posterior['transformed_period_scales'] = transformed_mcmc_period_scales  # noqa: E501
         self.inference_data.posterior['raw_period_scales'] = xr.DataArray(raw_mcmc_period_scales.reshape(self.post['covar_module.mixture_scales_prior'].shape),  # noqa: E501
-                                                                          coords=self.inference_data.posterior['covar_module.mixture_scales_prior'].indexes)  # noqa: E501
+                                                                          coords=self.inference_data.posterior['covar_module.mixture_scales_prior'].indexes)
         self.inference_data.posterior['raw_frequency_scales'] = xr.DataArray(raw_mcmc_frequency_scales.reshape(self.post['covar_module.mixture_scales_prior'].shape),  # noqa: E501
-                                                                             coords=self.inference_data.posterior['covar_module.mixture_scales_prior'].indexes)  # noqa: E501
+                                                                             coords=self.inference_data.posterior['covar_module.mixture_scales_prior'].indexes)
 
         # self.mcmc_results = mcmc(self, sampler, **kwargs)
 
@@ -1428,7 +1423,7 @@ class Lightcurve(gpytorch.Module):
                     p = 1/self.model.covar_module.mixture_means[i, 0]
                 else:
                     p = self.xtransform.inverse(1/self.model.covar_module.mixture_means[i, 0],  # noqa: E501
-                                                shift=False).cpu().detach().numpy()[0, 0]
+                                                shift=False).cpu().detach().numpy()[0, 0]  # noqa: E501
                 print(f"Period {i}: "
                       f"{p}"
                       f" weight: {self.model.covar_module.mixture_weights[i]}")
@@ -1460,9 +1455,9 @@ class Lightcurve(gpytorch.Module):
                     scales.append(1/(2*torch.pi*self.model.sci_kernel.mixture_scales[i, 0]))  # noqa: E501
                 else:
                     p = self.xtransform.inverse(1/self.model.sci_kernel.mixture_means[i, 0],  # noqa: E501
-                                                shift=False).cpu().detach().numpy()[0, 0]
+                                                shift=False).cpu().detach().numpy()[0, 0]  # noqa: E501
                     scales.append(self.xtransform.inverse(1/(2*torch.pi*self.model.sci_kernel.mixture_scales[i, 0]),  # noqa: E501
-                                                shift=False).cpu().detach().numpy()[0, 0])
+                                                shift=False).cpu().detach().numpy()[0, 0])  # noqa: E501
                 periods.append(p)
                 weights.append(self.model.sci_kernel.mixture_weights[i])
 

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -1907,10 +1907,10 @@ class Lightcurve(torch.nn.Module):
         with torch.no_grad():
             f, ax = plt.subplots(1, 1, figsize=(8, 6))
             # Plot training data as black stars
-            ax.plot(self.xdata.numpy(), self.ydata.numpy(), 'k*')
+            ax.plot(self.xdata.cpu().numpy(), self.ydata.cpu().numpy(), 'k*')
             for i in range(min(n_samples_to_plot, self.num_samples)):
                 # Plot predictive samples as colored lines
-                ax.plot(x_fine_raw.numpy(), output[i].sample().numpy(), 'b', alpha=0.2)
+                ax.plot(x_fine_raw.cpu().numpy(), output[i].sample().cpu().numpy(), 'b', alpha=0.2)
 
             ax.legend(['Observed Data', 'Sample means'])
             if ylim is not None:
@@ -1938,14 +1938,14 @@ class Lightcurve(torch.nn.Module):
         lower, upper = observed_pred.confidence_region()
 
         # Plot training data as black stars
-        ax.plot(self.xdata.numpy(), self.ydata.numpy(), 'k*')
+        ax.plot(self.xdata.cpu().numpy(), self.ydata.cpu().numpy(), 'k*')
 
         # Plot predictive GP mean as blue line
-        ax.plot(x_fine_raw.numpy(), observed_pred.mean.numpy(), 'b')
+        ax.plot(x_fine_raw.cpu().numpy(), observed_pred.mean.cpu().numpy(), 'b')
 
         # Shade between the lower and upper confidence bounds
-        ax.fill_between(x_fine_raw.numpy(),
-                        lower.numpy(), upper.numpy(),
+        ax.fill_between(x_fine_raw.cpu().numpy(),
+                        lower.cpu().numpy(), upper.cpu().numpy(),
                         alpha=0.5)
         if ylim is not None:
             ax.set_ylim(ylim)
@@ -1978,11 +1978,11 @@ class Lightcurve(torch.nn.Module):
                                    dim=1)
 
             observed_pred = self.likelihood(self.model(x_fine_tmp))
-            ax.plot(x_fine_raw.numpy(), observed_pred.mean.numpy(), 'b')
+            ax.plot(x_fine_raw.cpu().numpy(), observed_pred.mean.cpu().numpy(), 'b')
 
             lower, upper = observed_pred.confidence_region()
-            ax.fill_between(x_fine_raw.numpy(),
-                            lower.numpy(), upper.numpy(),
+            ax.fill_between(x_fine_raw.cpu().numpy(),
+                            lower.cpu().numpy(), upper.cpu().numpy(),
                             alpha=0.5)
             ax.legend(['Observed Data', 'Mean', 'Confidence'])
 

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -1153,15 +1153,6 @@ class Lightcurve(torch.nn.Module):
 
         if cuda:
             self.cuda()
-            for key in self.state_dict().keys():
-                print(key)
-                try:
-                    print(self.state_dict()[key].device)
-                except AttributeError:
-                    pass
-                #self.state_dict()[key] = self.state_dict()[key].cuda()
-            for param_name, param in self.model.named_parameters():
-                print(f'Parameter name: {param_name:42} value = {param.data}, device = {param.data.device}')  # noqa: E501
 
         if not self.__PRIORS_SET:
             self.set_default_priors()
@@ -1198,6 +1189,17 @@ class Lightcurve(torch.nn.Module):
                              num_chains=num_chains,
                              disable_progbar=disable_progbar)
         import linear_operator.utils.errors as linear
+        for key in self.state_dict().keys():
+            print(key)
+            try:
+                print(self.state_dict()[key].device)
+            except AttributeError:
+                pass
+            #self.state_dict()[key] = self.state_dict()[key].cuda()
+        for param_name, param in self.model.named_parameters():
+            print(f'Parameter name: {param_name:42} value = {param.data}, device = {param.data.device}')  # noqa: E501
+
+
         try:
             if cuda:
                 self.mcmc_run.run(self._xdata_transformed.cuda(),

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -1184,6 +1184,9 @@ class Lightcurve(torch.nn.Module):
                     #self.state_dict()[key] = self.state_dict()[key].cuda()
                 for param_name, param in self.model.named_parameters():
                     print(f'Parameter name: {param_name:42} value = {param.data}, device = {param.data.device}')  # noqa: E501
+                for param_name, param in self._model_pars.items():
+                    print(param)
+                    print(f'Parameter name: {param_name:42} value = {param["module"].raw_value}, device = {param["module"].raw_value.device}')  # noqa: E501
                 sampled_model = model.pyro_sample_from_prior()  # .detatch()
                 output = sampled_model.likelihood(sampled_model(x))  # .detatch()
                 pyro.sample("obs", output, obs=y)

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -2034,10 +2034,10 @@ class Lightcurve(torch.nn.Module):
         """
         from astropy.table import Table
         t = Table()
-        t['x'] = [np.asarray(self.xdata)]
-        t['y'] = [np.asarray(self.ydata)]
+        t['x'] = [np.asarray(self.xdata.cpu())]
+        t['y'] = [np.asarray(self.ydata.cpu())]
         if hasattr(self, 'yerr'):
-            t['yerr'] = [np.asarray(self.yerr)]
+            t['yerr'] = [np.asarray(self.yerr.cpu())]
         if self.__FITTED_MCMC or self.__FITTED_MAP:
             # These outputs can only be produced if a fit has been run.
             periods, weights, scales = self.get_periods()
@@ -2063,9 +2063,9 @@ class Lightcurve(torch.nn.Module):
                 self._eval()
                 with torch.no_grad():
                     observed_pred = self.likelihood(self.model(self._xdata_transformed))
-                    t['y_pred_mean_obs'] = [np.asarray(observed_pred.mean)]
-                    t['y_pred_lower_obs'] = [np.asarray(observed_pred.confidence_region()[0])]  # noqa: E501
-                    t['y_pred_upper_obs'] = [np.asarray(observed_pred.confidence_region()[1])]   # noqa: E501
+                    t['y_pred_mean_obs'] = [np.asarray(observed_pred.mean.cpu())]
+                    t['y_pred_lower_obs'] = [np.asarray(observed_pred.confidence_region()[0].cpu())]  # noqa: E501
+                    t['y_pred_upper_obs'] = [np.asarray(observed_pred.confidence_region()[1].cpu())]   # noqa: E501
 
                     if self.ndim == 1:
                         x_raw = self.xdata
@@ -2082,10 +2082,10 @@ class Lightcurve(torch.nn.Module):
 
                     # Make predictions
                     observed_pred = self.likelihood(self.model(x_fine_transformed))
-                    t['x_fine'] = [np.asarray(x_fine_raw)]
-                    t['y_pred_mean'] = [np.asarray(observed_pred.mean)]
-                    t['y_pred_lower'] = [np.asarray(observed_pred.confidence_region()[0])]  # noqa: E501
-                    t['y_pred_upper'] = [np.asarray(observed_pred.confidence_region()[1])]   # noqa: E501
+                    t['x_fine'] = [np.asarray(x_fine_raw.cpu())]
+                    t['y_pred_mean'] = [np.asarray(observed_pred.mean.cpu())]
+                    t['y_pred_lower'] = [np.asarray(observed_pred.confidence_region()[0].cpu())]  # noqa: E501
+                    t['y_pred_upper'] = [np.asarray(observed_pred.confidence_region()[1].cpu())]   # noqa: E501
             elif self.__FITTED_MCMC:
                 raise NotImplementedError("MCMC predictions not yet implemented")
                 # with torch.no_grad():

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -1229,6 +1229,8 @@ class Lightcurve(torch.nn.Module):
                     #self.state_dict()[key] = self.state_dict()[key].cuda()
                 for param_name, param in self.model.named_parameters():
                     print(f'Parameter name: {param_name:42} value = {param.data}, device = {param.data.device}')  # noqa: E501
+                print(self.model.mixture_means_prior)
+                print(self.model.mixture_means)
                 print('----')
                 print("Lookup dict:")
                 for param_name, param in self._model_pars.items():

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -1161,6 +1161,7 @@ class Lightcurve(torch.nn.Module):
             self.cuda()
 
         model = self.model
+        print(model.device)
 
         def pyro_model(x, y):
             with (gpytorch.settings.fast_computations(False, False, False),

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -251,7 +251,7 @@ def minmax(data, dim=0):
     return (data-m)/r, m, r
 
 
-class Lightcurve(torch.nn.Module):
+class Lightcurve(gpytorch.Module):
     """ A class for storing, manipulating and fitting light curves
 
     This class is designed to be a convenient way to store and manipulate

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -1157,6 +1157,8 @@ class Lightcurve(torch.nn.Module):
                 print(key)
                 try:
                     print(self.state_dict()[key].device)
+                except AttributeError:
+                    pass
                 #self.state_dict()[key] = self.state_dict()[key].cuda()
             for param_name, param in self.model.named_parameters():
                 print(f'Parameter name: {param_name:42} value = {param.data}, device = {param.data.device}')  # noqa: E501

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -1229,8 +1229,10 @@ class Lightcurve(torch.nn.Module):
                     #self.state_dict()[key] = self.state_dict()[key].cuda()
                 for param_name, param in self.model.named_parameters():
                     print(f'Parameter name: {param_name:42} value = {param.data}, device = {param.data.device}')  # noqa: E501
-                print(self.model.mixture_means_prior)
                 print(self.model.mixture_means)
+                print(self.model.mixture_scales)
+                print(self.model.mixture_weights)
+                # print(self.model.mixture_means_prior)
                 print('----')
                 print("Lookup dict:")
                 for param_name, param in self._model_pars.items():

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -1151,14 +1151,16 @@ class Lightcurve(torch.nn.Module):
         # self._train()
         # self._eval()
 
+        if cuda:
+            self.cuda()
+
         if not self.__PRIORS_SET:
             self.set_default_priors()
 
         if max_cg_iterations is None:
             max_cg_iterations = 10000
 
-        if cuda:
-            self.cuda()
+
 
         model = self.model
 

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -46,6 +46,26 @@ def _reraise_with_note(e, note):
 
 
 class Transformer(torch.nn.Module):
+    def __init__(self):
+        """Baseclass for data transformers
+
+        This is a baseclass for data transformers, which are used to transform
+        data before it is passed to the GP.
+
+        Parameters
+        ----------
+
+        Examples
+        --------
+
+        Notes
+        -----
+        The baseclass has no implementation, and should not be used directly.
+        `__init__` is only implemented to allow the class to be subclassed and
+        ensure that `nn.Module` stuff is setup correctly. Subclasses should
+        implement the `transform` and `inverse` methods."""
+        super().__init__()
+
     def transform(self, data, **kwargs):
         """ Transform some data and return it, storing the parameters required
         to repeat or reverse the transform
@@ -262,6 +282,7 @@ class Lightcurve(torch.nn.Module):
         ytransform : str or Transformer, optional
             The transform to apply to the y data, by default None
         """
+        super().__init__()
 
         transform_dic = {'minmax': MinMax(),
                          'zscore': ZScore(),

--- a/pgmuvi/trainers.py
+++ b/pgmuvi/trainers.py
@@ -136,7 +136,7 @@ def train(lightcurve=None, model=None, likelihood=None,
     if lightcurve is not None:
         pars = lightcurve.get_parameters()
         for key, value in pars.items():
-            results[key] = [value..cpu().detach().numpy()]
+            results[key] = [value.cpu().detach().numpy()]
     else:
         for param_name, param in model.named_parameters():
             p = param_name.split('.')[1] if 'raw' in param_name else param_name
@@ -150,15 +150,15 @@ def train(lightcurve=None, model=None, likelihood=None,
         optimizer.step()
         # Now update list of parameters
         if i > 0:
-            results['delta_loss'].append(loss..cpu().detach().numpy() - results['loss'][-1])
-        results['loss'].append(loss..cpu().detach().numpy())
+            results['delta_loss'].append(loss.cpu().detach().numpy() - results['loss'][-1])
+        results['loss'].append(loss.cpu().detach().numpy())
 
         if lightcurve is not None:
             for key, value in lightcurve.get_parameters().items():
-                results[key].append(value..cpu().detach().numpy())
+                results[key].append(value.cpu().detach().numpy())
         else:
             for param_name, param in model.named_parameters():
-                results[param_name].append(param..cpu().detach().numpy())
+                results[param_name].append(param.cpu().detach().numpy())
             # print(i, param_name," = ",param.item())
         # Finally check if convergence criterion is met
         # optimisers are stochastic, so we average the change in loss

--- a/pgmuvi/trainers.py
+++ b/pgmuvi/trainers.py
@@ -136,7 +136,7 @@ def train(lightcurve=None, model=None, likelihood=None,
     if lightcurve is not None:
         pars = lightcurve.get_parameters()
         for key, value in pars.items():
-            results[key] = [value.detach().numpy()]
+            results[key] = [value..cpu().detach().numpy()]
     else:
         for param_name, param in model.named_parameters():
             p = param_name.split('.')[1] if 'raw' in param_name else param_name
@@ -150,15 +150,15 @@ def train(lightcurve=None, model=None, likelihood=None,
         optimizer.step()
         # Now update list of parameters
         if i > 0:
-            results['delta_loss'].append(loss.detach().numpy() - results['loss'][-1])
-        results['loss'].append(loss.detach().numpy())
+            results['delta_loss'].append(loss..cpu().detach().numpy() - results['loss'][-1])
+        results['loss'].append(loss..cpu().detach().numpy())
 
         if lightcurve is not None:
             for key, value in lightcurve.get_parameters().items():
-                results[key].append(value.detach().numpy())
+                results[key].append(value..cpu().detach().numpy())
         else:
             for param_name, param in model.named_parameters():
-                results[param_name].append(param.detach().numpy())
+                results[param_name].append(param..cpu().detach().numpy())
             # print(i, param_name," = ",param.item())
         # Finally check if convergence criterion is met
         # optimisers are stochastic, so we average the change in loss


### PR DESCRIPTION
This PR converts `Lightcurve` and related classes into `gpytorch.Module` instances instead of regular python classes. As a result, they inherit a lot of infrastructure to make management of things like GPU usages easier. Further improvements are probably required, but it would be good to merge this to get things moving and continue on other problems.