### PR TITLE
Refactor weights, periods, and scales conversion

### DIFF
--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -30,6 +30,7 @@ from .gps import (
 )
 import matplotlib.pyplot as plt
 from .trainers import train
+from .initialization import _to_numpy
 from gpytorch.constraints import Interval, GreaterThan, LessThan, Positive  # noqa: F401
 from .constraints import get_constraint_set
 from gpytorch.priors import LogNormalPrior, NormalPrior, UniformPrior  # noqa: F401
@@ -6342,23 +6343,9 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                     self.model.sci_kernel.mixture_weights[i].detach().numpy()
                 )
 
-        # weights = np.array(weights)
-        # periods = np.array(periods)
-        # scales = np.array(scales)
-        weights = np.array([
-            w.detach().cpu().numpy() if hasattr(w, "detach") else w
-            for w in weights
-        ])
-        
-        periods = np.array([
-            p.detach().cpu().numpy() if hasattr(p, "detach") else p
-            for p in periods
-        ])
-        
-        scales = np.array([
-            s.detach().cpu().numpy() if hasattr(s, "detach") else s
-            for s in scales
-        ])
+        weights = np.array([_to_numpy(w) for w in weights])
+        periods = np.array([_to_numpy(p) for p in periods])
+        scales = np.array([_to_numpy(s) for s in scales])
 
         return (
             torch.as_tensor(periods),

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -6342,9 +6342,23 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                     self.model.sci_kernel.mixture_weights[i].detach().numpy()
                 )
 
-        weights = np.array(weights)
-        periods = np.array(periods)
-        scales = np.array(scales)
+        # weights = np.array(weights)
+        # periods = np.array(periods)
+        # scales = np.array(scales)
+        weights = np.array([
+            w.detach().cpu().numpy() if hasattr(w, "detach") else w
+            for w in weights
+        ])
+        
+        periods = np.array([
+            p.detach().cpu().numpy() if hasattr(p, "detach") else p
+            for p in periods
+        ])
+        
+        scales = np.array([
+            s.detach().cpu().numpy() if hasattr(s, "detach") else s
+            for s in scales
+        ])
 
         return (
             torch.as_tensor(periods),

--- a/tests/test_get_methods.py
+++ b/tests/test_get_methods.py
@@ -226,5 +226,40 @@ class TestGetConstraintsSpectral(unittest.TestCase):
         self.assertIn("Registered constraints:", output)
 
 
+# ---------------------------------------------------------------------------
+# Regression tests for get_periods
+# ---------------------------------------------------------------------------
+
+
+class TestGetPeriodsGradTensor(unittest.TestCase):
+    """get_periods must not raise when mixture parameters require grad.
+
+    Regression test for the original failure where np.array() was called
+    directly on tensors that had requires_grad=True.
+    """
+
+    def setUp(self):
+        self.lc = _make_1d_lc()
+        self.lc.set_model("1D", num_mixtures=2)
+
+    def test_no_xtransform_returns_without_error(self):
+        # xtransform is None by default; parameters may require grad after
+        # set_model, so this must not raise RuntimeError.
+        has_grad = any(
+            p.requires_grad for p in self.lc.model.parameters()
+        )
+        self.assertTrue(has_grad, "Expected model parameters to require grad")
+        periods, weights, scales = self.lc.get_periods()
+        self.assertIsInstance(periods, torch.Tensor)
+        self.assertIsInstance(weights, torch.Tensor)
+        self.assertIsInstance(scales, torch.Tensor)
+
+    def test_returns_correct_length(self):
+        periods, weights, scales = self.lc.get_periods()
+        self.assertEqual(len(periods), 2)
+        self.assertEqual(len(weights), 2)
+        self.assertEqual(len(scales), 2)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
A call to `get_periods` was causing
```
 ---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
/tmp/ipykernel_14623/1060860930.py in <cell line: 0>()
      1 # Inspect the fitted spectral-mixture components
      2 
----> 3 gp_periods_1d, gp_weights_1d, gp_scales_1d = lc_1d.get_periods()
      4 
      5 print("GP spectral-mixture component periods:")

1 frames/usr/local/lib/python3.12/dist-packages/pgmuvi/lightcurve.py in get_periods(self)
   6344 
   6345         weights = np.array(weights)
-> 6346         periods = np.array(periods)
   6347         scales = np.array(scales)
   6348 

/usr/local/lib/python3.12/dist-packages/torch/_tensor.py in __array__(self, dtype)
   1251             return handle_torch_function(Tensor.__array__, (self,), self, dtype=dtype)
   1252         if dtype is None:
-> 1253             return self.numpy()
   1254         else:
   1255             return self.numpy().astype(dtype, copy=False)

RuntimeError: Can't call numpy() on Tensor that requires grad. Use tensor.detach().numpy() instead.
```