### PR TITLE
Add optional per-band GP validation for consensus candidates

### DIFF
--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -6960,6 +6960,13 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 "acf_harmonic_order": None,
                 "acf_error": None,
                 "selected_from": None,
+                "gp_validation_used": False,
+                "gp_dominant_frequency": None,
+                "gp_dominant_period": None,
+                "gp_frequency_difference": None,
+                "gp_frequency_tolerance": None,
+                "gp_validation_status": None,
+                "gp_validation_error": None,
             }
 
             if reasons:
@@ -7092,6 +7099,170 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             "controls": controls,
             "band_records": band_records,
             "accepted_bands": accepted_bands,
+            "rejected_bands": rejected_bands,
+            "rejection_reasons": rejection_reasons,
+        }
+
+    def _consensus_validate_candidates_with_1d_gp(
+        self,
+        candidate_diag,
+        gp_validation_kwargs=None,
+        gp_frequency_tolerance_factor=3.0,
+        verbose=False,
+    ):
+        """Validate LS/ACF-vetted band candidates against per-band 1D GP PSD."""
+        if not isinstance(candidate_diag, dict):
+            raise ValueError("candidate_diag must be a dictionary.")
+        if gp_validation_kwargs is None:
+            gp_validation_kwargs = {}
+        elif not isinstance(gp_validation_kwargs, dict):
+            raise ValueError("gp_validation_kwargs must be None or a dictionary.")
+
+        gp_frequency_tolerance_factor = float(gp_frequency_tolerance_factor)
+        if (
+            not np.isfinite(gp_frequency_tolerance_factor)
+            or gp_frequency_tolerance_factor <= 0
+        ):
+            raise ValueError(
+                "gp_frequency_tolerance_factor must be a finite, strictly "
+                "positive float."
+            )
+
+        period_summary_kwargs = gp_validation_kwargs.get("period_summary_kwargs")
+        if period_summary_kwargs is None:
+            period_summary_kwargs = {}
+        elif not isinstance(period_summary_kwargs, dict):
+            raise ValueError(
+                "gp_validation_kwargs['period_summary_kwargs'] must be a "
+                "dictionary when provided."
+            )
+
+        controls = dict(candidate_diag.get("controls", {}))
+        band_records = {
+            band: dict(record)
+            for band, record in candidate_diag.get("band_records", {}).items()
+        }
+        accepted_bands = list(candidate_diag.get("accepted_bands", []))
+        rejected_bands = list(candidate_diag.get("rejected_bands", []))
+        rejection_reasons = {
+            band: list(reasons)
+            for band, reasons in candidate_diag.get("rejection_reasons", {}).items()
+        }
+
+        for band, record in band_records.items():
+            _ = band
+            record.setdefault("gp_validation_used", False)
+            record.setdefault("gp_dominant_frequency", None)
+            record.setdefault("gp_dominant_period", None)
+            record.setdefault("gp_frequency_difference", None)
+            record.setdefault("gp_frequency_tolerance", None)
+            record.setdefault("gp_validation_status", None)
+            record.setdefault("gp_validation_error", None)
+
+        default_gp_fit_kwargs = {
+            "model": "1D",
+            "num_mixtures": 1,
+            "use_mls_init": True,
+            "training_iter": 100,
+            "fit_strategy": None,
+        }
+        gp_fit_kwargs = dict(gp_validation_kwargs)
+        gp_fit_kwargs.pop("period_summary_kwargs", None)
+        default_gp_fit_kwargs.update(gp_fit_kwargs)
+        default_gp_fit_kwargs["fit_strategy"] = None
+
+        accepted_after_gp = []
+        for band_label in accepted_bands:
+            record = band_records.get(band_label, {"band": band_label})
+            band_records[band_label] = record
+
+            record["gp_validation_used"] = True
+            record["gp_validation_status"] = None
+            record["gp_validation_error"] = None
+
+            ls_freq = float(record.get("dominant_frequency", np.nan))
+            ls_period = record.get("dominant_period")
+            gp_freq = None
+            gp_period = None
+            reason = None
+
+            try:
+                if not (np.isfinite(ls_freq) and ls_freq > 0):
+                    raise ValueError(
+                        "dominant_frequency is missing or invalid for GP validation."
+                    )
+
+                lc_band = self.select_bands([str(band_label)])
+                lc_band.fit(**default_gp_fit_kwargs)
+                summary = lc_band.get_period_summary(**period_summary_kwargs)
+
+                gp_freq = getattr(summary, "dominant_frequency", None)
+                if gp_freq is None and hasattr(summary, "get"):
+                    gp_freq = summary.get("dominant_frequency")
+
+                gp_period = getattr(summary, "dominant_period", None)
+                if gp_period is None and hasattr(summary, "get"):
+                    gp_period = summary.get("dominant_period")
+
+                gp_freq = float(gp_freq)
+                if not (np.isfinite(gp_freq) and gp_freq > 0):
+                    raise ValueError("GP dominant frequency is not finite/positive.")
+
+                if gp_period is None:
+                    gp_period = float(1.0 / gp_freq)
+                elif np.isfinite(float(gp_period)) and float(gp_period) > 0:
+                    gp_period = float(gp_period)
+                else:
+                    gp_period = float(1.0 / gp_freq)
+
+                tolerance = max(
+                    gp_frequency_tolerance_factor * 0.1 * ls_freq,
+                    1.0e-8,
+                )
+                diff = abs(gp_freq - ls_freq)
+
+                record["gp_dominant_frequency"] = gp_freq
+                record["gp_dominant_period"] = gp_period
+                record["gp_frequency_difference"] = float(diff)
+                record["gp_frequency_tolerance"] = float(tolerance)
+
+                if diff <= tolerance:
+                    record["gp_validation_status"] = "agreement"
+                    accepted_after_gp.append(band_label)
+                else:
+                    record["gp_validation_status"] = "disagreement"
+                    reason = "gp_ls_frequency_disagreement"
+
+            except Exception as exc:
+                record["gp_validation_status"] = "failed"
+                record["gp_validation_error"] = f"{type(exc).__name__}: {exc}"
+                reason = "gp_validation_failed"
+
+            if reason is not None:
+                if band_label not in rejected_bands:
+                    rejected_bands.append(band_label)
+                reasons = rejection_reasons.setdefault(band_label, [])
+                if reason not in reasons:
+                    reasons.append(reason)
+
+            if verbose:
+                _status = record.get("gp_validation_status")
+                _msg = (
+                    f"[consensus][gp] band={band_label} "
+                    f"ls_period={ls_period} "
+                    f"ls_frequency={record.get('dominant_frequency')} "
+                    f"gp_period={record.get('gp_dominant_period')} "
+                    f"gp_frequency={record.get('gp_dominant_frequency')} "
+                    f"status={_status}"
+                )
+                if reason is not None:
+                    _msg += f" rejection_reason={reason}"
+                print(_msg)
+
+        return {
+            "controls": controls,
+            "band_records": band_records,
+            "accepted_bands": accepted_after_gp,
             "rejected_bands": rejected_bands,
             "rejection_reasons": rejection_reasons,
         }
@@ -7408,8 +7579,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
 
         Manual ``consensus_frequencies`` can be supplied directly and bypass
         automatic candidate collection. Automatic LS/ACF consensus construction
-        currently requires a 2D light curve. 1D GP validation in this strategy
-        is planned but not implemented yet.
+        currently requires a 2D light curve.
 
         Parameters
         ----------
@@ -7417,7 +7587,9 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             Standard :meth:`fit` kwargs plus consensus-specific controls:
             ``min_points_per_band``, ``max_gap_fraction``, ``min_duty_cycle``,
             ``outlier_sigma``, ``use_acf``, ``constrain_consensus``,
-            ``consensus_width_factor``, and ``consensus_dedup_rtol``.
+            ``consensus_width_factor``, ``consensus_dedup_rtol``,
+            ``use_gp_validation``, ``gp_validation_kwargs``, and
+            ``gp_frequency_tolerance_factor``.
 
             Manual overrides are also accepted via:
 
@@ -7438,6 +7610,16 @@ class Lightcurve(InputHelpers, gpytorch.Module):
               Relative tolerance used to cluster near-identical frequency
               candidates before consensus ranking. Must be finite and strictly
               positive.
+            - ``use_gp_validation`` : bool, default ``False``
+              If ``True``, run optional per-band 1D GP frequency validation on
+              LS/ACF-vetted candidates before final consensus aggregation.
+            - ``gp_validation_kwargs`` : dict or None, default ``None``
+              Extra kwargs for per-band 1D GP validation fit and period summary.
+              Reserved nested key: ``period_summary_kwargs`` (dict), forwarded
+              only to :meth:`get_period_summary`.
+            - ``gp_frequency_tolerance_factor`` : float, default ``3.0``
+              Positive scale factor controlling the LS-vs-GP frequency
+              consistency tolerance.
 
         Returns
         -------
@@ -7474,12 +7656,32 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         use_acf = fit_kwargs.pop("use_acf", False)
         consensus_width_factor = fit_kwargs.pop("consensus_width_factor", None)
         consensus_dedup_rtol = fit_kwargs.pop("consensus_dedup_rtol", 0.01)
+        use_gp_validation = fit_kwargs.pop("use_gp_validation", False)
+        gp_validation_kwargs = fit_kwargs.pop("gp_validation_kwargs", None)
+        gp_frequency_tolerance_factor = fit_kwargs.pop(
+            "gp_frequency_tolerance_factor", 3.0
+        )
         verbose = fit_kwargs.get("verbose", False)
         consensus_dedup_rtol = float(consensus_dedup_rtol)
         if not np.isfinite(consensus_dedup_rtol) or consensus_dedup_rtol <= 0:
             raise ValueError(
                 "consensus_dedup_rtol must be a finite, strictly positive "
                 "float."
+            )
+        if not isinstance(use_gp_validation, bool):
+            raise ValueError("use_gp_validation must be a boolean.")
+        if gp_validation_kwargs is not None and not isinstance(
+            gp_validation_kwargs, dict
+        ):
+            raise ValueError("gp_validation_kwargs must be None or a dictionary.")
+        gp_frequency_tolerance_factor = float(gp_frequency_tolerance_factor)
+        if (
+            not np.isfinite(gp_frequency_tolerance_factor)
+            or gp_frequency_tolerance_factor <= 0
+        ):
+            raise ValueError(
+                "gp_frequency_tolerance_factor must be a finite, strictly "
+                "positive float."
             )
 
         auto_constraint_bounds = None
@@ -7488,8 +7690,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             if self.ndim != 2:
                 raise ValueError(
                     "Automatic consensus frequency construction requires a 2D "
-                    "light curve. 1D validation in this strategy is planned "
-                    "but not implemented yet."
+                    "light curve."
                 )
             candidate_diag = self._consensus_collect_band_candidates(
                 min_points_per_band=min_points_per_band,
@@ -7498,6 +7699,13 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 use_acf=use_acf,
                 verbose=verbose,
             )
+            if use_gp_validation:
+                candidate_diag = self._consensus_validate_candidates_with_1d_gp(
+                    candidate_diag=candidate_diag,
+                    gp_validation_kwargs=gp_validation_kwargs,
+                    gp_frequency_tolerance_factor=gp_frequency_tolerance_factor,
+                    verbose=verbose,
+                )
             auto_controls = candidate_diag["controls"]
             accepted_bands = candidate_diag.get("accepted_bands", [])
             if not accepted_bands:
@@ -7593,6 +7801,10 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                     "constrain_consensus": bool(apply_consensus_constraints),
                     "consensus_width_factor": float(consensus_width_factor),
                     "consensus_dedup_rtol": float(consensus_dedup_rtol),
+                    "use_gp_validation": bool(use_gp_validation),
+                    "gp_frequency_tolerance_factor": float(
+                        gp_frequency_tolerance_factor
+                    ),
                 },
             }
             if verbose:
@@ -7682,6 +7894,10 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                     "constrain_consensus": bool(apply_consensus_constraints),
                     "consensus_width_factor": consensus_width_factor,
                     "consensus_dedup_rtol": float(consensus_dedup_rtol),
+                    "use_gp_validation": bool(use_gp_validation),
+                    "gp_frequency_tolerance_factor": float(
+                        gp_frequency_tolerance_factor
+                    ),
                 },
                 "mode": "manual_consensus_frequencies",
             }
@@ -7711,6 +7927,9 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 "outlier_sigma",
                 "use_acf",
                 "consensus_width_factor",
+                "use_gp_validation",
+                "gp_validation_kwargs",
+                "gp_frequency_tolerance_factor",
                 "periods",
                 "use_mls_init",
                 "use_best_band_init",

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -7760,9 +7760,9 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         )
         verbose = fit_kwargs.get("verbose", False)
         consensus_dedup_rtol = float(consensus_dedup_rtol)
-        if not np.isfinite(consensus_dedup_rtol) or consensus_dedup_rtol < 0:
+        if not np.isfinite(consensus_dedup_rtol) or consensus_dedup_rtol <= 0:
             raise ValueError(
-                "consensus_dedup_rtol must be a finite, non-negative "
+                "consensus_dedup_rtol must be a finite, strictly positive "
                 "float."
             )
         if not isinstance(use_gp_validation, bool):

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -6800,6 +6800,48 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         }
 
     @staticmethod
+    def _consensus_fractional_frequency_difference(f1, f2):
+        """Return the standard consensus fractional frequency difference.
+
+        Definition
+        ----------
+        ``abs(f1 - f2) / min(f1, f2)``
+        The smaller-frequency normalisation keeps agreement checks symmetric in
+        frequency space while measuring mismatch relative to the slower
+        timescale represented by the pair.
+
+        Parameters
+        ----------
+        f1 : float
+            First positive frequency [1/day].
+        f2 : float
+            Second positive frequency [1/day].
+
+        Returns
+        -------
+        float
+            Fractional frequency difference for consensus agreement tests.
+
+        Raises
+        ------
+        ValueError
+            If either frequency is not finite and strictly positive.
+        """
+        f1_val = float(f1)
+        f2_val = float(f2)
+        if not (
+            np.isfinite(f1_val)
+            and np.isfinite(f2_val)
+            and f1_val > 0
+            and f2_val > 0
+        ):
+            raise ValueError(
+                "fractional frequency difference requires finite, positive "
+                "frequencies."
+            )
+        return abs(f1_val - f2_val) / min(f1_val, f2_val)
+
+    @staticmethod
     def _consensus_compare_ls_acf(
         ls_frequency,
         acf_frequency,
@@ -7258,15 +7300,18 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 frequency_difference = abs(
                     gp_dominant_frequency - candidate_frequency
                 )
-                # Standard consensus disagreement definition in frequency space.
-                frac_diff = frequency_difference / min(
+                fractional_frequency_difference = (
+                    self._consensus_fractional_frequency_difference(
                     candidate_frequency, gp_dominant_frequency
+                )
                 )
 
                 record["gp_dominant_frequency"] = gp_dominant_frequency
                 record["gp_dominant_period"] = gp_dominant_period
                 record["gp_frequency_difference"] = float(frequency_difference)
-                record["gp_fractional_frequency_difference"] = float(frac_diff)
+                record["gp_fractional_frequency_difference"] = float(
+                    fractional_frequency_difference
+                )
                 record["gp_frequency_tolerance"] = float(frequency_tolerance)
 
                 if frequency_difference <= frequency_tolerance:
@@ -7354,8 +7399,10 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 )
             freq = float(candidate["frequency"])
             score = float(candidate["score"])
-            if not np.isfinite(freq):
-                raise ValueError("Candidate frequencies must be finite.")
+            if not (np.isfinite(freq) and freq > 0):
+                raise ValueError(
+                    "Candidate frequencies must be finite and positive."
+                )
             if not np.isfinite(score):
                 raise ValueError("Candidate scores must be finite.")
             candidate_copy = dict(candidate)
@@ -7385,9 +7432,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             f1 = float(normalized[i]["frequency"])
             for j in range(i + 1, len(normalized)):
                 f2 = float(normalized[j]["frequency"])
-                # Use the same consensus fractional-frequency definition across
-                # clustering and agreement checks.
-                rel_diff = abs(f1 - f2) / min(f1, f2)
+                rel_diff = self._consensus_fractional_frequency_difference(f1, f2)
                 if rel_diff < _rtol:
                     _union(i, j)
 
@@ -7715,9 +7760,9 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         )
         verbose = fit_kwargs.get("verbose", False)
         consensus_dedup_rtol = float(consensus_dedup_rtol)
-        if not np.isfinite(consensus_dedup_rtol) or consensus_dedup_rtol <= 0:
+        if not np.isfinite(consensus_dedup_rtol) or consensus_dedup_rtol < 0:
             raise ValueError(
-                "consensus_dedup_rtol must be a finite, strictly positive "
+                "consensus_dedup_rtol must be a finite, non-negative "
                 "float."
             )
         if not isinstance(use_gp_validation, bool):
@@ -7752,12 +7797,13 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 verbose=verbose,
             )
             if use_gp_validation:
-                candidate_diag = self._consensus_validate_candidates_with_1d_gp(
+                validated_diag = self._consensus_validate_candidates_with_1d_gp(
                     candidate_diag=candidate_diag,
                     gp_validation_kwargs=gp_validation_kwargs,
                     gp_frequency_tolerance_factor=gp_frequency_tolerance_factor,
                     verbose=verbose,
                 )
+                candidate_diag = validated_diag
             auto_controls = candidate_diag["controls"]
             accepted_bands = candidate_diag.get("accepted_bands", [])
             if not accepted_bands:

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -7013,6 +7013,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 "gp_dominant_frequency": None,
                 "gp_dominant_period": None,
                 "gp_frequency_difference": None,
+                "gp_fractional_frequency_difference": None,
                 "gp_frequency_tolerance": None,
                 "gp_validation_status": None,
                 "gp_validation_error": None,
@@ -7169,6 +7170,95 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             "rejection_reasons": rejection_reasons,
         }
 
+    @staticmethod
+    def _consensus_prepare_gp_validation_fit_kwargs(gp_validation_kwargs=None):
+        """Build a safe, isolated kwarg dict for nested 1D GP validation fits.
+
+        All consensus logic operates in frequency space [1/day]. Periods are
+        derived from frequencies only for user-facing diagnostics.
+
+        This helper:
+
+        1. Starts from conservative defaults (``model="1D"``,
+           ``num_mixtures=1``, ``use_mls_init=True``,
+           ``training_iter=100``).
+        2. Merges non-blocked user overrides from ``gp_validation_kwargs``.
+        3. Always forces ``fit_strategy=None`` after merging.
+
+        Why ``fit_strategy`` is forced to ``None``
+        ------------------------------------------
+        Nested validation fits run on 1D per-band ``Lightcurve`` objects
+        created by ``select_bands``. These objects have no multi-band
+        structure and cannot support ``fit_strategy="consensus"``.
+        Propagating the outer ``fit_strategy`` would cause infinite
+        recursion or a misleading error.
+
+        Why consensus-only kwargs are stripped
+        --------------------------------------
+        Keys like ``consensus_frequencies``, ``use_gp_validation``, and
+        ``outlier_sigma`` are meaningful only at the 2D consensus level.
+        Forwarding them into nested 1D fits would either be silently
+        ignored or cause unexpected errors.
+
+        Parameters
+        ----------
+        gp_validation_kwargs : dict or None, optional
+            User-supplied overrides. The reserved nested key
+            ``period_summary_kwargs`` is stripped here and must NOT be
+            forwarded to ``fit()``; callers must pass it separately to
+            ``get_period_summary``.
+
+        Returns
+        -------
+        dict
+            Sanitized kwargs safe for a nested 1D ``Lightcurve.fit()``
+            call. The ``fit_strategy`` key is always ``None``.
+        """
+        # Keys that must NOT propagate into nested GP validation fits.
+        # Consensus-only kwargs are meaningless or harmful for 1D band fits.
+        # period_summary_kwargs is forwarded separately to get_period_summary.
+        _BLOCKED_KEYS = frozenset({
+            "fit_strategy",
+            "consensus_frequencies",
+            "consensus_scales",
+            "consensus_frequency_width",
+            "consensus_frequency_k",
+            "consensus_scale_max_factor",
+            "apply_consensus_constraints",
+            "constrain_consensus",
+            "use_gp_validation",
+            "gp_validation_kwargs",
+            "gp_frequency_tolerance_factor",
+            "outlier_sigma",
+            "consensus_width_factor",
+            "consensus_dedup_rtol",
+            "min_points_per_band",
+            "max_gap_fraction",
+            "min_duty_cycle",
+            "use_acf",
+            "period_summary_kwargs",
+        })
+
+        # Conservative defaults: keep validation lightweight and reproducible.
+        # Users can override non-blocked keys via gp_validation_kwargs.
+        defaults = {
+            "model": "1D",
+            "num_mixtures": 1,
+            "use_mls_init": True,
+            "training_iter": 100,
+        }
+
+        merged = dict(defaults)
+        if gp_validation_kwargs:
+            for key, val in gp_validation_kwargs.items():
+                if key not in _BLOCKED_KEYS:
+                    merged[key] = val
+
+        # Force fit_strategy=None last, regardless of any user override.
+        # A recursive consensus fit on a 1D band lightcurve is always wrong.
+        merged["fit_strategy"] = None
+        return merged
+
     def _consensus_validate_candidates_with_1d_gp(
         self,
         candidate_diag,
@@ -7231,17 +7321,10 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             record.setdefault("gp_validation_status", None)
             record.setdefault("gp_validation_error", None)
 
-        default_gp_fit_kwargs = {
-            "model": "1D",
-            "num_mixtures": 1,
-            "use_mls_init": True,
-            "training_iter": 100,
-            "fit_strategy": None,
-        }
-        gp_fit_kwargs = dict(gp_validation_kwargs)
-        gp_fit_kwargs.pop("period_summary_kwargs", None)
-        default_gp_fit_kwargs.update(gp_fit_kwargs)
-        default_gp_fit_kwargs["fit_strategy"] = None
+        default_gp_fit_kwargs = (
+            self._consensus_prepare_gp_validation_fit_kwargs(gp_validation_kwargs)
+        )
+        gp_ls_tolerance_base_factor = 0.1
 
         accepted_after_gp = []
         for band_label in accepted_bands:
@@ -7272,6 +7355,10 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                         "dominant_frequency is missing or invalid for GP validation."
                     )
 
+                # Validation is performed on a separate 1D Lightcurve returned
+                # by select_bands. The per-band fit mutates only lc_band —
+                # self.model, self.likelihood, self.guess, and
+                # self.consensus_diagnostics on this instance are unaffected.
                 lc_band = self.select_bands([str(band_label)])
                 lc_band.fit(**default_gp_fit_kwargs)
                 summary = lc_band.get_period_summary(**period_summary_kwargs)
@@ -7323,7 +7410,9 @@ class Lightcurve(InputHelpers, gpytorch.Module):
 
             except Exception as exc:
                 record["gp_validation_status"] = "failed"
-                record["gp_validation_error"] = f"{type(exc).__name__}: {exc}"
+                record["gp_validation_error"] = (
+                    f"band={band_label}: {type(exc).__name__}: {exc}"
+                )
                 reason = "gp_validation_failed"
 
             if reason is not None:

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -7231,6 +7231,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             "use_gp_validation",
             "gp_validation_kwargs",
             "gp_frequency_tolerance_factor",
+            "gp_ls_tolerance_base_factor",
             "outlier_sigma",
             "consensus_width_factor",
             "consensus_dedup_rtol",
@@ -7266,6 +7267,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         candidate_diag,
         gp_validation_kwargs=None,
         gp_frequency_tolerance_factor=3.0,
+        gp_ls_tolerance_base_factor=DEFAULT_GP_LS_TOLERANCE_BASE_FACTOR,
         verbose=False,
     ):
         """Validate LS/ACF-vetted band candidates against per-band 1D GP PSD.
@@ -7289,6 +7291,16 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         ):
             raise ValueError(
                 "gp_frequency_tolerance_factor must be a finite, strictly "
+                "positive float."
+            )
+
+        gp_ls_tolerance_base_factor = float(gp_ls_tolerance_base_factor)
+        if (
+            not np.isfinite(gp_ls_tolerance_base_factor)
+            or gp_ls_tolerance_base_factor <= 0
+        ):
+            raise ValueError(
+                "gp_ls_tolerance_base_factor must be a finite, strictly "
                 "positive float."
             )
 
@@ -7380,7 +7392,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
 
                 frequency_tolerance = max(
                     gp_frequency_tolerance_factor
-                    * DEFAULT_GP_LS_TOLERANCE_BASE_FACTOR
+                    * gp_ls_tolerance_base_factor
                     * min(candidate_frequency, gp_dominant_frequency),
                     _CONSENSUS_MIN_GP_FREQUENCY_TOLERANCE,
                 )
@@ -7847,6 +7859,10 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         gp_frequency_tolerance_factor = fit_kwargs.pop(
             "gp_frequency_tolerance_factor", 3.0
         )
+        gp_ls_tolerance_base_factor = fit_kwargs.pop(
+            "gp_ls_tolerance_base_factor",
+            DEFAULT_GP_LS_TOLERANCE_BASE_FACTOR,
+        )
         verbose = fit_kwargs.get("verbose", False)
         consensus_dedup_rtol = float(consensus_dedup_rtol)
         if not np.isfinite(consensus_dedup_rtol) or consensus_dedup_rtol <= 0:
@@ -7867,6 +7883,15 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         ):
             raise ValueError(
                 "gp_frequency_tolerance_factor must be a finite, strictly "
+                "positive float."
+            )
+        gp_ls_tolerance_base_factor = float(gp_ls_tolerance_base_factor)
+        if (
+            not np.isfinite(gp_ls_tolerance_base_factor)
+            or gp_ls_tolerance_base_factor <= 0
+        ):
+            raise ValueError(
+                "gp_ls_tolerance_base_factor must be a finite, strictly "
                 "positive float."
             )
 
@@ -7890,6 +7915,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                     candidate_diag=candidate_diag,
                     gp_validation_kwargs=gp_validation_kwargs,
                     gp_frequency_tolerance_factor=gp_frequency_tolerance_factor,
+                    gp_ls_tolerance_base_factor=gp_ls_tolerance_base_factor,
                     verbose=verbose,
                 )
                 candidate_diag = validated_diag
@@ -7992,6 +8018,9 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                     "gp_frequency_tolerance_factor": float(
                         gp_frequency_tolerance_factor
                     ),
+                    "gp_ls_tolerance_base_factor": float(
+                        gp_ls_tolerance_base_factor
+                    ),
                 },
             }
             if verbose:
@@ -8085,6 +8114,9 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                     "gp_frequency_tolerance_factor": float(
                         gp_frequency_tolerance_factor
                     ),
+                    "gp_ls_tolerance_base_factor": float(
+                        gp_ls_tolerance_base_factor
+                    ),
                 },
                 "mode": "manual_consensus_frequencies",
             }
@@ -8117,6 +8149,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 "use_gp_validation",
                 "gp_validation_kwargs",
                 "gp_frequency_tolerance_factor",
+                "gp_ls_tolerance_base_factor",
                 "periods",
                 "use_mls_init",
                 "use_best_band_init",

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -63,7 +63,7 @@ _ACF_STATUS_AGREEMENT = "agreement"
 _ACF_STATUS_HARMONIC = "harmonic"
 _ACF_STATUS_DISAGREEMENT = "disagreement"
 _ACF_STATUS_UNAVAILABLE = "unavailable"
-_CONSENSUS_GP_LS_TOLERANCE_BASE_FACTOR = 0.1
+DEFAULT_GP_LS_TOLERANCE_BASE_FACTOR = 0.1
 _CONSENSUS_MIN_GP_FREQUENCY_TOLERANCE = 1.0e-8
 
 
@@ -7380,7 +7380,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
 
                 frequency_tolerance = max(
                     gp_frequency_tolerance_factor
-                    * _CONSENSUS_GP_LS_TOLERANCE_BASE_FACTOR
+                    * DEFAULT_GP_LS_TOLERANCE_BASE_FACTOR
                     * min(candidate_frequency, gp_dominant_frequency),
                     _CONSENSUS_MIN_GP_FREQUENCY_TOLERANCE,
                 )

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -6801,22 +6801,29 @@ class Lightcurve(InputHelpers, gpytorch.Module):
 
     @staticmethod
     def _consensus_compare_ls_acf(
-        ls_period,
-        acf_period,
+        ls_frequency,
+        acf_frequency,
         harmonic_tolerance=0.15,
     ):
-        """Compare LS and ACF dominant periods for deterministic consistency checks.
+        """Compare LS and ACF dominant frequencies for consistency checks.
 
+        All internal comparisons are performed in frequency space [1/day].
         ACF is treated as an independent periodicity diagnostic. Bands where
         LS and ACF strongly disagree are rejected because the dominant LS peak
         is less likely to reflect the shared physical timescale.
 
+        The ``ratio`` returned is ``larger_frequency / smaller_frequency``.
+        Because both inputs represent the same physical cycle rate, a harmonic
+        relationship in frequency space (f1 = n * f2) yields the same integer
+        ratio as the equivalent period-space check, so harmonic detection is
+        unaffected by the convention change.
+
         Parameters
         ----------
-        ls_period : float
-            Dominant period derived from Lomb-Scargle for a single band.
-        acf_period : float
-            Dominant period derived from ACF for the same band.
+        ls_frequency : float
+            Dominant frequency [1/day] derived from Lomb-Scargle for a band.
+        acf_frequency : float
+            Dominant frequency [1/day] derived from ACF for the same band.
         harmonic_tolerance : float, optional
             Relative tolerance used to classify direct or harmonic agreement.
 
@@ -6826,11 +6833,11 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             Comparison summary with keys:
             ``status`` (``"agreement"``, ``"harmonic"``,
             ``"disagreement"``, or ``"unavailable"``),
-            ``ratio`` (larger/smaller period ratio), and
+            ``ratio`` (larger/smaller frequency ratio), and
             ``harmonic_order`` (integer harmonic when applicable).
         """
-        ls_val = float(ls_period) if ls_period is not None else np.nan
-        acf_val = float(acf_period) if acf_period is not None else np.nan
+        ls_val = float(ls_frequency) if ls_frequency is not None else np.nan
+        acf_val = float(acf_frequency) if acf_frequency is not None else np.nan
 
         if not (
             np.isfinite(ls_val)
@@ -6988,6 +6995,13 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             longest_period = float(metrics.get("longest_detectable_period", np.nan))
             if not (np.isfinite(longest_period) and longest_period > 0):
                 longest_period = baseline / 2.0 if np.isfinite(baseline) else np.nan
+            # Minimum physically plausible frequency (inverse of longest
+            # detectable period). All plausibility checks use frequency space.
+            min_detectable_frequency = (
+                float(1.0 / longest_period)
+                if (np.isfinite(longest_period) and longest_period > 0)
+                else 0.0
+            )
             nyquist_freq = float(metrics.get("nyquist_frequency", np.inf))
 
             plausible_idx = []
@@ -6996,8 +7010,9 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                     continue
                 if np.isfinite(nyquist_freq) and fval > nyquist_freq:
                     continue
-                period = 1.0 / fval
-                if np.isfinite(longest_period) and period > longest_period:
+                # Frequency below the minimum detectable frequency means the
+                # corresponding period would exceed the longest detectable period.
+                if min_detectable_frequency > 0 and fval < min_detectable_frequency:
                     continue
                 plausible_idx.append(idx)
 
@@ -7016,12 +7031,19 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 best_idx = plausible_idx[0]
 
             dominant_freq = float(ls_freqs_np[best_idx])
+            # Period is derived here for storage as a user-facing diagnostic
+            # only; all internal decisions remain in frequency space.
             dominant_period = float(1.0 / dominant_freq)
 
-            if np.isfinite(longest_period) and dominant_period > longest_period:
+            # Final plausibility guard: frequency must meet the minimum
+            # detectable frequency threshold.
+            if (
+                min_detectable_frequency > 0
+                and dominant_freq < min_detectable_frequency
+            ):
                 rejected_bands.append(band_label)
                 rejection_reasons[band_label] = [
-                    "baseline_too_short_for_candidate_period",
+                    "baseline_too_short_for_candidate_frequency",
                 ]
                 band_records[band_label] = record
                 continue
@@ -7046,9 +7068,11 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                     record["acf_frequency"] = acf_candidate["frequency"]
                     record["acf_period"] = acf_candidate["period"]
 
+                # Consistency check is performed in frequency space; period
+                # fields in the record are presentation-only derivations.
                 acf_compare = self._consensus_compare_ls_acf(
-                    ls_period=dominant_period,
-                    acf_period=record["acf_period"],
+                    ls_frequency=dominant_freq,
+                    acf_frequency=record["acf_frequency"],
                 )
                 record["acf_comparison_status"] = acf_compare["status"]
                 record["acf_period_ratio"] = acf_compare["ratio"]
@@ -7110,7 +7134,13 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         gp_frequency_tolerance_factor=3.0,
         verbose=False,
     ):
-        """Validate LS/ACF-vetted band candidates against per-band 1D GP PSD."""
+        """Validate LS/ACF-vetted band candidates against per-band 1D GP PSD.
+
+        All comparison logic operates in frequency space [1/day].  Period
+        values stored in ``band_records`` (``gp_dominant_period`` etc.) are
+        derived from the validated GP frequency solely for user-facing display
+        and are not used in any acceptance/rejection decision.
+        """
         if not isinstance(candidate_diag, dict):
             raise ValueError("candidate_diag must be a dictionary.")
         if gp_validation_kwargs is None:
@@ -7180,8 +7210,12 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             record["gp_validation_status"] = None
             record["gp_validation_error"] = None
 
-            ls_freq = float(record.get("dominant_frequency", np.nan))
-            ls_period = record.get("dominant_period")
+            _ls_freq_raw = record.get("dominant_frequency", np.nan)
+            ls_freq = (
+                float(_ls_freq_raw) if _ls_freq_raw is not None else np.nan
+            )
+            # Period is derived for verbose display only; all GP validation
+            # decisions are made in frequency space.
             gp_freq = None
             gp_period = None
             reason = None
@@ -7247,9 +7281,15 @@ class Lightcurve(InputHelpers, gpytorch.Module):
 
             if verbose:
                 _status = record.get("gp_validation_status")
+                # Period shown here is derived from frequency for display only.
+                _ls_period_display = (
+                    float(1.0 / ls_freq)
+                    if (np.isfinite(ls_freq) and ls_freq > 0)
+                    else None
+                )
                 _msg = (
                     f"[consensus][gp] band={band_label} "
-                    f"ls_period={ls_period} "
+                    f"ls_period={_ls_period_display} "
                     f"ls_frequency={record.get('dominant_frequency')} "
                     f"gp_period={record.get('gp_dominant_period')} "
                     f"gp_frequency={record.get('gp_dominant_frequency')} "

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -7031,9 +7031,6 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 best_idx = plausible_idx[0]
 
             dominant_freq = float(ls_freqs_np[best_idx])
-            # Period is derived here for storage as a user-facing diagnostic
-            # only; all internal decisions remain in frequency space.
-            dominant_period = float(1.0 / dominant_freq)
 
             # Final plausibility guard: frequency must meet the minimum
             # detectable frequency threshold.
@@ -7087,6 +7084,9 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                     band_records[band_label] = record
                     continue
 
+            # Consensus logic operates in frequency space internally. Period is
+            # derived only for user-facing diagnostics.
+            dominant_period = float(1.0 / dominant_freq)
             record["dominant_frequency"] = dominant_freq
             record["dominant_period"] = dominant_period
             record["ls_significant"] = bool(
@@ -7210,18 +7210,22 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             record["gp_validation_status"] = None
             record["gp_validation_error"] = None
 
-            _ls_freq_raw = record.get("dominant_frequency", np.nan)
-            ls_freq = (
-                float(_ls_freq_raw) if _ls_freq_raw is not None else np.nan
+            _candidate_frequency_raw = record.get("dominant_frequency", np.nan)
+            candidate_frequency = (
+                float(_candidate_frequency_raw)
+                if _candidate_frequency_raw is not None
+                else np.nan
             )
             # Period is derived for verbose display only; all GP validation
             # decisions are made in frequency space.
-            gp_freq = None
-            gp_period = None
+            gp_dominant_frequency = None
+            gp_dominant_period = None
             reason = None
 
             try:
-                if not (np.isfinite(ls_freq) and ls_freq > 0):
+                if not (
+                    np.isfinite(candidate_frequency) and candidate_frequency > 0
+                ):
                     raise ValueError(
                         "dominant_frequency is missing or invalid for GP validation."
                     )
@@ -7230,37 +7234,42 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 lc_band.fit(**default_gp_fit_kwargs)
                 summary = lc_band.get_period_summary(**period_summary_kwargs)
 
-                gp_freq = getattr(summary, "dominant_frequency", None)
-                if gp_freq is None and hasattr(summary, "get"):
-                    gp_freq = summary.get("dominant_frequency")
+                gp_dominant_frequency = getattr(summary, "dominant_frequency", None)
+                if gp_dominant_frequency is None and hasattr(summary, "get"):
+                    gp_dominant_frequency = summary.get("dominant_frequency")
 
-                gp_period = getattr(summary, "dominant_period", None)
-                if gp_period is None and hasattr(summary, "get"):
-                    gp_period = summary.get("dominant_period")
-
-                gp_freq = float(gp_freq)
-                if not (np.isfinite(gp_freq) and gp_freq > 0):
+                gp_dominant_frequency = float(gp_dominant_frequency)
+                if not (
+                    np.isfinite(gp_dominant_frequency)
+                    and gp_dominant_frequency > 0
+                ):
                     raise ValueError("GP dominant frequency is not finite/positive.")
 
-                if gp_period is None:
-                    gp_period = float(1.0 / gp_freq)
-                elif np.isfinite(float(gp_period)) and float(gp_period) > 0:
-                    gp_period = float(gp_period)
-                else:
-                    gp_period = float(1.0 / gp_freq)
+                # Consensus logic operates in frequency space internally.
+                # Period is derived from frequency only for display/diagnostics.
+                gp_dominant_period = float(1.0 / gp_dominant_frequency)
 
-                tolerance = max(
-                    gp_frequency_tolerance_factor * 0.1 * ls_freq,
+                frequency_tolerance = max(
+                    gp_frequency_tolerance_factor
+                    * gp_ls_tolerance_base_factor
+                    * min(candidate_frequency, gp_dominant_frequency),
                     1.0e-8,
                 )
-                diff = abs(gp_freq - ls_freq)
+                frequency_difference = abs(
+                    gp_dominant_frequency - candidate_frequency
+                )
+                # Standard consensus disagreement definition in frequency space.
+                frac_diff = frequency_difference / min(
+                    candidate_frequency, gp_dominant_frequency
+                )
 
-                record["gp_dominant_frequency"] = gp_freq
-                record["gp_dominant_period"] = gp_period
-                record["gp_frequency_difference"] = float(diff)
-                record["gp_frequency_tolerance"] = float(tolerance)
+                record["gp_dominant_frequency"] = gp_dominant_frequency
+                record["gp_dominant_period"] = gp_dominant_period
+                record["gp_frequency_difference"] = float(frequency_difference)
+                record["gp_fractional_frequency_difference"] = float(frac_diff)
+                record["gp_frequency_tolerance"] = float(frequency_tolerance)
 
-                if diff <= tolerance:
+                if frequency_difference <= frequency_tolerance:
                     record["gp_validation_status"] = "agreement"
                     accepted_after_gp.append(band_label)
                 else:
@@ -7283,8 +7292,11 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 _status = record.get("gp_validation_status")
                 # Period shown here is derived from frequency for display only.
                 _ls_period_display = (
-                    float(1.0 / ls_freq)
-                    if (np.isfinite(ls_freq) and ls_freq > 0)
+                    float(1.0 / candidate_frequency)
+                    if (
+                        np.isfinite(candidate_frequency)
+                        and candidate_frequency > 0
+                    )
                     else None
                 )
                 _msg = (
@@ -7369,13 +7381,13 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             if ri != rj:
                 parent[rj] = ri
 
-        epsilon_denom = np.finfo(float).tiny
         for i in range(len(normalized)):
             f1 = float(normalized[i]["frequency"])
             for j in range(i + 1, len(normalized)):
                 f2 = float(normalized[j]["frequency"])
-                denom = max(abs(f1), abs(f2), epsilon_denom)
-                rel_diff = abs(f1 - f2) / denom
+                # Use the same consensus fractional-frequency definition across
+                # clustering and agreement checks.
+                rel_diff = abs(f1 - f2) / min(f1, f2)
                 if rel_diff < _rtol:
                     _union(i, j)
 
@@ -8100,13 +8112,13 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         return self.fit(**fit_kwargs)
 
     def _consensus_multicomp_fit(self, **fit_kwargs):
-        """Consensus-fit stub for future multi-component consensus fitting."""
+        """Frequency-space consensus-fit stub for multi-component fitting."""
         raise NotImplementedError(
             "fit_strategy='consensus_multicomp' is not implemented yet."
         )
 
     def _consensus_relaxed_fit(self, **fit_kwargs):
-        """Consensus-fit stub for future relaxed-consensus fitting behavior."""
+        """Frequency-space consensus-fit stub for relaxed-consensus behavior."""
         raise NotImplementedError(
             "fit_strategy='consensus_relaxed' is not implemented yet."
         )

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -64,6 +64,7 @@ _ACF_STATUS_HARMONIC = "harmonic"
 _ACF_STATUS_DISAGREEMENT = "disagreement"
 _ACF_STATUS_UNAVAILABLE = "unavailable"
 _CONSENSUS_GP_LS_TOLERANCE_BASE_FACTOR = 0.1
+_CONSENSUS_MIN_GP_FREQUENCY_TOLERANCE = 1.0e-8
 
 
 def _reraise_with_note(e, note):
@@ -7381,7 +7382,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                     gp_frequency_tolerance_factor
                     * _CONSENSUS_GP_LS_TOLERANCE_BASE_FACTOR
                     * min(candidate_frequency, gp_dominant_frequency),
-                    1.0e-8,
+                    _CONSENSUS_MIN_GP_FREQUENCY_TOLERANCE,
                 )
                 frequency_difference = abs(
                     gp_dominant_frequency - candidate_frequency

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -63,6 +63,7 @@ _ACF_STATUS_AGREEMENT = "agreement"
 _ACF_STATUS_HARMONIC = "harmonic"
 _ACF_STATUS_DISAGREEMENT = "disagreement"
 _ACF_STATUS_UNAVAILABLE = "unavailable"
+_CONSENSUS_GP_LS_TOLERANCE_BASE_FACTOR = 0.1
 
 
 def _reraise_with_note(e, note):
@@ -7311,12 +7312,12 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             for band, reasons in candidate_diag.get("rejection_reasons", {}).items()
         }
 
-        for band, record in band_records.items():
-            _ = band
+        for record in band_records.values():
             record.setdefault("gp_validation_used", False)
             record.setdefault("gp_dominant_frequency", None)
             record.setdefault("gp_dominant_period", None)
             record.setdefault("gp_frequency_difference", None)
+            record.setdefault("gp_fractional_frequency_difference", None)
             record.setdefault("gp_frequency_tolerance", None)
             record.setdefault("gp_validation_status", None)
             record.setdefault("gp_validation_error", None)
@@ -7324,8 +7325,6 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         default_gp_fit_kwargs = (
             self._consensus_prepare_gp_validation_fit_kwargs(gp_validation_kwargs)
         )
-        gp_ls_tolerance_base_factor = 0.1
-
         accepted_after_gp = []
         for band_label in accepted_bands:
             record = band_records.get(band_label, {"band": band_label})
@@ -7380,7 +7379,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
 
                 frequency_tolerance = max(
                     gp_frequency_tolerance_factor
-                    * gp_ls_tolerance_base_factor
+                    * _CONSENSUS_GP_LS_TOLERANCE_BASE_FACTOR
                     * min(candidate_frequency, gp_dominant_frequency),
                     1.0e-8,
                 )
@@ -7389,8 +7388,8 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 )
                 fractional_frequency_difference = (
                     self._consensus_fractional_frequency_difference(
-                    candidate_frequency, gp_dominant_frequency
-                )
+                        candidate_frequency, gp_dominant_frequency
+                    )
                 )
 
                 record["gp_dominant_frequency"] = gp_dominant_frequency

--- a/tests/test_consensus_gp_validation.py
+++ b/tests/test_consensus_gp_validation.py
@@ -1,0 +1,120 @@
+"""Tests for consensus GP-validation helpers."""
+
+import unittest
+from types import SimpleNamespace
+
+import numpy as np
+
+from pgmuvi.lightcurve import Lightcurve
+
+
+class _FakeBandLightcurve:
+    """Minimal fake Lightcurve used for per-band GP-validation tests."""
+
+    def __init__(self, dominant_frequency, fit_error=None):
+        self._dominant_frequency = dominant_frequency
+        self._fit_error = fit_error
+        self.fit_calls = []
+        self.summary_calls = []
+
+    def fit(self, **kwargs):
+        self.fit_calls.append(dict(kwargs))
+        if self._fit_error is not None:
+            raise self._fit_error
+
+    def get_period_summary(self, **kwargs):
+        self.summary_calls.append(dict(kwargs))
+        return SimpleNamespace(dominant_frequency=self._dominant_frequency)
+
+
+class TestConsensusGPValidationHelpers(unittest.TestCase):
+    """Unit tests for GP-validation kwarg sanitization and candidate vetting."""
+
+    def setUp(self):
+        x = np.linspace(0.0, 10.0, 32)
+        y = np.sin(x)
+        self.lc = Lightcurve(x, y)
+
+    def test_prepare_gp_validation_fit_kwargs_strips_blocked_and_forces_strategy(self):
+        """Blocked consensus keys are removed and fit_strategy is always None."""
+        kwargs = Lightcurve._consensus_prepare_gp_validation_fit_kwargs(
+            {
+                "model": "2D",
+                "fit_strategy": "consensus",
+                "consensus_frequencies": [0.1],
+                "use_gp_validation": True,
+                "period_summary_kwargs": {"backend": "gp"},
+                "training_iter": 7,
+                "lr": 0.05,
+            }
+        )
+
+        self.assertEqual(kwargs["model"], "2D")
+        self.assertEqual(kwargs["training_iter"], 7)
+        self.assertEqual(kwargs["lr"], 0.05)
+        self.assertIsNone(kwargs["fit_strategy"])
+        self.assertNotIn("consensus_frequencies", kwargs)
+        self.assertNotIn("use_gp_validation", kwargs)
+        self.assertNotIn("period_summary_kwargs", kwargs)
+
+    def test_validate_candidates_with_1d_gp_updates_records_and_band_lists(self):
+        """Agreement/disagreement/failure are reflected in diagnostics fields."""
+        candidate_diag = {
+            "controls": {},
+            "band_records": {
+                "A": {"band": "A", "dominant_frequency": 1.0},
+                "B": {"band": "B", "dominant_frequency": 1.0},
+                "C": {"band": "C", "dominant_frequency": 1.0},
+            },
+            "accepted_bands": ["A", "B", "C"],
+            "rejected_bands": [],
+            "rejection_reasons": {},
+        }
+        band_lcs = {
+            "A": _FakeBandLightcurve(dominant_frequency=1.05),
+            "B": _FakeBandLightcurve(dominant_frequency=5.0),
+            "C": _FakeBandLightcurve(
+                dominant_frequency=1.0, fit_error=RuntimeError("fit failed")
+            ),
+        }
+
+        def _fake_select_bands(labels):
+            return band_lcs[labels[0]]
+
+        self.lc.select_bands = _fake_select_bands
+
+        validated = self.lc._consensus_validate_candidates_with_1d_gp(
+            candidate_diag=candidate_diag,
+            gp_validation_kwargs={
+                "training_iter": 3,
+                "fit_strategy": "consensus",
+                "period_summary_kwargs": {"backend": "gp"},
+            },
+            gp_frequency_tolerance_factor=1.0,
+            verbose=False,
+        )
+
+        self.assertEqual(validated["accepted_bands"], ["A"])
+        self.assertCountEqual(validated["rejected_bands"], ["B", "C"])
+        self.assertEqual(
+            validated["rejection_reasons"]["B"], ["gp_ls_frequency_disagreement"]
+        )
+        self.assertEqual(validated["rejection_reasons"]["C"], ["gp_validation_failed"])
+
+        records = validated["band_records"]
+        self.assertEqual(records["A"]["gp_validation_status"], "agreement")
+        self.assertEqual(records["B"]["gp_validation_status"], "disagreement")
+        self.assertEqual(records["C"]["gp_validation_status"], "failed")
+
+        self.assertIsInstance(records["A"]["gp_fractional_frequency_difference"], float)
+        self.assertIsInstance(records["B"]["gp_fractional_frequency_difference"], float)
+        self.assertIsNone(records["C"]["gp_fractional_frequency_difference"])
+
+        self.assertTrue(records["A"]["gp_validation_used"])
+        self.assertTrue(records["B"]["gp_validation_used"])
+        self.assertTrue(records["C"]["gp_validation_used"])
+        self.assertIn("RuntimeError", records["C"]["gp_validation_error"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_consensus_gp_validation.py
+++ b/tests/test_consensus_gp_validation.py
@@ -43,6 +43,7 @@ class TestConsensusGPValidationHelpers(unittest.TestCase):
                 "fit_strategy": "consensus",
                 "consensus_frequencies": [0.1],
                 "use_gp_validation": True,
+                "gp_ls_tolerance_base_factor": 0.2,
                 "period_summary_kwargs": {"backend": "gp"},
                 "training_iter": 7,
                 "lr": 0.05,
@@ -55,6 +56,7 @@ class TestConsensusGPValidationHelpers(unittest.TestCase):
         self.assertIsNone(kwargs["fit_strategy"])
         self.assertNotIn("consensus_frequencies", kwargs)
         self.assertNotIn("use_gp_validation", kwargs)
+        self.assertNotIn("gp_ls_tolerance_base_factor", kwargs)
         self.assertNotIn("period_summary_kwargs", kwargs)
 
     def test_validate_candidates_with_1d_gp_updates_diagnostics(self):

--- a/tests/test_consensus_gp_validation.py
+++ b/tests/test_consensus_gp_validation.py
@@ -35,7 +35,7 @@ class TestConsensusGPValidationHelpers(unittest.TestCase):
         y = np.sin(x)
         self.lc = Lightcurve(x, y)
 
-    def test_prepare_gp_validation_fit_kwargs_strips_blocked_and_forces_strategy(self):
+    def test_prepare_gp_validation_fit_kwargs_strips_blocked_keys(self):
         """Blocked consensus keys are removed and fit_strategy is always None."""
         kwargs = Lightcurve._consensus_prepare_gp_validation_fit_kwargs(
             {
@@ -57,7 +57,7 @@ class TestConsensusGPValidationHelpers(unittest.TestCase):
         self.assertNotIn("use_gp_validation", kwargs)
         self.assertNotIn("period_summary_kwargs", kwargs)
 
-    def test_validate_candidates_with_1d_gp_updates_records_and_band_lists(self):
+    def test_validate_candidates_with_1d_gp_updates_diagnostics(self):
         """Agreement/disagreement/failure are reflected in diagnostics fields."""
         candidate_diag = {
             "controls": {},

--- a/tests/test_consensus_gp_validation.py
+++ b/tests/test_consensus_gp_validation.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 
 import numpy as np
 
-from pgmuvi.lightcurve import Lightcurve
+from pgmuvi.lightcurve import DEFAULT_GP_LS_TOLERANCE_BASE_FACTOR, Lightcurve
 
 
 class _FakeBandLightcurve:
@@ -116,6 +116,49 @@ class TestConsensusGPValidationHelpers(unittest.TestCase):
         self.assertTrue(records["B"]["gp_validation_used"])
         self.assertTrue(records["C"]["gp_validation_used"])
         self.assertIn("RuntimeError", records["C"]["gp_validation_error"])
+
+    def test_gp_ls_tolerance_base_factor_default_and_override(self):
+        """Default matches historical tolerance and override changes tolerance."""
+
+        def _candidate_diag():
+            return {
+                "controls": {},
+                "band_records": {"A": {"band": "A", "dominant_frequency": 1.0}},
+                "accepted_bands": ["A"],
+                "rejected_bands": [],
+                "rejection_reasons": {},
+            }
+
+        band_lcs = {"A": _FakeBandLightcurve(dominant_frequency=1.15)}
+
+        def _fake_select_bands(labels):
+            return band_lcs[labels[0]]
+
+        self.lc.select_bands = _fake_select_bands
+
+        default_validated = self.lc._consensus_validate_candidates_with_1d_gp(
+            candidate_diag=_candidate_diag(),
+            gp_frequency_tolerance_factor=1.0,
+            verbose=False,
+        )
+        default_record = default_validated["band_records"]["A"]
+
+        self.assertAlmostEqual(
+            default_record["gp_frequency_tolerance"],
+            DEFAULT_GP_LS_TOLERANCE_BASE_FACTOR,
+        )
+        self.assertEqual(default_record["gp_validation_status"], "disagreement")
+
+        override_validated = self.lc._consensus_validate_candidates_with_1d_gp(
+            candidate_diag=_candidate_diag(),
+            gp_frequency_tolerance_factor=1.0,
+            gp_ls_tolerance_base_factor=0.2,
+            verbose=False,
+        )
+        override_record = override_validated["band_records"]["A"]
+
+        self.assertAlmostEqual(override_record["gp_frequency_tolerance"], 0.2)
+        self.assertEqual(override_record["gp_validation_status"], "agreement")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add optional per-band GP validation for consensus candidates

Agent-Logs-Url: https://github.com/ICSM/pgmuvi/sessions/98f86db8-976b-4250-bb54-1bd34aa276ee

Co-authored-by: sundarjhu <15619959+sundarjhu@users.noreply.github.com>

refactor: convert consensus machinery to frequency-space internally

Agent-Logs-Url: https://github.com/ICSM/pgmuvi/sessions/c3a0fa8f-c6a5-409d-8b39-aca7297aa810

Co-authored-by: sundarjhu <15619959+sundarjhu@users.noreply.github.com>

refactor: standardize GP consensus frequency-space internals

Agent-Logs-Url: https://github.com/ICSM/pgmuvi/sessions/353b6879-88e4-49de-acac-d22fa5934037

Co-authored-by: sundarjhu <15619959+sundarjhu@users.noreply.github.com>

refactor: unify consensus fractional frequency checks

Agent-Logs-Url: https://github.com/ICSM/pgmuvi/sessions/353b6879-88e4-49de-acac-d22fa5934037

Co-authored-by: sundarjhu <15619959+sundarjhu@users.noreply.github.com>

fix: restore strict validation - consensus_dedup_rtol must be strictly positive

Agent-Logs-Url: https://github.com/ICSM/pgmuvi/sessions/273ac907-d4fd-4ed2-9816-44d705371e38

Co-authored-by: sundarjhu <15619959+sundarjhu@users.noreply.github.com>

feat: harden consensus workflow architecture

- Add _consensus_prepare_gp_validation_fit_kwargs static helper that
  builds sanitized, isolated kwargs for nested 1D GP validation fits.
  The helper strips all consensus-only kwargs (consensus_frequencies,
  use_gp_validation, outlier_sigma, etc.), strips period_summary_kwargs
  (forwarded separately), and always forces fit_strategy=None to prevent
  recursive consensus fits.

- Use the new helper in _consensus_validate_candidates_with_1d_gp,
  replacing the previous inline kwarg-preparation logic.

- Add gp_fractional_frequency_difference to the base band record schema
  in _consensus_collect_band_candidates, so every band record contains
  the same set of diagnostic keys regardless of execution path.

- Strengthen state-safety comment near lc_band.fit() to explicitly
  list self.model, self.likelihood, self.guess, and
  self.consensus_diagnostics as unaffected by the per-band fit.

- Include band label in GP validation exception messages for clearer
  per-band failure diagnostics.

Agent-Logs-Url: https://github.com/ICSM/pgmuvi/sessions/36dd35d8-adb0-4962-868f-a9da2dde43f2

Co-authored-by: sundarjhu <15619959+sundarjhu@users.noreply.github.com>