### PR TITLE
Fix separable 2D SM models drifting to maximum period

### DIFF
--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -843,6 +843,43 @@ _SM_MODELS: frozenset[str] = frozenset(
     }
 )
 
+# Separable 2D model names that *can* use a spectral-mixture time kernel
+# (via ``time_kernel_type='spectral_mixture'``).  These are not in _SM_MODELS
+# because they don't *always* use an SM kernel, but when they do, MLS-based
+# initialisation and frequency priors should be applied.
+_SEPARABLE_SM_CAPABLE_MODELS: frozenset[str] = frozenset(
+    {
+        "2DSeparable",
+        "2DAchromatic",
+        "2DWavelengthDependent",
+        "2DDustMean",
+        "2DPowerLawMean",
+    }
+)
+
+
+def _find_separable_sm_time_kernel(model):
+    """Return the SM time sub-kernel from a separable model, or None.
+
+    For separable 2D models the covar_module is a ProductKernel.  This
+    function walks its sub-kernels looking for one whose ``active_dims``
+    contains 0 (the time dimension) and that is (or wraps) a
+    SpectralMixtureKernel.
+    """
+    covar = getattr(model, "covar_module", None)
+    if covar is None:
+        return None
+    sub_kernels = getattr(covar, "kernels", None)
+    if sub_kernels is None:
+        return None
+    for k in sub_kernels:
+        ad = getattr(k, "active_dims", None)
+        if ad is not None and 0 in ad.tolist():
+            actual = getattr(k, "base_kernel", k)
+            if hasattr(actual, "mixture_means"):
+                return actual
+    return None
+
 
 @dataclasses.dataclass(frozen=True)
 class PeriodPeakResult:
@@ -4037,6 +4074,30 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             )
 
         # to-do - check if constraints on mixture scales are useful!
+
+        # For separable 2D models with an SM time kernel, constrain the
+        # wavelength kernel's output scale to prevent it from growing large
+        # enough to absorb all variance.  When the wavelength output scale
+        # dominates, the time kernel's frequency can drift to the boundary
+        # (maximum period) because the model explains the data through
+        # wavelength correlations + mean function alone.
+        if _find_separable_sm_time_kernel(self.model) is not None:
+            sk = self.model.covar_module
+            for k in getattr(sk, "kernels", []):
+                ad = getattr(k, "active_dims", None)
+                if ad is not None and 1 in ad.tolist():
+                    # This is the wavelength sub-kernel
+                    if hasattr(k, "outputscale"):
+                        data_var = float(self._ydata_transformed.var())
+                        wl_os_constraint = Interval(1e-6, max(data_var, 1e-4))
+                        try:
+                            k.register_constraint(
+                                "raw_outputscale", wl_os_constraint
+                            )
+                        except RuntimeError:
+                            pass
+                    break
+
         self.__CONTRAINTS_SET = True
 
     def get_constraints(self):
@@ -5890,7 +5951,13 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 )
             _init_freqs = 1.0 / _periods_tensor
             num_mixtures = len(_init_freqs)
-        elif use_mls_init and isinstance(model, str) and model in _SM_MODELS:
+        elif use_mls_init and isinstance(model, str) and (
+            model in _SM_MODELS
+            or (
+                model in _SEPARABLE_SM_CAPABLE_MODELS
+                and kwargs.get("time_kernel_type", "") in ("spectral_mixture", "sm")
+            )
+        ):
             # Compute constraint-set frequency bounds in raw data units.
             # These are used in addition to the data-span bounds to exclude
             # MLS peaks that would lie outside user-requested period limits.
@@ -6178,6 +6245,57 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         if not self.__CONTRAINTS_SET:
             self.set_default_constraints()
 
+        # For separable 2D models with an SM time kernel, register a
+        # frequency prior during MAP fitting to penalise low-frequency
+        # (long-period) solutions.  Without this, the MLL alone prefers
+        # to push the time-kernel frequency to the lower constraint
+        # boundary because the wavelength kernel + mean function can
+        # absorb all variance when the time kernel is near-constant.
+        _sep_sm_tk = _find_separable_sm_time_kernel(self.model)
+        if _sep_sm_tk is not None and not self.__PRIORS_SET:
+            from .priors import LogNormalFrequencyPrior
+            if self.ndim > 1:
+                _x_orig_span = float(
+                    self._xdata_raw[:, 0].max() - self._xdata_raw[:, 0].min()
+                )
+                _x_trans_span = float(
+                    self._xdata_transformed[:, 0].max()
+                    - self._xdata_transformed[:, 0].min()
+                )
+            else:
+                _x_orig_span = float(
+                    self._xdata_raw.max() - self._xdata_raw.min()
+                )
+                _x_trans_span = float(
+                    self._xdata_transformed.max()
+                    - self._xdata_transformed.min()
+                )
+            _p_scale = _x_trans_span / _x_orig_span if _x_orig_span > 0 else 1.0
+            _lower_p_model = 20.0 * _p_scale
+            _upper_p_model = _x_trans_span
+            if constraint_set is not None:
+                try:
+                    _cs = get_constraint_set(constraint_set)
+                    if "period" in _cs:
+                        _pb = _cs["period"]
+                        _plo, _plo_a = _pb["lower"]
+                        _phi, _phi_a = _pb["upper"]
+                        if _plo_a and _plo is not None:
+                            _lower_p_model = float(_plo) * _p_scale
+                        if _phi_a and _phi is not None:
+                            _upper_p_model = float(_phi) * _p_scale
+                except (ValueError, KeyError):
+                    pass
+            _freq_prior = LogNormalFrequencyPrior(
+                mu=5.0, sigma=1.0,
+                lower_period=_lower_p_model,
+                upper_period=_upper_p_model,
+                period=True,
+            )
+            _sep_sm_tk.register_prior(
+                "mixture_means_prior", _freq_prior, "mixture_means"
+            )
+
         if cuda:
             self.cuda()
         # Build the combined hyperparameter initialisation dict.
@@ -6255,6 +6373,24 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                         min=_clamp_lower, max=_clamp_upper
                     )
             _hypers_to_set["covar_module.mixture_means"] = _init_freqs_2d
+        elif (
+            _init_freqs is not None
+            and hasattr(self, "model")
+            and _find_separable_sm_time_kernel(self.model) is not None
+        ):
+            # Separable 2D model with an SM time kernel: mixture_means
+            # lives on the time sub-kernel (covar_module.kernels[0]), not
+            # on covar_module directly.  The SM is 1D (ard_num_dims=1).
+            # Find the dotted path to the SM kernel's mixture_means so
+            # set_hypers can resolve it.
+            _sep_mm_path = None
+            for pname, _ in self.model.named_parameters():
+                if pname.endswith("raw_mixture_means"):
+                    _sep_mm_path = pname.replace("raw_mixture_means",
+                                                 "mixture_means")
+                    break
+            if _sep_mm_path is not None:
+                _hypers_to_set[_sep_mm_path] = _init_freqs
         if guess is not None:
             _hypers_to_set.update(guess)
         if _hypers_to_set:

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -858,13 +858,43 @@ _SEPARABLE_SM_CAPABLE_MODELS: frozenset[str] = frozenset(
 )
 
 
+def _find_sm_in_kernel(kernel):
+    """Recursively search for a SpectralMixtureKernel within a kernel tree.
+
+    Walks :class:`~gpytorch.kernels.ScaleKernel` wrappers (via
+    ``base_kernel``) and container kernels (``AdditiveKernel``,
+    ``ProductKernel``, etc., via ``kernels``).  Returns the first kernel
+    that exposes ``mixture_means`` (i.e. a SpectralMixtureKernel), or
+    ``None`` if none is found.
+    """
+    if hasattr(kernel, "mixture_means"):
+        return kernel
+    # Unwrap ScaleKernel and similar single-child wrappers
+    base = getattr(kernel, "base_kernel", None)
+    if base is not None:
+        found = _find_sm_in_kernel(base)
+        if found is not None:
+            return found
+    # Walk AdditiveKernel / ProductKernel / SumKernel sub-kernels
+    sub_kernels = getattr(kernel, "kernels", None)
+    if sub_kernels is not None:
+        for k in sub_kernels:
+            found = _find_sm_in_kernel(k)
+            if found is not None:
+                return found
+    return None
+
+
 def _find_separable_sm_time_kernel(model):
     """Return the SM time sub-kernel from a separable model, or None.
 
     For separable 2D models the covar_module is a ProductKernel.  This
     function walks its sub-kernels looking for one whose ``active_dims``
     contains 0 (the time dimension) and that is (or wraps) a
-    SpectralMixtureKernel.
+    SpectralMixtureKernel.  The SM kernel may be nested inside additional
+    wrappers (e.g. a ScaleKernel) or additive containers
+    (e.g. when ``add_flicker=True`` produces an ``AdditiveKernel``), so
+    :func:`_find_sm_in_kernel` is used to recurse into those structures.
     """
     covar = getattr(model, "covar_module", None)
     if covar is None:
@@ -875,9 +905,9 @@ def _find_separable_sm_time_kernel(model):
     for k in sub_kernels:
         ad = getattr(k, "active_dims", None)
         if ad is not None and 0 in ad.tolist():
-            actual = getattr(k, "base_kernel", k)
-            if hasattr(actual, "mixture_means"):
-                return actual
+            found = _find_sm_in_kernel(k)
+            if found is not None:
+                return found
     return None
 
 
@@ -4081,6 +4111,10 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         # dominates, the time kernel's frequency can drift to the boundary
         # (maximum period) because the model explains the data through
         # wavelength correlations + mean function alone.
+        # The upper bound is max(data_var, 1e-4): using data_var directly
+        # caps the wavelength kernel at the observed variance, while the
+        # floor of 1e-4 prevents a degenerate upper bound when the data
+        # have near-zero variance (e.g. unit-normalised toy data).
         if _find_separable_sm_time_kernel(self.model) is not None:
             sk = self.model.covar_module
             for k in getattr(sk, "kernels", []):
@@ -6242,17 +6276,26 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         if not self.__CONTRAINTS_SET:
             self.set_default_constraints(constraint_set=constraint_set)
 
-        if not self.__CONTRAINTS_SET:
-            self.set_default_constraints()
+        # Ensure all default priors (noise, scale, etc.) are registered.
+        # This must happen before the separable-SM specialisation below so
+        # that the specialised LogNormalFrequencyPrior can override the
+        # generic mixture_means_prior registered by set_default_priors().
+        # Setting __PRIORS_SET=True here also prevents mcmc() from
+        # inadvertently overwriting the specialised prior by calling
+        # set_default_priors() again.
+        if not self.__PRIORS_SET:
+            self.set_default_priors()
 
         # For separable 2D models with an SM time kernel, register a
-        # frequency prior during MAP fitting to penalise low-frequency
-        # (long-period) solutions.  Without this, the MLL alone prefers
-        # to push the time-kernel frequency to the lower constraint
-        # boundary because the wavelength kernel + mean function can
-        # absorb all variance when the time kernel is near-constant.
+        # specialised frequency prior during MAP fitting to penalise
+        # low-frequency (long-period) solutions.  Without this, the MLL
+        # alone prefers to push the time-kernel frequency to the lower
+        # constraint boundary because the wavelength kernel + mean function
+        # can absorb all variance when the time kernel is near-constant.
+        # This call comes *after* set_default_priors() so that it overrides
+        # the generic mixture_means_prior that set_default_priors() registers.
         _sep_sm_tk = _find_separable_sm_time_kernel(self.model)
-        if _sep_sm_tk is not None and not self.__PRIORS_SET:
+        if _sep_sm_tk is not None:
             from .priors import LogNormalFrequencyPrior
             if self.ndim > 1:
                 _x_orig_span = float(

--- a/tests/test_separable_sm_init.py
+++ b/tests/test_separable_sm_init.py
@@ -11,9 +11,11 @@ import torch
 from pgmuvi.lightcurve import (
     Lightcurve,
     _find_separable_sm_time_kernel,
+    _find_sm_in_kernel,
     _SEPARABLE_SM_CAPABLE_MODELS,
     _SM_MODELS,
 )
+from pgmuvi.priors import LogNormalFrequencyPrior
 from pgmuvi.synthetic import make_chromatic_sinusoid_2d
 
 
@@ -45,6 +47,34 @@ class TestSeparableSMCapableModels(unittest.TestCase):
         for name in ("2DWavelengthDependent", "2DAchromatic", "2DDustMean",
                       "2DPowerLawMean", "2DSeparable"):
             self.assertIn(name, _SEPARABLE_SM_CAPABLE_MODELS)
+
+
+class TestFindSMInKernel(unittest.TestCase):
+    """Test the recursive _find_sm_in_kernel helper."""
+
+    def test_finds_direct_sm(self):
+        from gpytorch.kernels import SpectralMixtureKernel
+        k = SpectralMixtureKernel(num_mixtures=1, ard_num_dims=1)
+        self.assertIs(_find_sm_in_kernel(k), k)
+
+    def test_finds_sm_under_scale_kernel(self):
+        from gpytorch.kernels import SpectralMixtureKernel, ScaleKernel
+        sm = SpectralMixtureKernel(num_mixtures=1, ard_num_dims=1)
+        scaled = ScaleKernel(sm)
+        self.assertIs(_find_sm_in_kernel(scaled), sm)
+
+    def test_finds_sm_in_additive_kernel(self):
+        """SM nested inside an AdditiveKernel (as created by add_flicker=True)."""
+        from gpytorch.kernels import SpectralMixtureKernel, RBFKernel, AdditiveKernel
+        sm = SpectralMixtureKernel(num_mixtures=1, ard_num_dims=1)
+        rbf = RBFKernel()
+        additive = AdditiveKernel(sm, rbf)
+        self.assertIs(_find_sm_in_kernel(additive), sm)
+
+    def test_returns_none_for_rbf(self):
+        from gpytorch.kernels import RBFKernel
+        k = RBFKernel()
+        self.assertIsNone(_find_sm_in_kernel(k))
 
 
 class TestFindSeparableSMTimeKernel(unittest.TestCase):
@@ -135,6 +165,66 @@ class TestSeparableSMInitPath(unittest.TestCase):
         ]
         self.assertEqual(len(paths), 1)
         self.assertIn("kernels.0", paths[0])
+
+    def test_fit_seeds_mixture_means_from_periods(self):
+        """fit() with explicit periods= should seed mixture_means to 1/period."""
+        period = 40.0
+        lc = _make_2d_lc(period=period, n_per_band=20)
+        default_mm = 0.6931  # GPyTorch default (log 2)
+        lc.fit(
+            model="2DWavelengthDependent",
+            time_kernel_type="spectral_mixture",
+            num_mixtures=1,
+            training_iter=1,
+            periods=[period],
+            use_mls_init=False,
+            lr=0.0,  # zero learning rate: no training movement
+        )
+        tk = _find_separable_sm_time_kernel(lc.model)
+        self.assertIsNotNone(tk)
+        mm = float(tk.mixture_means.detach().squeeze())
+        expected_freq = 1.0 / period
+        # Should be seeded near 1/period, well away from the default
+        self.assertAlmostEqual(mm, expected_freq, places=4)
+        self.assertNotAlmostEqual(mm, default_mm, places=2)
+
+    def test_fit_registers_lognormal_frequency_prior(self):
+        """fit() should register a LogNormalFrequencyPrior on the SM time kernel."""
+        lc = _make_2d_lc(n_per_band=20)
+        lc.fit(
+            model="2DWavelengthDependent",
+            time_kernel_type="spectral_mixture",
+            num_mixtures=1,
+            training_iter=1,
+            use_mls_init=False,
+            lr=0.0,
+        )
+        tk = _find_separable_sm_time_kernel(lc.model)
+        self.assertIsNotNone(tk)
+        # named_priors yields (name, module, prior, getter_fn, setter_fn)
+        priors = {item[0]: item[2] for item in tk.named_priors()}
+        self.assertIn("mixture_means_prior", priors)
+        self.assertIsInstance(priors["mixture_means_prior"], LogNormalFrequencyPrior)
+
+    def test_priors_set_flag_prevents_overwrite_on_repeat_call(self):
+        """Calling fit() twice should not raise RuntimeError from double prior reg."""
+        lc = _make_2d_lc(n_per_band=20)
+        kwargs = dict(
+            model="2DWavelengthDependent",
+            time_kernel_type="spectral_mixture",
+            num_mixtures=1,
+            training_iter=1,
+            use_mls_init=False,
+            lr=0.0,
+        )
+        lc.fit(**kwargs)
+        # Second fit with same model string triggers model re-creation;
+        # set_default_priors() should not attempt to re-register the
+        # mixture_means_prior after fit() already marked __PRIORS_SET.
+        try:
+            lc.fit(**kwargs)
+        except RuntimeError as exc:
+            self.fail(f"Second fit() raised RuntimeError: {exc}")
 
 
 if __name__ == "__main__":

--- a/tests/test_separable_sm_init.py
+++ b/tests/test_separable_sm_init.py
@@ -1,0 +1,141 @@
+"""Tests for separable 2D models with spectral-mixture time kernels.
+
+Verifies that MLS-based initialisation, frequency constraints, frequency
+priors, and wavelength output-scale constraints are correctly applied when
+a separable model (e.g. ``2DWavelengthDependent``) uses
+``time_kernel_type='spectral_mixture'``.
+"""
+
+import unittest
+import torch
+from pgmuvi.lightcurve import (
+    Lightcurve,
+    _find_separable_sm_time_kernel,
+    _SEPARABLE_SM_CAPABLE_MODELS,
+    _SM_MODELS,
+)
+from pgmuvi.synthetic import make_chromatic_sinusoid_2d
+
+
+def _make_2d_lc(period=40.0, n_per_band=50, t_span=200.0, seed=42):
+    """Create a simple 2D Lightcurve for testing."""
+    return make_chromatic_sinusoid_2d(
+        n_per_band=n_per_band,
+        period=period,
+        wavelengths=[500.0, 700.0],
+        amplitude_law="linear",
+        amplitude_slope=0.0,
+        noise_level=0.1,
+        t_span=t_span,
+        irregular=False,
+        seed=seed,
+    )
+
+
+class TestSeparableSMCapableModels(unittest.TestCase):
+    """Verify the _SEPARABLE_SM_CAPABLE_MODELS set."""
+
+    def test_no_overlap_with_sm_models(self):
+        self.assertEqual(
+            _SM_MODELS & _SEPARABLE_SM_CAPABLE_MODELS,
+            frozenset(),
+        )
+
+    def test_expected_models_present(self):
+        for name in ("2DWavelengthDependent", "2DAchromatic", "2DDustMean",
+                      "2DPowerLawMean", "2DSeparable"):
+            self.assertIn(name, _SEPARABLE_SM_CAPABLE_MODELS)
+
+
+class TestFindSeparableSMTimeKernel(unittest.TestCase):
+    """Test _find_separable_sm_time_kernel helper."""
+
+    def setUp(self):
+        self.lc = _make_2d_lc()
+
+    def test_returns_sm_kernel_for_sm_time_kernel(self):
+        self.lc.set_model(
+            "2DWavelengthDependent",
+            time_kernel_type="spectral_mixture",
+            num_mixtures=1,
+        )
+        tk = _find_separable_sm_time_kernel(self.lc.model)
+        self.assertIsNotNone(tk)
+        self.assertTrue(hasattr(tk, "mixture_means"))
+
+    def test_returns_none_for_matern_time_kernel(self):
+        self.lc.set_model(
+            "2DWavelengthDependent",
+            time_kernel_type="matern",
+        )
+        tk = _find_separable_sm_time_kernel(self.lc.model)
+        self.assertIsNone(tk)
+
+    def test_returns_none_for_full_2d_sm(self):
+        self.lc.set_model("2D", num_mixtures=2)
+        tk = _find_separable_sm_time_kernel(self.lc.model)
+        self.assertIsNone(tk)
+
+
+class TestSeparableSMConstraints(unittest.TestCase):
+    """Verify constraints are set on separable SM models."""
+
+    def setUp(self):
+        self.lc = _make_2d_lc()
+        self.lc.set_model(
+            "2DWavelengthDependent",
+            time_kernel_type="spectral_mixture",
+            num_mixtures=1,
+        )
+
+    def test_mixture_means_in_model_pars(self):
+        self.assertIn("mixture_means", self.lc._model_pars)
+
+    def test_constraints_registered_after_set_default_constraints(self):
+        self.lc.set_default_constraints()
+        found = False
+        for name, constraint in self.lc.model.named_constraints():
+            if "mixture_means" in name:
+                found = True
+                break
+        self.assertTrue(found, "mixture_means constraint not registered")
+
+    def test_wavelength_outputscale_constrained(self):
+        self.lc.set_default_constraints()
+        sk = self.lc.model.covar_module
+        for k in sk.kernels:
+            ad = getattr(k, "active_dims", None)
+            if ad is not None and 1 in ad.tolist() and hasattr(k, "outputscale"):
+                found = False
+                for name, constraint in k.named_constraints():
+                    if "outputscale" in name:
+                        found = True
+                        break
+                self.assertTrue(
+                    found,
+                    "wavelength kernel outputscale constraint not registered",
+                )
+                return
+        self.skipTest("No wavelength kernel with outputscale found")
+
+
+class TestSeparableSMInitPath(unittest.TestCase):
+    """Verify that the init path correctly seeds separable SM models."""
+
+    def test_named_parameters_path(self):
+        lc = _make_2d_lc()
+        lc.set_model(
+            "2DWavelengthDependent",
+            time_kernel_type="spectral_mixture",
+            num_mixtures=1,
+        )
+        paths = [
+            p for p, _ in lc.model.named_parameters()
+            if p.endswith("raw_mixture_means")
+        ]
+        self.assertEqual(len(paths), 1)
+        self.assertIn("kernels.0", paths[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Fix pathological preference for maximum period (minimum frequency) in separable 2D models (`2DWavelengthDependent`, `2DAchromatic`, etc.) when using a spectral-mixture time kernel
- Three interacting bugs caused the issue: MLS init was skipped, frequency init path couldn't find `mixture_means` inside the `ProductKernel`, and no frequency prior was registered during MAP fitting
- Add wavelength output-scale constraint to prevent the wavelength kernel from absorbing all variance (which made the time kernel irrelevant)

## Detail

When fitting real multiwavelength data with `model=2DWavelengthDependent, time_kernel_type=spectral_mixture`, the fitted period always drifted to the upper constraint boundary (~5800 d) regardless of initialisation. The 1D per-band fits correctly recovered the ~600 d period.

**Root causes:**

1. `_SM_MODELS` did not include separable model names, so the MLS-based initialisation gate in `fit()` was never triggered — the SM kernel started at random GPyTorch defaults instead of near the LS-detected period.

2. The frequency initialisation path checked `self.model.covar_module.mixture_means`, but for separable models `mixture_means` lives at `covar_module.kernels[0].mixture_means` (inside the `ProductKernel`). Even explicit `periods=` arguments silently failed to seed the kernel.

3. No frequency prior was registered during `fit()` (priors were only set in `mcmc()`), so the MLL had no penalty for low-frequency solutions. The fundamental MLL bias in separable models — where the wavelength kernel + mean function can absorb all variance when the time kernel is near-constant — went unchecked.

**Fixes:**

- New `_SEPARABLE_SM_CAPABLE_MODELS` set and `_find_separable_sm_time_kernel()` helper
- Widened MLS init gate to trigger for separable SM models
- New `elif` branch resolving `covar_module.kernels.0.mixture_means` for `set_hypers()`
- `LogNormalFrequencyPrior` auto-registered on SM time kernel during `fit()`
- Wavelength kernel `outputscale` constrained to `[1e-6, data_variance]`

## Test plan

- [ ] New unit tests in `tests/test_separable_sm_init.py` pass
- [ ] Existing 2D constraint and integration tests unaffected
- [ ] Re-run the notebook from the issue (`PGMUVI_GPfit.ipynb`) with `2DWavelengthDependent` + SM time kernel — fitted period should stay near the 1D-diagnosed ~600 d rather than drifting to boundary
- [ ] Verify 1D SM models (`1D`, `2D`) are unaffected by the changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)