### PR TITLE
ensure that `psd` has shape consistent with `means` and `scales`

### DIFF
--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -1892,6 +1892,8 @@ class Lightcurve(gpytorch.Module):
         psd1 = norm.log_prob(freq.unsqueeze(-1))
         psd2 = norm.log_prob(-freq.unsqueeze(-1))
         psd = torch.log(0.5 * (torch.exp(psd1) + torch.exp(psd2)))
+        if len(psd.shape) < len(means.shape):
+          psd = psd.unsqueeze(-1)
         if debug:
             print(psd.shape)
         try:


### PR DESCRIPTION
Applied `unsqueeze` if `psd` has fewer dimensions than `means`, so that the summation is performed along the correct axis.