### PR TITLE
Add fit_strategy dispatch skeleton and consensus stubs

### DIFF
--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -5798,8 +5798,9 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             Optional fitting-strategy selector.  The default ``None`` keeps the
             existing general ``fit`` workflow unchanged.  When set to one of
             the listed strategy names, ``fit`` dispatches to the corresponding
-            internal consensus-fit pathway.  All non-``None`` strategies are
-            currently stubs and raise ``NotImplementedError``.
+            internal consensus-fit pathway.  The listed strategy names are
+            reserved for planned consensus-fit implementations and currently
+            raise ``NotImplementedError``.
         **kwargs : dict, optional
             Any other keyword arguments to be passed to the model constructor,
             likelihood constructor, or the optimizer.
@@ -6342,41 +6343,25 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         if fit_strategy == "consensus_relaxed":
             return self._consensus_relaxed_fit(**fit_kwargs)
         raise ValueError(
-            "Invalid fit_strategy. Expected one of: "
+            "Invalid fit_strategy. Expected None or one of: "
             "'consensus', 'consensus_multicomp', 'consensus_relaxed'. "
             f"Got {fit_strategy!r}."
         )
 
     def _consensus_standard_fit(self, **fit_kwargs):
-        """Stub for future strict cross-band consensus-initialized 2D GP fit.
-
-        The planned implementation will run per-band 1D LS/ACF/GP analyses,
-        build a consensus frequency window across bands, reject discrepant
-        bands, initialize/constrain 2D time-frequency SM parameters, and then
-        run the 2D GP fit.
-        """
+        """Consensus-fit stub; currently raises ``NotImplementedError``."""
         raise NotImplementedError(
             "fit_strategy='consensus' is not implemented yet."
         )
 
     def _consensus_multicomp_fit(self, **fit_kwargs):
-        """Stub for future multi-component cross-band consensus SM fitting.
-
-        The planned implementation will identify multiple recurring
-        frequencies from 1D analyses, cluster them across bands, and
-        initialize/constrain multi-component SM kernels.
-        """
+        """Consensus-fit stub; currently raises ``NotImplementedError``."""
         raise NotImplementedError(
             "fit_strategy='consensus_multicomp' is not implemented yet."
         )
 
     def _consensus_relaxed_fit(self, **fit_kwargs):
-        """Stub for future relaxed consensus-initialized 2D GP fitting.
-
-        The planned implementation will retain or downweight discrepant bands
-        instead of hard rejection, broadening constraints or weighting bands
-        by confidence.
-        """
+        """Consensus-fit stub; currently raises ``NotImplementedError``."""
         raise NotImplementedError(
             "fit_strategy='consensus_relaxed' is not implemented yet."
         )

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -5826,6 +5826,32 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         # whether to substitute the stored _model_num_mixtures.
         _num_mixtures_arg = num_mixtures
 
+        # Dispatch alternative fit strategies before any stateful setup from
+        # the default/general fit pathway mutates this Lightcurve instance.
+        if fit_strategy is not None:
+            return self._consensus_fit(
+                fit_strategy=fit_strategy,
+                model=model,
+                likelihood=likelihood,
+                num_mixtures=num_mixtures,
+                guess=guess,
+                periods=periods,
+                use_mls_init=use_mls_init,
+                use_best_band_init=use_best_band_init,
+                constraint_set=constraint_set,
+                grid_size=grid_size,
+                cuda=cuda,
+                training_iter=training_iter,
+                max_cg_iterations=max_cg_iterations,
+                optim=optim,
+                miniter=miniter,
+                stop=stop,
+                lr=lr,
+                stopavg=stopavg,
+                variance=variance,
+                **kwargs,
+            )
+
         if not hasattr(self, "likelihood"):
             self.set_likelihood(likelihood, variance=variance, **kwargs)
         elif not self.__SET_LIKELIHOOD_CALLED and likelihood is None:
@@ -5854,30 +5880,6 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                     "`num_mixtures` must be a positive integer or None, "
                     f"got {num_mixtures}."
                 )
-
-        if fit_strategy is not None:
-            return self._consensus_fit(
-                fit_strategy=fit_strategy,
-                model=model,
-                likelihood=likelihood,
-                num_mixtures=num_mixtures,
-                guess=guess,
-                periods=periods,
-                use_mls_init=use_mls_init,
-                use_best_band_init=use_best_band_init,
-                constraint_set=constraint_set,
-                grid_size=grid_size,
-                cuda=cuda,
-                training_iter=training_iter,
-                max_cg_iterations=max_cg_iterations,
-                optim=optim,
-                miniter=miniter,
-                stop=stop,
-                lr=lr,
-                stopavg=stopavg,
-                variance=variance,
-                **kwargs,
-            )
 
         # --- MLS-based initialisation ---
         _init_freqs = None  # frequencies (raw units) to seed the SM kernel

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -5646,6 +5646,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         lr=0.1,
         stopavg=30,
         variance=False,
+        fit_strategy=None,
         **kwargs,
     ):
         """Fit the lightcurve
@@ -5792,6 +5793,13 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             (standard deviations) and are squared before being used as noise
             variances in the likelihood.  Set to True if the stored
             uncertainties already represent variances.
+        fit_strategy : {"consensus", "consensus_multicomp",
+                        "consensus_relaxed"} or None, optional
+            Optional fitting-strategy selector.  The default ``None`` keeps the
+            existing general ``fit`` workflow unchanged.  When set to one of
+            the listed strategy names, ``fit`` dispatches to the corresponding
+            internal consensus-fit pathway.  All non-``None`` strategies are
+            currently stubs and raise ``NotImplementedError``.
         **kwargs : dict, optional
             Any other keyword arguments to be passed to the model constructor,
             likelihood constructor, or the optimizer.
@@ -5846,6 +5854,30 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                     "`num_mixtures` must be a positive integer or None, "
                     f"got {num_mixtures}."
                 )
+
+        if fit_strategy is not None:
+            return self._consensus_fit(
+                fit_strategy=fit_strategy,
+                model=model,
+                likelihood=likelihood,
+                num_mixtures=num_mixtures,
+                guess=guess,
+                periods=periods,
+                use_mls_init=use_mls_init,
+                use_best_band_init=use_best_band_init,
+                constraint_set=constraint_set,
+                grid_size=grid_size,
+                cuda=cuda,
+                training_iter=training_iter,
+                max_cg_iterations=max_cg_iterations,
+                optim=optim,
+                miniter=miniter,
+                stop=stop,
+                lr=lr,
+                stopavg=stopavg,
+                variance=variance,
+                **kwargs,
+            )
 
         # --- MLS-based initialisation ---
         _init_freqs = None  # frequencies (raw units) to seed the SM kernel
@@ -6298,6 +6330,54 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         self.__FITTED_MAP = True
 
         return self.results
+
+    def _consensus_fit(self, fit_strategy, **fit_kwargs):
+        """Dispatch consensus fit strategies to their internal handlers."""
+        if fit_strategy == "consensus":
+            return self._consensus_standard_fit(**fit_kwargs)
+        if fit_strategy == "consensus_multicomp":
+            return self._consensus_multicomp_fit(**fit_kwargs)
+        if fit_strategy == "consensus_relaxed":
+            return self._consensus_relaxed_fit(**fit_kwargs)
+        raise ValueError(
+            "Invalid fit_strategy. Expected one of: "
+            "'consensus', 'consensus_multicomp', 'consensus_relaxed'. "
+            f"Got {fit_strategy!r}."
+        )
+
+    def _consensus_standard_fit(self, **fit_kwargs):
+        """Stub for future strict cross-band consensus-initialized 2D GP fit.
+
+        The planned implementation will run per-band 1D LS/ACF/GP analyses,
+        build a consensus frequency window across bands, reject discrepant
+        bands, initialize/constrain 2D time-frequency SM parameters, and then
+        run the 2D GP fit.
+        """
+        raise NotImplementedError(
+            "fit_strategy='consensus' is not implemented yet."
+        )
+
+    def _consensus_multicomp_fit(self, **fit_kwargs):
+        """Stub for future multi-component cross-band consensus SM fitting.
+
+        The planned implementation will identify multiple recurring
+        frequencies from 1D analyses, cluster them across bands, and
+        initialize/constrain multi-component SM kernels.
+        """
+        raise NotImplementedError(
+            "fit_strategy='consensus_multicomp' is not implemented yet."
+        )
+
+    def _consensus_relaxed_fit(self, **fit_kwargs):
+        """Stub for future relaxed consensus-initialized 2D GP fitting.
+
+        The planned implementation will retain or downweight discrepant bands
+        instead of hard rejection, broadening constraints or weighting bands
+        by confidence.
+        """
+        raise NotImplementedError(
+            "fit_strategy='consensus_relaxed' is not implemented yet."
+        )
 
     def mcmc(
         self,

--- a/tests/test_fit_strategy.py
+++ b/tests/test_fit_strategy.py
@@ -1,0 +1,51 @@
+import unittest
+from unittest import mock
+
+import torch
+
+from pgmuvi.lightcurve import Lightcurve
+
+
+class TestFitStrategyDispatch(unittest.TestCase):
+    def setUp(self):
+        xdata = torch.as_tensor([0.0, 1.0, 2.0, 3.0], dtype=torch.float32)
+        ydata = torch.as_tensor([1.0, 2.0, 1.5, 2.5], dtype=torch.float32)
+        yerr = torch.full_like(ydata, 0.1)
+        self.lc = Lightcurve(xdata, ydata, yerr=yerr)
+
+    def test_fit_strategy_consensus_not_implemented(self):
+        msg = r"^fit_strategy='consensus' is not implemented yet\.$"
+        with self.assertRaisesRegex(NotImplementedError, msg):
+            self.lc.fit(fit_strategy="consensus")
+
+    def test_fit_strategy_consensus_multicomp_not_implemented(self):
+        msg = r"^fit_strategy='consensus_multicomp' is not implemented yet\.$"
+        with self.assertRaisesRegex(NotImplementedError, msg):
+            self.lc.fit(fit_strategy="consensus_multicomp")
+
+    def test_fit_strategy_consensus_relaxed_not_implemented(self):
+        msg = r"^fit_strategy='consensus_relaxed' is not implemented yet\.$"
+        with self.assertRaisesRegex(NotImplementedError, msg):
+            self.lc.fit(fit_strategy="consensus_relaxed")
+
+    def test_invalid_fit_strategy_raises_value_error(self):
+        msg = (
+            r"^Invalid fit_strategy\. Expected None or one of: "
+            r"'consensus', 'consensus_multicomp', 'consensus_relaxed'\. "
+            r"Got 'invalid_strategy'\.$"
+        )
+        with self.assertRaisesRegex(ValueError, msg):
+            self.lc.fit(fit_strategy="invalid_strategy")
+
+    def test_fit_strategy_none_uses_existing_fit_path(self):
+        with mock.patch.object(
+            Lightcurve,
+            "_consensus_fit",
+            side_effect=AssertionError("_consensus_fit should not be called"),
+        ):
+            with self.assertRaisesRegex(ValueError, r"^You must provide a model$"):
+                self.lc.fit(fit_strategy=None)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add fit_strategy dispatch skeleton and consensus stubs

Agent-Logs-Url: https://github.com/ICSM/pgmuvi/sessions/d9b91770-59e5-4eb3-89cb-c293afc1949e

Co-authored-by: sundarjhu <15619959+sundarjhu@users.noreply.github.com>

Move fit_strategy dispatch before stateful setup

Agent-Logs-Url: https://github.com/ICSM/pgmuvi/sessions/c39ae89d-d3ef-4477-a3f6-154b23a95e4c

Co-authored-by: sundarjhu <15619959+sundarjhu@users.noreply.github.com>

Refine consensus fit-strategy docs and error text

Agent-Logs-Url: https://github.com/ICSM/pgmuvi/sessions/15ae8420-a93d-4211-9c8b-b90ffa101295

Co-authored-by: sundarjhu <15619959+sundarjhu@users.noreply.github.com>