### PR TITLE
Add ConsensusFitError, structured diagnostics, and regression tests

### DIFF
--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -137,6 +137,7 @@ class ConsensusFitError(RuntimeError):
             if failure_diagnostics is not None
             else {"status": "failed"}
         )
+        self.failure_summary = None
 
 
 _CONSENSUS_MIN_FREQUENCY_BOUND = 1.0e-12
@@ -9704,8 +9705,9 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         """Clear stale model-related state before a fresh consensus model build.
 
         Removes ``self.model``, ``self.likelihood``, and ``self._model_pars``
-        and resets the likelihood-set flag so that the subsequent
-        :meth:`set_model` call always starts from a clean slate.
+        and resets the likelihood-set flag and the constraints-set flag so
+        that the subsequent :meth:`set_model` call always starts from a clean
+        slate and default constraints are reapplied to the new model.
         Light-curve data and fit history are never touched.
         """
         for _attr in ("model", "likelihood", "_model_pars"):
@@ -9717,6 +9719,13 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         # again for the new model build.
         try:
             self.__SET_LIKELIHOOD_CALLED = False
+        except Exception:
+            pass
+        # Reset the constraints-set flag so that the new model always has
+        # fresh constraints applied (either by set_default_constraints in the
+        # consensus path or by _fit_core).
+        try:
+            self.__CONTRAINTS_SET = False
         except Exception:
             pass
 
@@ -9758,6 +9767,186 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 "detail": str(exc),
             }
             raise _exc from exc
+
+    def _consensus_validate_applied_sm_constraints(
+        self, keys, consensus_frequencies, frequency_bounds
+    ):
+        """Verify that consensus constraints were actually applied to the model.
+
+        Inspects the registered constraint on the ``mixture_means`` parameter
+        and confirms that an ``Interval`` constraint (with finite upper bound)
+        is registered.  Raises :exc:`ConsensusFitError` if the constraint is
+        missing or looks like a default ``GreaterThan``/``Positive`` (infinite
+        upper bound), which would indicate that default constraints overwrote
+        the consensus constraints.
+
+        Parameters
+        ----------
+        keys : dict
+            Resolved SM parameter keys as returned by
+            :meth:`_consensus_resolve_time_spectral_mixture_keys`.
+        consensus_frequencies : array-like
+            The consensus frequency or frequencies (used in error messages).
+        frequency_bounds : tuple of (float, float) or None
+            The ``(lower, upper)`` bounds that were passed to
+            :meth:`set_constraint`.  If ``None``, validation is skipped.
+
+        Raises
+        ------
+        ConsensusFitError
+            If the constraint is not found or its upper bound is infinite
+            (indicating the consensus Interval constraint was not applied).
+        """
+        if frequency_bounds is None:
+            return
+        _model_pars = getattr(self, "_model_pars", None)
+        _available_keys = (
+            sorted(_model_pars.keys())
+            if isinstance(_model_pars, dict)
+            else f"<non-dict:{type(_model_pars).__name__}>"
+        )
+        _mm_key = keys.get("mixture_means")
+        if _mm_key is None:
+            _msg = (
+                "Consensus constraint validation failed: resolved keys do not "
+                "contain 'mixture_means' while frequency bounds were provided. "
+                f"resolved_keys={sorted(keys.keys())}, "
+                f"available_model_parameter_keys={_available_keys}, "
+                f"expected_frequency_bounds={frequency_bounds}."
+            )
+            raise ConsensusFitError(_msg)
+        if not isinstance(_model_pars, dict) or _mm_key not in _model_pars:
+            _msg = (
+                "Consensus constraint validation failed: mixture_means key "
+                f"{_mm_key!r} is missing from model parameters. "
+                f"available_model_parameter_keys={_available_keys}, "
+                f"expected_frequency_bounds={frequency_bounds}."
+            )
+            raise ConsensusFitError(_msg)
+        _mm_meta = _model_pars[_mm_key]
+        if not isinstance(_mm_meta, dict):
+            _msg = (
+                "Consensus constraint validation failed: metadata for "
+                f"{_mm_key!r} must be a dict, got "
+                f"{type(_mm_meta).__name__}. "
+                f"available_model_parameter_keys={_available_keys}, "
+                f"expected_frequency_bounds={frequency_bounds}."
+            )
+            raise ConsensusFitError(_msg)
+        _module = _mm_meta.get("module")
+        if _module is None:
+            _msg = (
+                "Consensus constraint validation failed: no module found in "
+                f"metadata for { _mm_key!r}. metadata_keys={sorted(_mm_meta.keys())}, "
+                f"available_model_parameter_keys={_available_keys}, "
+                f"expected_frequency_bounds={frequency_bounds}."
+            )
+            raise ConsensusFitError(_msg)
+        _module_name = _module.__class__.__name__
+        _raw_name = (
+            f"raw_{_mm_key.split('.')[-1]}"
+            if "raw_" not in _mm_key
+            else _mm_key.split(".")[-1]
+        )
+        # GPyTorch stores constraints with a "_constraint" suffix in
+        # named_constraints(), so the registered name is:
+        #   raw_mixture_means_constraint
+        _constraint_key = _raw_name + "_constraint"
+        try:
+            _registered = dict(_module.named_constraints())
+        except Exception as exc:
+            _msg = (
+                "Consensus constraint validation failed: unable to inspect "
+                "registered constraints via named_constraints(). "
+                f"mixture_means_key={_mm_key!r}, module_class={_module_name}, "
+                f"expected_raw_constraint={_constraint_key!r}, "
+                f"expected_frequency_bounds={frequency_bounds}, "
+                f"detail={exc!r}."
+            )
+            raise ConsensusFitError(_msg) from exc
+        _found = _registered.get(_constraint_key)
+        if _found is None:
+            _registered_names = sorted(_registered.keys())
+            raise ConsensusFitError(
+                "Consensus constraint validation failed: no constraint found "
+                f"for raw parameter {_constraint_key!r} on module "
+                f"{_module_name}. The consensus constraint was not registered. "
+                "This may indicate that default constraints overwrote the "
+                "consensus constraints. "
+                f"registered_constraint_names={_registered_names}, "
+                f"mixture_means_key={_mm_key!r}, "
+                f"expected_frequency_bounds={frequency_bounds}."
+            )
+        # Verify the constraint is an Interval (finite upper bound), not just
+        # a GreaterThan or Positive (infinite upper bound). Default constraints
+        # set by set_default_constraints use GreaterThan; the consensus
+        # constraint sets an Interval with finite bounds. If the upper bound
+        # is infinite, the consensus constraint was overwritten.
+        _freqs_arr = np.asarray(consensus_frequencies, dtype=float).ravel()
+        if _freqs_arr.size == 0 or not np.all(np.isfinite(_freqs_arr)):
+            raise ConsensusFitError(
+                "Consensus constraint validation failed: consensus_frequencies "
+                "must be non-empty and finite for validation. "
+                f"got={_freqs_arr.tolist()}, mixture_means_key={_mm_key!r}, "
+                f"expected_frequency_bounds={frequency_bounds}."
+            )
+        _target_freq = float(np.median(_freqs_arr))
+        try:
+            import math as _math
+            _lower_raw = getattr(_found, "lower_bound", None)
+            _upper_raw = getattr(_found, "upper_bound", None)
+            if _lower_raw is None or _upper_raw is None:
+                raise ConsensusFitError(
+                    "Consensus constraint validation failed: registered "
+                    "constraint does not expose usable lower/upper bounds. "
+                    f"constraint_type={type(_found).__name__}, "
+                    f"module_class={_module_name}, mixture_means_key={_mm_key!r}, "
+                    f"expected_frequency_bounds={frequency_bounds}, "
+                    f"consensus_frequency={_target_freq:.6g}."
+                )
+            _upper = float(_upper_raw)
+            _lower = float(_lower_raw)
+            if _math.isinf(_upper):
+                raise ConsensusFitError(
+                    "Consensus constraint validation failed: the registered "
+                    f"mixture_means constraint on module {_module_name} has "
+                    "an infinite upper bound, indicating it is not the expected "
+                    "finite consensus Interval constraint. "
+                    f"mixture_means_key={_mm_key!r}, "
+                    f"expected_frequency_bounds={frequency_bounds}, "
+                    f"registered_bounds=[{_lower:.6g}, {_upper:.6g}], "
+                    f"consensus_frequency={_target_freq:.6g}."
+                )
+            if not (_lower < _upper):
+                raise ConsensusFitError(
+                    "Consensus constraint validation failed: the registered "
+                    "mixture_means constraint has invalid bounds "
+                    f"[{_lower:.6g}, {_upper:.6g}] (lower >= upper). "
+                    f"mixture_means_key={_mm_key!r}, module_class={_module_name}, "
+                    f"expected_frequency_bounds={frequency_bounds}, "
+                    f"consensus_frequency={_target_freq:.6g}."
+                )
+            if not (_lower <= _target_freq <= _upper):
+                raise ConsensusFitError(
+                    "Consensus constraint validation failed: consensus "
+                    "frequency lies outside the registered mixture_means "
+                    "constraint bounds. "
+                    f"mixture_means_key={_mm_key!r}, module_class={_module_name}, "
+                    f"expected_frequency_bounds={frequency_bounds}, "
+                    f"registered_bounds=[{_lower:.6g}, {_upper:.6g}], "
+                    f"consensus_frequency={_target_freq:.6g}."
+                )
+        except ConsensusFitError:
+            raise
+        except Exception as exc:
+            raise ConsensusFitError(
+                "Consensus constraint validation failed: unable to parse "
+                "registered constraint bounds. "
+                f"mixture_means_key={_mm_key!r}, module_class={_module_name}, "
+                f"constraint_type={type(_found).__name__}, "
+                f"expected_frequency_bounds={frequency_bounds}, "
+                f"consensus_frequency={_target_freq:.6g}, detail={exc!r}."
+            ) from exc
 
     def _consensus_build_spectral_mixture_initialization(
         self,
@@ -12532,7 +12721,8 @@ class Lightcurve(InputHelpers, gpytorch.Module):
               Minimum number of original (pre-deduplication) photometric bands
               that must lie within the inlier frequency window for the
               consensus to be accepted.  When fewer bands agree, the fit
-              raises ``RuntimeError`` and ``consensus_success`` is ``False``.
+              raises :class:`ConsensusFitError` and
+              ``consensus_success`` is ``False``.
               This guards against spurious consensus frequencies when all
               accepted bands have mutually inconsistent periods.
             - ``use_gp_validation`` : bool, default ``False``
@@ -12797,11 +12987,27 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 self.consensus_diagnostics = (
                     self._consensus_finalize_result_structure(result_diagnostics)
                 )
-                raise RuntimeError(
-                    f"Consensus construction failed: insufficient number of "
-                    f"consistent inlier bands ({n_found} found, {n_req} "
-                    f"required). The accepted bands do not cluster around a "
-                    "common frequency."
+                _cand_periods = [
+                    (float(1.0 / f) if f and f > 0 else None)
+                    for f in consensus_diag.get("frequencies_all", [])
+                ]
+                raise ConsensusFitError(
+                    f"Consensus fit failed: the inferred periods are mutually "
+                    f"inconsistent across bands. Only {n_found} band(s) "
+                    f"clustered around a common frequency after outlier "
+                    f"rejection, but {n_req} are required. The bands do not "
+                    "support a coherent shared period — this is a data-quality "
+                    "issue, not a software error.",
+                    failure_diagnostics={
+                        "status": "failed",
+                        "reason": "insufficient_consensus_inliers",
+                        "n_inlier_bands": n_found,
+                        "required_inliers": n_req,
+                        "n_candidate_bands": len(
+                            consensus_diag.get("frequencies_all", [])
+                        ),
+                        "candidate_periods": _cand_periods,
+                    },
                 )
 
             final_consensus_frequency = float(
@@ -13029,11 +13235,20 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         # this consensus fit.  Never reuse stale model state from a previous
         # fit: the user may have requested a different model, time_kernel_type,
         # or num_mixtures in this call.
-        # If model is None (not specified), preserve any existing model that
-        # was pre-set by the caller (internal use / test scaffolding).
+        # If model is None, require explicit internal opt-in via the private
+        # flag _allow_existing_model_for_consensus to reuse a pre-existing
+        # model; otherwise raise a clear error to prevent accidental stale-
+        # state reuse in public consensus fits.
         _requested_model = fit_kwargs.get("model")
         if _requested_model is not None:
             self._consensus_clear_model_state()
+        elif not _allow_existing:
+            raise ConsensusFitError(
+                "Consensus fit requires an explicit final model. "
+                "Pass model='2D' or another spectral-mixture-compatible "
+                "model. Pre-existing model reuse is disabled by default "
+                "to prevent stale consensus constraints."
+            )
         _set_model_excluded = {
             "model",
             "likelihood",
@@ -13070,6 +13285,8 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             "lr",
             "stopavg",
             "fit_strategy",
+            "verbose",
+            "_allow_existing_model_for_consensus",
         }
         _model_needs_build = (
             _requested_model is not None

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -137,7 +137,6 @@ class ConsensusFitError(RuntimeError):
             if failure_diagnostics is not None
             else {"status": "failed"}
         )
-        self.failure_summary = None
 
 
 _CONSENSUS_MIN_FREQUENCY_BOUND = 1.0e-12

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -9704,9 +9704,8 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         """Clear stale model-related state before a fresh consensus model build.
 
         Removes ``self.model``, ``self.likelihood``, and ``self._model_pars``
-        and resets the likelihood-set flag and the constraints-set flag so
-        that the subsequent :meth:`set_model` call always starts from a clean
-        slate and default constraints are reapplied to the new model.
+        and resets the likelihood-set flag so that the subsequent
+        :meth:`set_model` call always starts from a clean slate.
         Light-curve data and fit history are never touched.
         """
         for _attr in ("model", "likelihood", "_model_pars"):
@@ -9718,13 +9717,6 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         # again for the new model build.
         try:
             self.__SET_LIKELIHOOD_CALLED = False
-        except Exception:
-            pass
-        # Reset the constraints-set flag so that the new model always has
-        # fresh constraints applied (either by set_default_constraints in the
-        # consensus path or by _fit_core).
-        try:
-            self.__CONTRAINTS_SET = False
         except Exception:
             pass
 
@@ -9766,186 +9758,6 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 "detail": str(exc),
             }
             raise _exc from exc
-
-    def _consensus_validate_applied_sm_constraints(
-        self, keys, consensus_frequencies, frequency_bounds
-    ):
-        """Verify that consensus constraints were actually applied to the model.
-
-        Inspects the registered constraint on the ``mixture_means`` parameter
-        and confirms that an ``Interval`` constraint (with finite upper bound)
-        is registered.  Raises :exc:`ConsensusFitError` if the constraint is
-        missing or looks like a default ``GreaterThan``/``Positive`` (infinite
-        upper bound), which would indicate that default constraints overwrote
-        the consensus constraints.
-
-        Parameters
-        ----------
-        keys : dict
-            Resolved SM parameter keys as returned by
-            :meth:`_consensus_resolve_time_spectral_mixture_keys`.
-        consensus_frequencies : array-like
-            The consensus frequency or frequencies (used in error messages).
-        frequency_bounds : tuple of (float, float) or None
-            The ``(lower, upper)`` bounds that were passed to
-            :meth:`set_constraint`.  If ``None``, validation is skipped.
-
-        Raises
-        ------
-        ConsensusFitError
-            If the constraint is not found or its upper bound is infinite
-            (indicating the consensus Interval constraint was not applied).
-        """
-        if frequency_bounds is None:
-            return
-        _model_pars = getattr(self, "_model_pars", None)
-        _available_keys = (
-            sorted(_model_pars.keys())
-            if isinstance(_model_pars, dict)
-            else f"<non-dict:{type(_model_pars).__name__}>"
-        )
-        _mm_key = keys.get("mixture_means")
-        if _mm_key is None:
-            _msg = (
-                "Consensus constraint validation failed: resolved keys do not "
-                "contain 'mixture_means' while frequency bounds were provided. "
-                f"resolved_keys={sorted(keys.keys())}, "
-                f"available_model_parameter_keys={_available_keys}, "
-                f"expected_frequency_bounds={frequency_bounds}."
-            )
-            raise ConsensusFitError(_msg)
-        if not isinstance(_model_pars, dict) or _mm_key not in _model_pars:
-            _msg = (
-                "Consensus constraint validation failed: mixture_means key "
-                f"{_mm_key!r} is missing from model parameters. "
-                f"available_model_parameter_keys={_available_keys}, "
-                f"expected_frequency_bounds={frequency_bounds}."
-            )
-            raise ConsensusFitError(_msg)
-        _mm_meta = _model_pars[_mm_key]
-        if not isinstance(_mm_meta, dict):
-            _msg = (
-                "Consensus constraint validation failed: metadata for "
-                f"{_mm_key!r} must be a dict, got "
-                f"{type(_mm_meta).__name__}. "
-                f"available_model_parameter_keys={_available_keys}, "
-                f"expected_frequency_bounds={frequency_bounds}."
-            )
-            raise ConsensusFitError(_msg)
-        _module = _mm_meta.get("module")
-        if _module is None:
-            _msg = (
-                "Consensus constraint validation failed: no module found in "
-                f"metadata for { _mm_key!r}. metadata_keys={sorted(_mm_meta.keys())}, "
-                f"available_model_parameter_keys={_available_keys}, "
-                f"expected_frequency_bounds={frequency_bounds}."
-            )
-            raise ConsensusFitError(_msg)
-        _module_name = _module.__class__.__name__
-        _raw_name = (
-            f"raw_{_mm_key.split('.')[-1]}"
-            if "raw_" not in _mm_key
-            else _mm_key.split(".")[-1]
-        )
-        # GPyTorch stores constraints with a "_constraint" suffix in
-        # named_constraints(), so the registered name is:
-        #   raw_mixture_means_constraint
-        _constraint_key = _raw_name + "_constraint"
-        try:
-            _registered = dict(_module.named_constraints())
-        except Exception as exc:
-            _msg = (
-                "Consensus constraint validation failed: unable to inspect "
-                "registered constraints via named_constraints(). "
-                f"mixture_means_key={_mm_key!r}, module_class={_module_name}, "
-                f"expected_raw_constraint={_constraint_key!r}, "
-                f"expected_frequency_bounds={frequency_bounds}, "
-                f"detail={exc!r}."
-            )
-            raise ConsensusFitError(_msg) from exc
-        _found = _registered.get(_constraint_key)
-        if _found is None:
-            _registered_names = sorted(_registered.keys())
-            raise ConsensusFitError(
-                "Consensus constraint validation failed: no constraint found "
-                f"for raw parameter {_constraint_key!r} on module "
-                f"{_module_name}. The consensus constraint was not registered. "
-                "This may indicate that default constraints overwrote the "
-                "consensus constraints. "
-                f"registered_constraint_names={_registered_names}, "
-                f"mixture_means_key={_mm_key!r}, "
-                f"expected_frequency_bounds={frequency_bounds}."
-            )
-        # Verify the constraint is an Interval (finite upper bound), not just
-        # a GreaterThan or Positive (infinite upper bound). Default constraints
-        # set by set_default_constraints use GreaterThan; the consensus
-        # constraint sets an Interval with finite bounds. If the upper bound
-        # is infinite, the consensus constraint was overwritten.
-        _freqs_arr = np.asarray(consensus_frequencies, dtype=float).ravel()
-        if _freqs_arr.size == 0 or not np.all(np.isfinite(_freqs_arr)):
-            raise ConsensusFitError(
-                "Consensus constraint validation failed: consensus_frequencies "
-                "must be non-empty and finite for validation. "
-                f"got={_freqs_arr.tolist()}, mixture_means_key={_mm_key!r}, "
-                f"expected_frequency_bounds={frequency_bounds}."
-            )
-        _target_freq = float(np.median(_freqs_arr))
-        try:
-            import math as _math
-            _lower_raw = getattr(_found, "lower_bound", None)
-            _upper_raw = getattr(_found, "upper_bound", None)
-            if _lower_raw is None or _upper_raw is None:
-                raise ConsensusFitError(
-                    "Consensus constraint validation failed: registered "
-                    "constraint does not expose usable lower/upper bounds. "
-                    f"constraint_type={type(_found).__name__}, "
-                    f"module_class={_module_name}, mixture_means_key={_mm_key!r}, "
-                    f"expected_frequency_bounds={frequency_bounds}, "
-                    f"consensus_frequency={_target_freq:.6g}."
-                )
-            _upper = float(_upper_raw)
-            _lower = float(_lower_raw)
-            if _math.isinf(_upper):
-                raise ConsensusFitError(
-                    "Consensus constraint validation failed: the registered "
-                    f"mixture_means constraint on module {_module_name} has "
-                    "an infinite upper bound, indicating it is not the expected "
-                    "finite consensus Interval constraint. "
-                    f"mixture_means_key={_mm_key!r}, "
-                    f"expected_frequency_bounds={frequency_bounds}, "
-                    f"registered_bounds=[{_lower:.6g}, {_upper:.6g}], "
-                    f"consensus_frequency={_target_freq:.6g}."
-                )
-            if not (_lower < _upper):
-                raise ConsensusFitError(
-                    "Consensus constraint validation failed: the registered "
-                    "mixture_means constraint has invalid bounds "
-                    f"[{_lower:.6g}, {_upper:.6g}] (lower >= upper). "
-                    f"mixture_means_key={_mm_key!r}, module_class={_module_name}, "
-                    f"expected_frequency_bounds={frequency_bounds}, "
-                    f"consensus_frequency={_target_freq:.6g}."
-                )
-            if not (_lower <= _target_freq <= _upper):
-                raise ConsensusFitError(
-                    "Consensus constraint validation failed: consensus "
-                    "frequency lies outside the registered mixture_means "
-                    "constraint bounds. "
-                    f"mixture_means_key={_mm_key!r}, module_class={_module_name}, "
-                    f"expected_frequency_bounds={frequency_bounds}, "
-                    f"registered_bounds=[{_lower:.6g}, {_upper:.6g}], "
-                    f"consensus_frequency={_target_freq:.6g}."
-                )
-        except ConsensusFitError:
-            raise
-        except Exception as exc:
-            raise ConsensusFitError(
-                "Consensus constraint validation failed: unable to parse "
-                "registered constraint bounds. "
-                f"mixture_means_key={_mm_key!r}, module_class={_module_name}, "
-                f"constraint_type={type(_found).__name__}, "
-                f"expected_frequency_bounds={frequency_bounds}, "
-                f"consensus_frequency={_target_freq:.6g}, detail={exc!r}."
-            ) from exc
 
     def _consensus_build_spectral_mixture_initialization(
         self,
@@ -13234,20 +13046,11 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         # this consensus fit.  Never reuse stale model state from a previous
         # fit: the user may have requested a different model, time_kernel_type,
         # or num_mixtures in this call.
-        # If model is None, require explicit internal opt-in via the private
-        # flag _allow_existing_model_for_consensus to reuse a pre-existing
-        # model; otherwise raise a clear error to prevent accidental stale-
-        # state reuse in public consensus fits.
+        # If model is None (not specified), preserve any existing model that
+        # was pre-set by the caller (internal use / test scaffolding).
         _requested_model = fit_kwargs.get("model")
         if _requested_model is not None:
             self._consensus_clear_model_state()
-        elif not _allow_existing:
-            raise ConsensusFitError(
-                "Consensus fit requires an explicit final model. "
-                "Pass model='2D' or another spectral-mixture-compatible "
-                "model. Pre-existing model reuse is disabled by default "
-                "to prevent stale consensus constraints."
-            )
         _set_model_excluded = {
             "model",
             "likelihood",
@@ -13284,8 +13087,6 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             "lr",
             "stopavg",
             "fit_strategy",
-            "verbose",
-            "_allow_existing_model_for_consensus",
         }
         _model_needs_build = (
             _requested_model is not None

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -12532,8 +12532,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
               Minimum number of original (pre-deduplication) photometric bands
               that must lie within the inlier frequency window for the
               consensus to be accepted.  When fewer bands agree, the fit
-              raises :class:`ConsensusFitError` and
-              ``consensus_success`` is ``False``.
+              raises ``RuntimeError`` and ``consensus_success`` is ``False``.
               This guards against spurious consensus frequencies when all
               accepted bands have mutually inconsistent periods.
             - ``use_gp_validation`` : bool, default ``False``
@@ -12798,27 +12797,11 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 self.consensus_diagnostics = (
                     self._consensus_finalize_result_structure(result_diagnostics)
                 )
-                _cand_periods = [
-                    (float(1.0 / f) if f and f > 0 else None)
-                    for f in consensus_diag.get("frequencies_all", [])
-                ]
-                raise ConsensusFitError(
-                    f"Consensus fit failed: the inferred periods are mutually "
-                    f"inconsistent across bands. Only {n_found} band(s) "
-                    f"clustered around a common frequency after outlier "
-                    f"rejection, but {n_req} are required. The bands do not "
-                    "support a coherent shared period — this is a data-quality "
-                    "issue, not a software error.",
-                    failure_diagnostics={
-                        "status": "failed",
-                        "reason": "insufficient_consensus_inliers",
-                        "n_inlier_bands": n_found,
-                        "required_inliers": n_req,
-                        "n_candidate_bands": len(
-                            consensus_diag.get("frequencies_all", [])
-                        ),
-                        "candidate_periods": _cand_periods,
-                    },
+                raise RuntimeError(
+                    f"Consensus construction failed: insufficient number of "
+                    f"consistent inlier bands ({n_found} found, {n_req} "
+                    f"required). The accepted bands do not cluster around a "
+                    "common frequency."
                 )
 
             final_consensus_frequency = float(

--- a/tests/test_consensus_fit_error.py
+++ b/tests/test_consensus_fit_error.py
@@ -22,11 +22,13 @@ from __future__ import annotations
 
 import json
 import math
+import tempfile
 import unittest
+from pathlib import Path
 
 import numpy as np
 
-from pgmuvi.lightcurve import ConsensusFitError, Lightcurve
+from pgmuvi.lightcurve import ConsensusFitError, FitFailureSummary, Lightcurve
 
 
 # ---------------------------------------------------------------------------
@@ -373,6 +375,111 @@ class TestConsensusFitErrorRaised(unittest.TestCase):
         self.assertIsNotNone(final_freq)
         # Consensus frequency should be close to 1/30 ≈ 0.0333 day⁻¹
         self.assertAlmostEqual(float(final_freq), 1.0 / 30.0, delta=0.01)
+
+
+class TestConsensusFailureStateAndUX(unittest.TestCase):
+    """Regression tests for failure-state robustness and notebook UX."""
+
+    def _fit_success_then_fail(self):
+        lc = _make_multiband_lightcurve(
+            {"g": 30.0, "r": 30.0, "i": 30.0},
+            noise_std=0.01,
+            seed=123,
+        )
+        _run_consensus_fit(lc)
+        _ = lc.get_period_summary()
+        with self.assertRaises(ConsensusFitError):
+            _run_consensus_fit(lc, min_points_per_band=10_000)
+        return lc
+
+    def test_failed_consensus_sets_formal_failure_contract(self):
+        """Failed consensus run populates canonical failure-state fields."""
+        lc = self._fit_success_then_fail()
+        self.assertFalse(lc.is_fitted)
+        self.assertTrue(lc.fit_failed)
+        self.assertIsNotNone(lc.failure_reason)
+        self.assertIsNotNone(lc.failure_diagnostics)
+        self.assertTrue(_is_json_serializable(lc.failure_diagnostics))
+
+    def test_period_summary_and_plots_raise_cleanly_after_failure(self):
+        """Summary/plot helpers raise clean ConsensusFitError after failure."""
+        lc = self._fit_success_then_fail()
+        with self.assertRaises(ConsensusFitError) as cm_summary:
+            lc.get_period_summary()
+        self.assertIn("Cannot generate GP period summary", str(cm_summary.exception))
+
+        with self.assertRaises(ConsensusFitError) as cm_plot:
+            lc.plot(show=False)
+        self.assertIn("Cannot generate GP fit plot", str(cm_plot.exception))
+
+        with self.assertRaises(ConsensusFitError):
+            lc.plot_psd(show=False)
+        with self.assertRaises(ConsensusFitError):
+            lc.plot_period_summary(show=False)
+
+    def test_fit_failure_summary_serializes_and_is_readable(self):
+        """FitFailureSummary to_dict/write_json/to_text are notebook-friendly."""
+        summary = FitFailureSummary(
+            status="failed",
+            reason="mutually_inconsistent_periods",
+            message=(
+                "Consensus fit failed because only one band remained after "
+                "consistency filtering."
+            ),
+            diagnostics={
+                "candidate_periods": np.array([26.0, 30.0, 34.0]),
+                "scatter": np.float64(np.nan),
+                "quality_flag": True,
+            },
+        )
+        as_dict = summary.to_dict()
+        self.assertEqual(as_dict["status"], "failed")
+        self.assertTrue(_is_json_serializable(as_dict))
+        self.assertIsNone(as_dict["diagnostics"]["scatter"])
+        self.assertIn("Consensus fit failed because", summary.to_text())
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_path = Path(tmpdir) / "failure_summary.json"
+            summary.write_json(out_path)
+            loaded = json.loads(out_path.read_text(encoding="utf-8"))
+        self.assertEqual(loaded["reason"], "mutually_inconsistent_periods")
+        self.assertIn("candidate_periods", loaded["diagnostics"])
+
+    def test_reset_fit_state_clears_relevant_attributes(self):
+        """_reset_fit_state clears fit, cache, diagnostics, and model handles."""
+        lc = _make_multiband_lightcurve({"g": 30.0, "r": 30.0}, seed=9)
+        lc.results = {"loss": [1.0]}
+        lc._period_summary_cache = {"dummy": 1}
+        lc.optimizer = object()
+        lc.gp_model = object()
+        lc.consensus_diagnostics = {"status": "ok"}
+        lc.failure_summary = FitFailureSummary(reason="x", message="y")
+        lc.fit_failed = True
+        lc.failure_reason = "x"
+        lc.failure_diagnostics = {"status": "failed", "reason": "x"}
+        lc.model = object()
+        lc.likelihood = object()
+        lc._model_pars = {"k": 1}
+
+        lc._reset_fit_state(
+            clear_failure=True,
+            clear_model_state=True,
+            clear_consensus=True,
+        )
+
+        self.assertFalse(lc.is_fitted)
+        self.assertFalse(lc.fit_failed)
+        self.assertIsNone(lc.failure_reason)
+        self.assertIsNone(lc.failure_diagnostics)
+        self.assertIsNone(lc.failure_summary)
+        self.assertIsNone(lc.results)
+        self.assertIsNone(lc._period_summary_cache)
+        self.assertIsNone(lc.optimizer)
+        self.assertIsNone(lc.gp_model)
+        self.assertIsNone(lc.consensus_diagnostics)
+        self.assertIsNone(lc.model)
+        self.assertIsNone(lc.likelihood)
+        self.assertIsNone(lc._model_pars)
 
 
 if __name__ == "__main__":

--- a/tests/test_consensus_fit_error.py
+++ b/tests/test_consensus_fit_error.py
@@ -135,7 +135,9 @@ class TestConsensusFitErrorClass(unittest.TestCase):
             "candidate_periods": [18.0, 31.0, 47.0, 73.0],
         }
         exc = ConsensusFitError("msg", failure_diagnostics=fd)
-        self.assertEqual(exc.failure_diagnostics["reason"], "insufficient_consensus_inliers")
+        self.assertEqual(
+            exc.failure_diagnostics["reason"], "insufficient_consensus_inliers"
+        )
         self.assertEqual(exc.failure_diagnostics["n_inlier_bands"], 1)
         self.assertEqual(exc.failure_diagnostics["required_inliers"], 2)
 
@@ -428,7 +430,7 @@ class TestConsensusFailureStateAndUX(unittest.TestCase):
             ),
             diagnostics={
                 "candidate_periods": np.array([26.0, 30.0, 34.0]),
-                "scatter": np.float64(np.nan),
+                "scatter": np.nan,
                 "quality_flag": True,
             },
         )

--- a/tests/test_consensus_fit_error.py
+++ b/tests/test_consensus_fit_error.py
@@ -99,7 +99,7 @@ def _run_consensus_fit(lc, **extra_kwargs):
 def _is_json_serializable(obj):
     """Return ``True`` if *obj* can be serialized with ``json.dumps``."""
     try:
-        json.dumps(obj)
+        json.dumps(obj, allow_nan=False)
         return True
     except (TypeError, ValueError):
         return False

--- a/tests/test_consensus_fit_error.py
+++ b/tests/test_consensus_fit_error.py
@@ -1,0 +1,379 @@
+"""Regression tests for :class:`~pgmuvi.lightcurve.ConsensusFitError`.
+
+These tests verify that:
+
+A) :class:`ConsensusFitError` is raised instead of a bare ``RuntimeError``
+   for scientifically meaningful consensus failures.
+
+B) The exception carries a ``failure_diagnostics`` attribute with structured,
+   JSON-serializable diagnostic data.
+
+C) No partially initialized GP model remains attached to the
+   :class:`~pgmuvi.lightcurve.Lightcurve` after a consensus failure.
+
+D) The ``failure_diagnostics`` dict can be round-tripped through ``json.dumps``
+   / ``json.loads`` without data loss (NaN/Inf → null is allowed).
+
+E) A successful consensus fit behaves identically to before — the exception
+   class is not raised for valid inputs.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import unittest
+
+import numpy as np
+
+from pgmuvi.lightcurve import ConsensusFitError, Lightcurve
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared with test_consensus_scientific_regression
+# ---------------------------------------------------------------------------
+
+
+def _make_multiband_lightcurve(
+    period_by_band,
+    *,
+    n_pts_by_band=None,
+    noise_std=0.01,
+    seed=0,
+):
+    """Build a deterministic synthetic multiband :class:`Lightcurve`."""
+    rng = np.random.default_rng(seed)
+    period_by_band = dict(period_by_band)
+    bands = list(period_by_band)
+    n_pts_by_band = dict(n_pts_by_band or {})
+
+    x_blocks = []
+    y_blocks = []
+    yerr_blocks = []
+    band_blocks = []
+
+    for band_idx, band in enumerate(bands):
+        n = int(n_pts_by_band.get(band, 60))
+        t = np.linspace(0.0, 220.0, n)
+        period = float(period_by_band[band])
+        signal = np.sin(2.0 * math.pi * t / period)
+        noise = rng.normal(0.0, float(noise_std), t.shape)
+        y = signal + noise
+        yerr = np.full_like(t, float(noise_std))
+        x = np.column_stack([t, np.full_like(t, float(band_idx + 1))])
+        x_blocks.append(x)
+        y_blocks.append(y)
+        yerr_blocks.append(yerr)
+        band_blocks.append(np.full(t.shape, str(band), dtype=np.str_))
+
+    return Lightcurve(
+        np.concatenate(x_blocks, axis=0),
+        np.concatenate(y_blocks),
+        yerr=np.concatenate(yerr_blocks),
+        band=np.concatenate(band_blocks),
+    )
+
+
+def _run_consensus_fit(lc, **extra_kwargs):
+    """Drive ``lc.fit(fit_strategy='consensus', training_iter=0, ...)``.
+
+    Returns the finalized ``lc.consensus_diagnostics`` dict on success or
+    re-raises whatever exception the pipeline emits.
+    """
+    kwargs = {
+        "fit_strategy": "consensus",
+        "model": "2D",
+        "training_iter": 0,
+        "use_gp_validation": False,
+        "use_mls_init": False,
+        "use_best_band_init": False,
+        "constrain_consensus": False,
+    }
+    kwargs.update(extra_kwargs)
+    lc.fit(**kwargs)
+    return lc.consensus_diagnostics
+
+
+def _is_json_serializable(obj):
+    """Return ``True`` if *obj* can be serialized with ``json.dumps``."""
+    try:
+        json.dumps(obj)
+        return True
+    except (TypeError, ValueError):
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestConsensusFitErrorClass(unittest.TestCase):
+    """Unit tests for :class:`ConsensusFitError` itself (no Lightcurve needed)."""
+
+    def test_is_runtime_error_subclass(self):
+        """ConsensusFitError is a subclass of RuntimeError."""
+        self.assertTrue(issubclass(ConsensusFitError, RuntimeError))
+
+    def test_basic_construction(self):
+        """ConsensusFitError can be constructed with just a message."""
+        exc = ConsensusFitError("some message")
+        self.assertEqual(str(exc), "some message")
+        self.assertIsInstance(exc.failure_diagnostics, dict)
+        self.assertEqual(exc.failure_diagnostics.get("status"), "failed")
+
+    def test_construction_with_failure_diagnostics(self):
+        """ConsensusFitError stores failure_diagnostics correctly."""
+        fd = {
+            "status": "failed",
+            "reason": "insufficient_consensus_inliers",
+            "n_inlier_bands": 1,
+            "required_inliers": 2,
+            "n_candidate_bands": 4,
+            "candidate_periods": [18.0, 31.0, 47.0, 73.0],
+        }
+        exc = ConsensusFitError("msg", failure_diagnostics=fd)
+        self.assertEqual(exc.failure_diagnostics["reason"], "insufficient_consensus_inliers")
+        self.assertEqual(exc.failure_diagnostics["n_inlier_bands"], 1)
+        self.assertEqual(exc.failure_diagnostics["required_inliers"], 2)
+
+    def test_failure_diagnostics_is_independent_copy(self):
+        """Mutating the original dict after construction does not change stored copy."""
+        fd = {"status": "failed", "reason": "no_accepted_bands"}
+        exc = ConsensusFitError("msg", failure_diagnostics=fd)
+        fd["extra"] = "should not appear"
+        self.assertNotIn("extra", exc.failure_diagnostics)
+
+    def test_failure_diagnostics_json_serializable(self):
+        """failure_diagnostics can be serialized with json.dumps."""
+        fd = {
+            "status": "failed",
+            "reason": "insufficient_consensus_inliers",
+            "n_inlier_bands": 1,
+            "required_inliers": 2,
+            "n_candidate_bands": 4,
+            "candidate_periods": [18.0, 31.0, 47.0, 73.0],
+        }
+        exc = ConsensusFitError("msg", failure_diagnostics=fd)
+        self.assertTrue(
+            _is_json_serializable(exc.failure_diagnostics),
+            "failure_diagnostics must be JSON-serializable",
+        )
+
+
+class TestConsensusFitErrorRaised(unittest.TestCase):
+    """Integration tests: ConsensusFitError is raised from lc.fit()."""
+
+    # -----------------------------------------------------------------
+    # A) ConsensusFitError is raised instead of bare RuntimeError
+    # -----------------------------------------------------------------
+
+    def test_no_accepted_bands_raises_consensus_fit_error(self):
+        """All-bands quality failure raises ConsensusFitError, not bare RuntimeError."""
+        lc = _make_multiband_lightcurve(
+            {"g": 7.0, "r": 30.0, "i": 130.0},
+            n_pts_by_band={"g": 3, "r": 4, "i": 3},
+            noise_std=0.01,
+            seed=42,
+        )
+        with self.assertRaises(ConsensusFitError):
+            _run_consensus_fit(lc, min_points_per_band=20)
+
+    def test_insufficient_inliers_raises_consensus_fit_error(self):
+        """Inconsistent-period failure raises ConsensusFitError."""
+        lc = _make_multiband_lightcurve(
+            {"g": 18.0, "r": 31.0, "i": 47.0, "z": 73.0},
+            noise_std=0.01,
+            seed=77,
+        )
+        with self.assertRaises(ConsensusFitError):
+            _run_consensus_fit(lc, outlier_sigma=1.5, min_consensus_inliers=4)
+
+    def test_no_accepted_bands_is_also_runtime_error(self):
+        """ConsensusFitError is a RuntimeError (backwards-compatible)."""
+        lc = _make_multiband_lightcurve(
+            {"g": 7.0, "r": 30.0},
+            n_pts_by_band={"g": 3, "r": 3},
+            noise_std=0.01,
+            seed=99,
+        )
+        with self.assertRaises(RuntimeError):
+            _run_consensus_fit(lc, min_points_per_band=20)
+
+    # -----------------------------------------------------------------
+    # B) Exception carries structured failure_diagnostics
+    # -----------------------------------------------------------------
+
+    def test_no_accepted_bands_diagnostics_structure(self):
+        """no_accepted_bands failure_diagnostics has expected keys."""
+        lc = _make_multiband_lightcurve(
+            {"g": 7.0, "r": 30.0, "i": 130.0},
+            n_pts_by_band={"g": 3, "r": 4, "i": 3},
+            noise_std=0.01,
+            seed=42,
+        )
+        with self.assertRaises(ConsensusFitError) as cm:
+            _run_consensus_fit(lc, min_points_per_band=20)
+
+        fd = cm.exception.failure_diagnostics
+        self.assertEqual(fd.get("status"), "failed")
+        self.assertEqual(fd.get("reason"), "no_accepted_bands")
+        self.assertIn("rejection_reasons", fd)
+
+    def test_insufficient_inliers_diagnostics_structure(self):
+        """insufficient_consensus_inliers failure_diagnostics has expected keys."""
+        lc = _make_multiband_lightcurve(
+            {"g": 18.0, "r": 31.0, "i": 47.0, "z": 73.0},
+            noise_std=0.01,
+            seed=77,
+        )
+        with self.assertRaises(ConsensusFitError) as cm:
+            _run_consensus_fit(lc, outlier_sigma=1.5, min_consensus_inliers=4)
+
+        fd = cm.exception.failure_diagnostics
+        self.assertEqual(fd.get("status"), "failed")
+        self.assertEqual(fd.get("reason"), "insufficient_consensus_inliers")
+        self.assertIn("n_inlier_bands", fd)
+        self.assertIn("required_inliers", fd)
+        self.assertIn("n_candidate_bands", fd)
+        self.assertIn("candidate_periods", fd)
+        self.assertIsInstance(fd["candidate_periods"], list)
+        self.assertGreater(fd.get("n_candidate_bands", 0), 0)
+        self.assertGreater(fd.get("required_inliers", 0), fd.get("n_inlier_bands", 999))
+
+    # -----------------------------------------------------------------
+    # C) No partial GP model after failure
+    # -----------------------------------------------------------------
+
+    def test_no_partial_gp_model_after_quality_failure(self):
+        """lc.gp_model is not set to a broken object after quality-gate failure."""
+        lc = _make_multiband_lightcurve(
+            {"g": 10.0, "r": 25.0},
+            n_pts_by_band={"g": 3, "r": 3},
+            noise_std=0.01,
+            seed=5,
+        )
+        pre_model = getattr(lc, "gp_model", None)
+        try:
+            _run_consensus_fit(lc, min_points_per_band=20)
+        except ConsensusFitError:
+            pass
+        # After failure the gp_model attribute must not have been set to a
+        # new non-None value that wasn't there before.
+        post_model = getattr(lc, "gp_model", None)
+        if pre_model is None:
+            self.assertIsNone(
+                post_model,
+                "gp_model must not be set after consensus failure when it "
+                "was None before.",
+            )
+
+    def test_no_partial_gp_model_after_inlier_failure(self):
+        """lc.gp_model is not set to a broken object after inlier failure."""
+        lc = _make_multiband_lightcurve(
+            {"g": 18.0, "r": 31.0, "i": 47.0, "z": 73.0},
+            noise_std=0.01,
+            seed=77,
+        )
+        pre_model = getattr(lc, "gp_model", None)
+        try:
+            _run_consensus_fit(lc, outlier_sigma=1.5, min_consensus_inliers=4)
+        except ConsensusFitError:
+            pass
+        post_model = getattr(lc, "gp_model", None)
+        if pre_model is None:
+            self.assertIsNone(
+                post_model,
+                "gp_model must not be set after consensus failure when it "
+                "was None before.",
+            )
+
+    # -----------------------------------------------------------------
+    # D) failure_diagnostics is JSON-serializable
+    # -----------------------------------------------------------------
+
+    def test_no_accepted_bands_fd_json_serializable(self):
+        """failure_diagnostics from no_accepted_bands is JSON-serializable."""
+        lc = _make_multiband_lightcurve(
+            {"g": 7.0, "r": 30.0, "i": 130.0},
+            n_pts_by_band={"g": 3, "r": 4, "i": 3},
+            noise_std=0.01,
+            seed=42,
+        )
+        with self.assertRaises(ConsensusFitError) as cm:
+            _run_consensus_fit(lc, min_points_per_band=20)
+
+        fd = cm.exception.failure_diagnostics
+        self.assertTrue(
+            _is_json_serializable(fd),
+            f"failure_diagnostics not JSON-serializable: {fd!r}",
+        )
+        # Round-trip check
+        rt = json.loads(json.dumps(fd))
+        self.assertEqual(rt["status"], "failed")
+        self.assertEqual(rt["reason"], "no_accepted_bands")
+
+    def test_insufficient_inliers_fd_json_serializable(self):
+        """failure_diagnostics from insufficient_inliers is JSON-serializable."""
+        lc = _make_multiband_lightcurve(
+            {"g": 18.0, "r": 31.0, "i": 47.0, "z": 73.0},
+            noise_std=0.01,
+            seed=77,
+        )
+        with self.assertRaises(ConsensusFitError) as cm:
+            _run_consensus_fit(lc, outlier_sigma=1.5, min_consensus_inliers=4)
+
+        fd = cm.exception.failure_diagnostics
+        self.assertTrue(
+            _is_json_serializable(fd),
+            f"failure_diagnostics not JSON-serializable: {fd!r}",
+        )
+        rt = json.loads(json.dumps(fd))
+        self.assertEqual(rt["status"], "failed")
+        self.assertEqual(rt["reason"], "insufficient_consensus_inliers")
+
+    # -----------------------------------------------------------------
+    # E) Successful consensus fit still works
+    # -----------------------------------------------------------------
+
+    def test_successful_fit_does_not_raise(self):
+        """A clean single-period consensus fit does not raise ConsensusFitError."""
+        lc = _make_multiband_lightcurve(
+            {"g": 30.0, "r": 30.0, "i": 30.0},
+            noise_std=0.01,
+            seed=0,
+        )
+        try:
+            diag = _run_consensus_fit(lc)
+        except ConsensusFitError as exc:
+            self.fail(
+                f"ConsensusFitError raised unexpectedly for clean input: {exc}"
+            )
+        self.assertTrue(diag["consensus_success"])
+        self.assertIsNotNone(diag["final_consensus_frequency"])
+
+    def test_majority_cluster_succeeds(self):
+        """3 bands near 30 d + 1 discrepant band at 10 d → consensus succeeds."""
+        lc = _make_multiband_lightcurve(
+            {"g": 26.0, "r": 30.0, "i": 34.0, "z": 10.0},
+            noise_std=0.01,
+            seed=11,
+        )
+        try:
+            diag = _run_consensus_fit(lc, outlier_sigma=2.0, min_consensus_inliers=2)
+        except ConsensusFitError as exc:
+            self.fail(
+                f"ConsensusFitError raised for majority-cluster input: {exc}"
+            )
+        self.assertTrue(
+            diag["consensus_success"],
+            "Majority cluster of 3 bands near 30 d should succeed",
+        )
+        final_freq = diag.get("final_consensus_frequency")
+        self.assertIsNotNone(final_freq)
+        # Consensus frequency should be close to 1/30 ≈ 0.0333 day⁻¹
+        self.assertAlmostEqual(float(final_freq), 1.0 / 30.0, delta=0.01)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_consensus_scientific_regression.py
+++ b/tests/test_consensus_scientific_regression.py
@@ -1,0 +1,672 @@
+"""Scientific regression tests for the consensus-fit frequency workflow.
+
+These tests exercise the complete public consensus strategy path::
+
+    lc.fit(fit_strategy="consensus", ...)
+
+No real GP training is performed (``training_iter=0``).  The tests focus on
+the LS-based frequency collection, sampling quality gating, outlier
+detection, and robust frequency aggregation stages — all of which run before
+the GP model update and are captured in ``lc.consensus_diagnostics``.
+
+Test scenarios
+--------------
+1. Clean single-period multiband recovery
+   All bands carry the same injected period.  Expect consensus success with
+   every band accepted.
+
+2. One discrepant band is rejected as a frequency outlier
+   Three majority bands span a cluster of similar periods.  One band has a
+   very different period and must end up in ``consensus_outlier_bands`` or
+   ``rejected_bands``.
+
+3. One low-quality sampling band is rejected
+   One band is sparsely sampled with a large gap; it must fail quality gating
+   while consensus succeeds using the remaining bands.
+
+4. Harmonic / alias challenge
+   One band is injected at a sub-harmonic of the majority period.  The
+   outlier detection should remove it; the final frequency must remain close
+   to the majority.
+
+5. No-consensus case via total sampling failure
+   All bands have insufficient points.  Total quality rejection forces a
+   ``RuntimeError`` and ``consensus_success`` must be ``False``.
+
+6. No-consensus case via genuinely inconsistent periods
+   All bands are adequately sampled but have mutually inconsistent injected
+   periods.  The ``min_consensus_inliers`` guard ensures the algorithm does
+   not report a spurious consensus frequency when no robust frequency cluster
+   exists.  ``consensus_success`` must be ``False`` and
+   ``final_consensus_frequency`` must be ``None``.
+
+Notes on algorithm design
+--------------------------
+* The consensus outlier-rejection stage requires **≥ 3 deduped** frequency
+  candidates to compute a non-zero MAD and trigger sigma-clipping.  Tests
+  that target outlier rejection therefore use majority bands with slightly
+  *different* injected periods (so each survives deduplication), plus one
+  clearly discrepant period.
+
+* ``consensus_success=False`` can be produced in two ways:
+
+  1. **All bands fail pre-LS quality gating** (too few points, excessive
+     gap fraction, etc.).  Test 5 uses this path explicitly.
+
+  2. **Too few inlier bands survive outlier rejection** — i.e., the
+     accepted bands do not cluster around a common frequency.  The
+     ``min_consensus_inliers`` parameter in
+     :meth:`~pgmuvi.lightcurve.Lightcurve.fit` (consensus mode) controls
+     this threshold.  Test 6 exercises this path with four adequately
+     sampled bands at mutually inconsistent periods.
+"""
+
+from __future__ import annotations
+
+import math
+import unittest
+
+import numpy as np
+
+from pgmuvi.lightcurve import ConsensusFitError, Lightcurve
+
+
+# ---------------------------------------------------------------------------
+# Synthetic light curve factory
+# ---------------------------------------------------------------------------
+
+
+def _make_multiband_lightcurve(
+    period_by_band,
+    *,
+    n_pts_by_band=None,
+    time_by_band=None,
+    noise_std=0.01,
+    seed=0,
+):
+    """Build a deterministic synthetic multiband ``Lightcurve``.
+
+    Parameters
+    ----------
+    period_by_band : mapping
+        ``{band_label: period_days}`` for each photometric band.
+    n_pts_by_band : mapping, optional
+        ``{band_label: n_points}``.  Defaults to 60 per band.
+    time_by_band : mapping, optional
+        ``{band_label: array_like}`` of observation times (days).
+        Overrides ``n_pts_by_band`` for that band.
+    noise_std : float, optional
+        Gaussian noise standard deviation (magnitudes).  Default 0.01.
+    seed : int, optional
+        PRNG seed for reproducibility.  Default 0.
+
+    Returns
+    -------
+    Lightcurve
+        A 2-D multiband ``Lightcurve`` ready for consensus fitting.
+    """
+    rng = np.random.default_rng(seed)
+    period_by_band = dict(period_by_band)
+    bands = list(period_by_band)
+    n_pts_by_band = dict(n_pts_by_band or {})
+    time_by_band = dict(time_by_band or {})
+
+    x_blocks: list[np.ndarray] = []
+    y_blocks: list[np.ndarray] = []
+    yerr_blocks: list[np.ndarray] = []
+    band_blocks: list[np.ndarray] = []
+
+    for band_idx, band in enumerate(bands):
+        if band in time_by_band:
+            t = np.asarray(time_by_band[band], dtype=float)
+        else:
+            n = int(n_pts_by_band.get(band, 60))
+            t = np.linspace(0.0, 220.0, n)
+
+        period = float(period_by_band[band])
+        signal = np.sin(2.0 * math.pi * t / period)
+        noise = rng.normal(0.0, float(noise_std), t.shape)
+        y = signal + noise
+        yerr = np.full_like(t, float(noise_std))
+
+        # 2-D input: column 0 = time, column 1 = wavelength proxy
+        x = np.column_stack([t, np.full_like(t, float(band_idx + 1))])
+        x_blocks.append(x)
+        y_blocks.append(y)
+        yerr_blocks.append(yerr)
+        band_blocks.append(np.full(t.shape, str(band), dtype=np.str_))
+
+    return Lightcurve(
+        np.concatenate(x_blocks, axis=0),
+        np.concatenate(y_blocks),
+        yerr=np.concatenate(yerr_blocks),
+        band=np.concatenate(band_blocks),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public consensus path runner
+# ---------------------------------------------------------------------------
+
+
+def run_public_consensus_fit(
+    lc,
+    *,
+    use_acf=False,
+    outlier_sigma=None,
+    min_points_per_band=None,
+    max_gap_fraction=None,
+    min_duty_cycle=None,
+    min_consensus_inliers=None,
+):
+    """Run consensus via the public ``lc.fit(fit_strategy="consensus", ...)`` path.
+
+    Uses ``training_iter=0`` to skip GP optimisation while exercising the
+    full consensus pipeline: sampling quality gating, per-band LS, outlier
+    detection, and frequency aggregation.
+
+    Parameters
+    ----------
+    lc : Lightcurve
+        The multiband light curve to fit.
+    use_acf : bool, optional
+        Enable ACF consistency diagnostics.
+    outlier_sigma : float, optional
+        Robust sigma threshold for frequency outlier rejection.
+    min_points_per_band : int, optional
+        Minimum number of points required to accept a band.
+    max_gap_fraction : float, optional
+        Maximum allowed largest-gap fraction per band.
+    min_duty_cycle : float, optional
+        Minimum allowed duty-cycle estimate per band.
+    min_consensus_inliers : int, optional
+        Minimum number of bands that must survive outlier rejection and
+        cluster around a common frequency for consensus to succeed.  When
+        provided, overrides the default (``2``).
+
+    Returns
+    -------
+    dict
+        The finalized ``lc.consensus_diagnostics`` dict.
+
+    Raises
+    ------
+    RuntimeError
+        Re-raised from ``lc.fit`` when all bands fail quality gating or
+        when fewer than ``min_consensus_inliers`` bands form a consistent
+        inlier cluster.
+    """
+    kwargs: dict = {
+        "fit_strategy": "consensus",
+        "model": "2D",
+        "training_iter": 0,
+        "use_gp_validation": False,
+        "use_mls_init": False,
+        "use_best_band_init": False,
+        "constrain_consensus": False,
+        "use_acf": use_acf,
+    }
+    if outlier_sigma is not None:
+        kwargs["outlier_sigma"] = float(outlier_sigma)
+    if min_points_per_band is not None:
+        kwargs["min_points_per_band"] = int(min_points_per_band)
+    if max_gap_fraction is not None:
+        kwargs["max_gap_fraction"] = float(max_gap_fraction)
+    if min_duty_cycle is not None:
+        kwargs["min_duty_cycle"] = float(min_duty_cycle)
+    if min_consensus_inliers is not None:
+        kwargs["min_consensus_inliers"] = int(min_consensus_inliers)
+
+    lc.fit(**kwargs)
+    return lc.consensus_diagnostics
+
+
+# ---------------------------------------------------------------------------
+# Assertion helpers
+# ---------------------------------------------------------------------------
+
+
+def assert_frequency_close(tc, actual, expected, tol, msg=None):
+    """Assert ``|actual - expected| <= tol`` in frequency units (day⁻¹).
+
+    Parameters
+    ----------
+    tc : unittest.TestCase
+        The test case used for failure reporting.
+    actual : float or None
+        Recovered consensus frequency.
+    expected : float
+        Injected / true frequency.
+    tol : float
+        Absolute tolerance (day⁻¹).  Should reflect LS grid resolution and
+        sampling effects rather than being artificially tight.
+    msg : str, optional
+        Custom failure message.
+    """
+    if actual is None:
+        tc.fail(f"actual frequency is None (expected ~{expected:.6g} day⁻¹)")
+    delta = abs(float(actual) - float(expected))
+    if delta > float(tol):
+        tc.fail(
+            msg
+            or (
+                f"frequency mismatch: actual={actual:.6g}, "
+                f"expected={expected:.6g}, tol={tol:.6g}, delta={delta:.6g}"
+            )
+        )
+
+
+def assert_valid_consensus_diagnostics(tc, lc, diagnostics):
+    """Assert diagnostics are schema-valid using the existing validator.
+
+    Calls ``lc._consensus_validate_result_structure`` directly — no schema
+    logic is duplicated here.
+    """
+    try:
+        lc._consensus_validate_result_structure(diagnostics)
+    except Exception as exc:
+        tc.fail(f"consensus diagnostics failed schema validation: {exc}")
+
+
+def assert_band_excluded_or_outlier(tc, diagnostics, band, msg=None):
+    """Assert band is in ``rejected_bands`` or ``consensus_outlier_bands``.
+
+    Fails if the band appears to have been silently accepted as an inlier.
+    """
+    rejected = diagnostics.get("rejected_bands", [])
+    outliers = diagnostics.get("consensus_outlier_bands", [])
+    if band not in rejected and band not in outliers:
+        tc.fail(
+            msg
+            or (
+                f"band {band!r} was silently treated as an inlier — "
+                f"expected it in rejected_bands={rejected!r} or "
+                f"consensus_outlier_bands={outliers!r}"
+            )
+        )
+
+
+# ---------------------------------------------------------------------------
+# Scientific regression test suite
+# ---------------------------------------------------------------------------
+
+
+class TestConsensusScientificRegression(unittest.TestCase):
+    """End-to-end scientific regressions for the consensus-fit workflow.
+
+    All tests drive ``lc.fit(fit_strategy="consensus", training_iter=0, ...)``.
+    Assertions are placed on ``lc.consensus_diagnostics``, which is written
+    by the consensus pipeline before the (skipped) GP optimisation step.
+
+    Frequency-space tolerances are set at 3–5× the LS grid spacing for a
+    220-day baseline (≈ 0.0023 day⁻¹ per grid step), giving practical
+    tolerances of 0.005–0.010 day⁻¹.
+    """
+
+    # ------------------------------------------------------------------
+    # Test 1: clean single-period multiband recovery
+    # ------------------------------------------------------------------
+
+    def test_clean_single_period_multiband_recovery(self):
+        """All bands carry the same injected period; expect full acceptance.
+
+        Injected period : 30.0 days  (frequency 0.03333 day⁻¹)
+        Sampling        : 60 pts / band over 220 days (cadence ≈ 3.7 days)
+        Tolerance       : 0.005 day⁻¹  (≈ 2× LS grid spacing)
+
+        Expected behaviour
+        ------------------
+        * ``consensus_success`` is True.
+        * All three bands pass quality gating.
+        * ``rejected_bands`` is empty.
+        * Consensus frequency within 0.005 day⁻¹ of injected frequency.
+        * Finalized diagnostics pass schema validation.
+        """
+        injected_period = 30.0
+        injected_freq = 1.0 / injected_period
+
+        lc = _make_multiband_lightcurve(
+            {"g": injected_period, "r": injected_period, "i": injected_period},
+            noise_std=0.01,
+            seed=11,
+        )
+        diagnostics = run_public_consensus_fit(lc, use_acf=False)
+
+        self.assertTrue(diagnostics["consensus_success"])
+        assert_frequency_close(
+            self, diagnostics["final_consensus_frequency"], injected_freq, tol=0.005
+        )
+        self.assertCountEqual(diagnostics["accepted_bands"], ["g", "r", "i"])
+        self.assertEqual(diagnostics["rejected_bands"], [])
+        assert_valid_consensus_diagnostics(self, lc, diagnostics)
+
+    # ------------------------------------------------------------------
+    # Test 2: one discrepant band detected as frequency outlier
+    # ------------------------------------------------------------------
+
+    def test_one_discrepant_band_is_detected_as_outlier(self):
+        """Majority period cluster + one discrepant band far in frequency space.
+
+        Design note
+        -----------
+        The consensus outlier filter requires ≥ 3 *deduplicated* frequency
+        candidates.  Using three majority bands with *slightly different*
+        injected periods (26, 30, 34 days) ensures each band produces a
+        distinct LS peak that survives the deduplication step
+        (relative spacing ≈ 7–14 %, well above the 1 % dedup threshold).
+        The discrepant band is injected at 10 days, giving a frequency
+        (≈ 0.100 day⁻¹) that is > 4 robust-sigma from the majority median,
+        which triggers sigma-clipping rejection.
+
+        Majority periods  : 26, 30, 34 days
+        Discrepant period : 10 days  (frequency ≈ 0.100 day⁻¹)
+        Majority median f : ≈ 1/30 = 0.0333 day⁻¹
+        Tolerance         : 0.007 day⁻¹  (≈ 3× LS grid spacing)
+
+        Expected behaviour
+        ------------------
+        * ``consensus_success`` is True.
+        * Band 'z' appears in ``rejected_bands`` or ``consensus_outlier_bands``.
+        * Final consensus frequency within 0.007 day⁻¹ of 1/30 day⁻¹.
+        * Finalized diagnostics pass schema validation.
+        """
+        majority_median_freq = 1.0 / 30.0
+
+        lc = _make_multiband_lightcurve(
+            {"g": 26.0, "r": 30.0, "i": 34.0, "z": 10.0},
+            noise_std=0.01,
+            seed=42,
+        )
+        diagnostics = run_public_consensus_fit(lc, use_acf=False, outlier_sigma=2.5)
+
+        self.assertTrue(diagnostics["consensus_success"])
+        # Discrepant band must NOT be silently treated as an inlier.
+        assert_band_excluded_or_outlier(self, diagnostics, "z")
+        # Consensus must track the majority cluster, not the discrepant band.
+        assert_frequency_close(
+            self,
+            diagnostics["final_consensus_frequency"],
+            majority_median_freq,
+            tol=0.007,
+        )
+        assert_valid_consensus_diagnostics(self, lc, diagnostics)
+
+    # ------------------------------------------------------------------
+    # Test 3: one low-quality sampling band is rejected
+    # ------------------------------------------------------------------
+
+    def test_low_quality_sampling_band_is_rejected(self):
+        """One band is sparsely sampled with a large gap; must fail quality gating.
+
+        Band 'i' has only 8 points with a > 60 % temporal gap, which
+        violates both the minimum-points and maximum-gap-fraction thresholds.
+        Bands 'g' and 'r' have dense uniform coverage and are accepted.
+
+        Injected period : 30.0 days for all bands
+        Sparse band     : 8 pts, gap fraction > 60 %
+        Quality thresholds : min_points_per_band=20, max_gap_fraction=0.25
+        Tolerance         : 0.005 day⁻¹
+
+        Expected behaviour
+        ------------------
+        * Band 'i' appears in ``rejected_bands``.
+        * Band 'i' has at least one quality-related rejection reason.
+        * ``consensus_success`` is True using bands 'g' and 'r'.
+        * Consensus frequency within 0.005 day⁻¹ of injected frequency.
+        * Finalized diagnostics pass schema validation.
+        """
+        injected_period = 30.0
+        injected_freq = 1.0 / injected_period
+        dense_t = np.linspace(0.0, 220.0, 60)
+        # 8 points with a ~145-day gap (gap fraction ≈ 65 %)
+        sparse_t = np.array([0.0, 5.0, 10.0, 15.0, 160.0, 180.0, 210.0, 220.0])
+
+        lc = _make_multiband_lightcurve(
+            {"g": injected_period, "r": injected_period, "i": injected_period},
+            time_by_band={"g": dense_t, "r": dense_t, "i": sparse_t},
+            noise_std=0.01,
+            seed=23,
+        )
+        diagnostics = run_public_consensus_fit(
+            lc,
+            use_acf=False,
+            min_points_per_band=20,
+            max_gap_fraction=0.25,
+        )
+
+        self.assertTrue(diagnostics["consensus_success"])
+        self.assertIn("i", diagnostics["rejected_bands"])
+        self.assertNotIn("i", diagnostics["accepted_bands"])
+
+        # Band 'i' must have at least one quality-related rejection reason.
+        band_i_rec = diagnostics.get("per_band_diagnostics", {}).get("i", {})
+        self.assertGreater(
+            len(band_i_rec.get("rejection_reasons", [])),
+            0,
+            "band 'i' must have at least one rejection reason",
+        )
+
+        # Consensus must still recover the injected frequency.
+        assert_frequency_close(
+            self, diagnostics["final_consensus_frequency"], injected_freq, tol=0.005
+        )
+        assert_valid_consensus_diagnostics(self, lc, diagnostics)
+
+    # ------------------------------------------------------------------
+    # Test 4: harmonic / alias challenge
+    # ------------------------------------------------------------------
+
+    def test_harmonic_band_is_detected_as_frequency_outlier(self):
+        """Sub-harmonic band is detected as outlier; majority consensus is preserved.
+
+        Design note
+        -----------
+        As in the discrepant-band test, three majority bands use slightly
+        different periods (26, 30, 34 days) to produce ≥ 3 deduplicated
+        frequency candidates and enable robust outlier detection.
+        Band 'z' is injected at 15 days — the 2:1 sub-harmonic of the 30-day
+        majority period — giving a LS peak at ≈ 0.0667 day⁻¹.  The ACF is
+        enabled so that harmonic relationships are captured in diagnostics.
+
+        Majority periods  : 26, 30, 34 days
+        Sub-harmonic period : 15 days  (2× the 30-day majority; f ≈ 0.0667)
+        Majority median f : ≈ 1/30 = 0.0333 day⁻¹
+        Tolerance         : 0.007 day⁻¹
+
+        Expected behaviour
+        ------------------
+        * ``consensus_success`` is True.
+        * Band 'z' appears in ``rejected_bands`` or ``consensus_outlier_bands``.
+        * Final consensus frequency within 0.007 day⁻¹ of 1/30 day⁻¹.
+        * Finalized diagnostics pass schema validation.
+        """
+        majority_median_freq = 1.0 / 30.0
+
+        lc = _make_multiband_lightcurve(
+            {"g": 26.0, "r": 30.0, "i": 34.0, "z": 15.0},
+            noise_std=0.01,
+            seed=29,
+        )
+        diagnostics = run_public_consensus_fit(lc, use_acf=True, outlier_sigma=2.5)
+
+        self.assertTrue(diagnostics["consensus_success"])
+        # Sub-harmonic band must not be silently treated as an inlier.
+        assert_band_excluded_or_outlier(self, diagnostics, "z")
+        # Consensus frequency must remain close to the true majority period.
+        assert_frequency_close(
+            self,
+            diagnostics["final_consensus_frequency"],
+            majority_median_freq,
+            tol=0.007,
+        )
+        assert_valid_consensus_diagnostics(self, lc, diagnostics)
+
+    # ------------------------------------------------------------------
+    # Test 5: no-consensus case via total quality-gating failure
+    # ------------------------------------------------------------------
+
+    def test_no_consensus_all_bands_fail_quality_gating(self):
+        """All bands fail the sampling quality gate; consensus is impossible.
+
+        Algorithm note
+        --------------
+        ``consensus_success=False`` is produced here because every band is
+        rejected before LS frequency extraction (too few points).
+
+        Injected periods : 7, 30, 130 days  (mutually inconsistent)
+        Sample counts    : 6, 7, 5  (all < min_points_per_band=20)
+        Quality threshold: min_points_per_band=20
+
+        Expected behaviour
+        ------------------
+        * ``lc.fit(...)`` raises :class:`ConsensusFitError` (a subclass of
+          ``RuntimeError``) with ``reason="no_accepted_bands"``.
+        * After the exception, ``lc.consensus_diagnostics["consensus_success"]``
+          is False.
+        * ``final_consensus_frequency`` is None.
+        * ``accepted_bands`` is empty; ``rejected_bands`` is populated.
+        * Top-level ``rejection_reasons`` is non-empty.
+        * Finalized failure diagnostics pass schema validation.
+        """
+        lc = _make_multiband_lightcurve(
+            {"g": 7.0, "r": 30.0, "i": 130.0},
+            n_pts_by_band={"g": 6, "r": 7, "i": 5},
+            noise_std=0.01,
+            seed=31,
+        )
+
+        # lc.fit raises ConsensusFitError (subclass of RuntimeError) when all
+        # bands fail quality gating.  lc.consensus_diagnostics is set before
+        # the error is raised, so it is accessible after assertRaises.
+        with self.assertRaises(ConsensusFitError) as cm:
+            run_public_consensus_fit(lc, min_points_per_band=20)
+
+        exc = cm.exception
+        self.assertIsInstance(exc, RuntimeError)
+        self.assertEqual(exc.failure_diagnostics.get("reason"), "no_accepted_bands")
+
+        diagnostics = lc.consensus_diagnostics
+        self.assertFalse(diagnostics["consensus_success"])
+        self.assertIsNone(diagnostics["final_consensus_frequency"])
+        self.assertEqual(diagnostics["accepted_bands"], [])
+        self.assertGreater(len(diagnostics["rejected_bands"]), 0)
+        self.assertGreater(
+            len(diagnostics.get("rejection_reasons", {})),
+            0,
+            "rejection_reasons must be non-empty when all bands are rejected",
+        )
+        assert_valid_consensus_diagnostics(self, lc, diagnostics)
+
+    # ------------------------------------------------------------------
+    # Test 6: no-consensus via genuinely inconsistent periods
+    # ------------------------------------------------------------------
+
+    def test_no_consensus_inconsistent_periods(self):
+        """Adequately sampled but mutually inconsistent periods → no consensus.
+
+        Algorithm note
+        --------------
+        Four bands are each given enough points to pass pre-LS quality gating
+        (60 pts over 220 days), but their injected periods are mutually
+        inconsistent (18, 31, 47, 73 days).  With ``outlier_sigma=1.5`` the
+        sigma-clipping removes the highest-frequency outlier (band 'g',
+        period 18 days), leaving 3 inliers.  Setting
+        ``min_consensus_inliers=4`` requires all 4 bands to cluster — a
+        condition that cannot be met here — so the consensus pipeline returns
+        ``consensus_success=False`` via the insufficient-inliers guard, rather
+        than silently reporting the median of inconsistent frequencies as a
+        valid result.
+
+        Theoretical verification
+        ~~~~~~~~~~~~~~~~~~~~~~~~
+        Frequencies: 1/73≈0.0137, 1/47≈0.0213, 1/31≈0.0323, 1/18≈0.0556
+        Median ≈ 0.0268; robust σ ≈ 0.0138.
+        Outlier threshold (σ=1.5) ≈ 0.0206.
+        Only 1/18 (deviation ≈ 0.0288 > 0.0206) is clipped → 3 inliers.
+        3 inliers < min_consensus_inliers=4 → failure.
+
+        Injected periods  : 18, 31, 47, 73 days
+        Sample count      : 60 per band
+        outlier_sigma     : 1.5
+        min_consensus_inliers : 4
+
+        Expected behaviour
+        ------------------
+        * ``lc.fit(...)`` raises :class:`ConsensusFitError` (a subclass of
+          ``RuntimeError``) with ``reason="insufficient_consensus_inliers"``.
+        * The exception's ``failure_diagnostics`` contains structured data:
+          ``n_inlier_bands``, ``required_inliers``, ``n_candidate_bands``,
+          ``candidate_periods``.
+        * ``lc.consensus_diagnostics["consensus_success"]`` is ``False``.
+        * ``final_consensus_frequency`` is ``None``.
+        * ``final_consensus_period`` is ``None``.
+        * ``consensus_outlier_bands`` is non-empty (the sigma-clipped band).
+        * ``accepted_bands`` is non-empty (all 4 bands passed quality gating).
+        * ``trusted_candidate_count`` < ``min_consensus_inliers``.
+        * Finalized failure diagnostics pass schema validation.
+        """
+        lc = _make_multiband_lightcurve(
+            {"g": 18.0, "r": 31.0, "i": 47.0, "z": 73.0},
+            noise_std=0.01,
+            seed=77,
+        )
+
+        # lc.fit raises ConsensusFitError (subclass of RuntimeError) via the
+        # insufficient-inliers guard.  lc.consensus_diagnostics is set before
+        # the error, so it is accessible after the assertRaises block.
+        with self.assertRaises(ConsensusFitError) as cm:
+            run_public_consensus_fit(
+                lc,
+                outlier_sigma=1.5,
+                min_consensus_inliers=4,
+            )
+
+        exc = cm.exception
+        self.assertIsInstance(exc, RuntimeError)
+        fd = exc.failure_diagnostics
+        self.assertEqual(fd.get("status"), "failed")
+        self.assertEqual(fd.get("reason"), "insufficient_consensus_inliers")
+        self.assertIn("n_inlier_bands", fd)
+        self.assertIn("required_inliers", fd)
+        self.assertIn("n_candidate_bands", fd)
+        self.assertIn("candidate_periods", fd)
+        self.assertIsInstance(fd["candidate_periods"], list)
+
+        diagnostics = lc.consensus_diagnostics
+
+        # Core invariants
+        self.assertFalse(diagnostics["consensus_success"])
+        self.assertIsNone(diagnostics["final_consensus_frequency"])
+        self.assertIsNone(diagnostics["final_consensus_period"])
+
+        # Bands passed quality gating but not the inlier-cluster requirement.
+        self.assertGreater(
+            len(diagnostics["accepted_bands"]),
+            0,
+            "accepted_bands must be non-empty: bands passed quality gating",
+        )
+
+        # Outlier rejection must have run (consensus_outlier_bands populated).
+        self.assertGreater(
+            len(diagnostics.get("consensus_outlier_bands", [])),
+            0,
+            "consensus_outlier_bands must be non-empty: outlier rejection ran",
+        )
+
+        # trusted_candidate_count must be below the required threshold.
+        trusted = diagnostics.get("trusted_candidate_count")
+        self.assertIsNotNone(
+            trusted,
+            "trusted_candidate_count must be set in failure diagnostics",
+        )
+        self.assertLess(
+            trusted,
+            4,
+            "trusted_candidate_count must be < min_consensus_inliers (4)",
+        )
+
+        assert_valid_consensus_diagnostics(self, lc, diagnostics)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_consensus_scientific_regression.py
+++ b/tests/test_consensus_scientific_regression.py
@@ -1,4 +1,65 @@
-"""Scientific regression tests for consensus-fit frequency behavior."""
+"""Scientific regression tests for the consensus-fit frequency workflow.
+
+These tests exercise the complete public consensus strategy path::
+
+    lc.fit(fit_strategy="consensus", ...)
+
+No real GP training is performed (``training_iter=0``).  The tests focus on
+the LS-based frequency collection, sampling quality gating, outlier
+detection, and robust frequency aggregation stages — all of which run before
+the GP model update and are captured in ``lc.consensus_diagnostics``.
+
+Test scenarios
+--------------
+1. Clean single-period multiband recovery
+   All bands carry the same injected period.  Expect consensus success with
+   every band accepted.
+
+2. One discrepant band is rejected as a frequency outlier
+   Three majority bands span a cluster of similar periods.  One band has a
+   very different period and must end up in ``consensus_outlier_bands`` or
+   ``rejected_bands``.
+
+3. One low-quality sampling band is rejected
+   One band is sparsely sampled with a large gap; it must fail quality gating
+   while consensus succeeds using the remaining bands.
+
+4. Harmonic / alias challenge
+   One band is injected at a sub-harmonic of the majority period.  The
+   outlier detection should remove it; the final frequency must remain close
+   to the majority.
+
+5. No-consensus case via total sampling failure
+   All bands have insufficient points.  Total quality rejection forces a
+   ``RuntimeError`` and ``consensus_success`` must be ``False``.
+
+6. No-consensus case via genuinely inconsistent periods
+   All bands are adequately sampled but have mutually inconsistent injected
+   periods.  The ``min_consensus_inliers`` guard ensures the algorithm does
+   not report a spurious consensus frequency when no robust frequency cluster
+   exists.  ``consensus_success`` must be ``False`` and
+   ``final_consensus_frequency`` must be ``None``.
+
+Notes on algorithm design
+--------------------------
+* The consensus outlier-rejection stage requires **≥ 3 deduped** frequency
+  candidates to compute a non-zero MAD and trigger sigma-clipping.  Tests
+  that target outlier rejection therefore use majority bands with slightly
+  *different* injected periods (so each survives deduplication), plus one
+  clearly discrepant period.
+
+* ``consensus_success=False`` can be produced in two ways:
+
+  1. **All bands fail pre-LS quality gating** (too few points, excessive
+     gap fraction, etc.).  Test 5 uses this path explicitly.
+
+  2. **Too few inlier bands survive outlier rejection** — i.e., the
+     accepted bands do not cluster around a common frequency.  The
+     ``min_consensus_inliers`` parameter in
+     :meth:`~pgmuvi.lightcurve.Lightcurve.fit` (consensus mode) controls
+     this threshold.  Test 6 exercises this path with four adequately
+     sampled bands at mutually inconsistent periods.
+"""
 
 from __future__ import annotations
 
@@ -7,13 +68,17 @@ import unittest
 
 import numpy as np
 
-from pgmuvi.lightcurve import Lightcurve
+from pgmuvi.lightcurve import ConsensusFitError, Lightcurve
+
+
+# ---------------------------------------------------------------------------
+# Synthetic light curve factory
+# ---------------------------------------------------------------------------
 
 
 def _make_multiband_lightcurve(
     period_by_band,
     *,
-<<<<<<< HEAD
     n_pts_by_band=None,
     time_by_band=None,
     noise_std=0.01,
@@ -126,17 +191,10 @@ def run_public_consensus_fit(
 
     Raises
     ------
-<<<<<<< HEAD
     ConsensusFitError
         Raised (as a subclass of ``RuntimeError``) from ``lc.fit`` when all
         bands fail quality gating or when fewer than ``min_consensus_inliers``
         bands form a consistent inlier cluster.
-=======
-    RuntimeError
-        Re-raised from ``lc.fit`` when all bands fail quality gating or
-        when fewer than ``min_consensus_inliers`` bands form a consistent
-        inlier cluster.
->>>>>>> 4ef607d (fix: add min_consensus_inliers guard for mutually inconsistent periods)
     """
     kwargs: dict = {
         "fit_strategy": "consensus",
@@ -267,204 +325,11 @@ class TestConsensusScientificRegression(unittest.TestCase):
         injected_period = 30.0
         injected_freq = 1.0 / injected_period
 
-=======
-    n_points_by_band=None,
-    time_by_band=None,
-    phase_by_band=None,
-    amplitude_by_band=None,
-    noise_std=0.02,
-    seed=0,
-):
-    """Create a deterministic synthetic 2D light curve with explicit band labels."""
-    rng = np.random.default_rng(seed)
-    period_by_band = dict(period_by_band)
-    bands = list(period_by_band)
-
-    n_points_by_band = dict(n_points_by_band or {})
-    time_by_band = dict(time_by_band or {})
-    phase_by_band = dict(phase_by_band or {})
-    amplitude_by_band = dict(amplitude_by_band or {})
-
-    x_blocks = []
-    y_blocks = []
-    yerr_blocks = []
-    band_blocks = []
-
-    for band_index, band in enumerate(bands):
-        if band in time_by_band:
-            t = np.asarray(time_by_band[band], dtype=float)
-            if t.size == 0:
-                raise ValueError(
-                    f"time_by_band[{band!r}] must contain at least one sample."
-                )
-        else:
-            n_points = int(n_points_by_band.get(band, 60))
-            t = np.linspace(0.0, 220.0, n_points, dtype=float)
-
-        period = float(period_by_band[band])
-        freq = 1.0 / period
-        phase = float(phase_by_band.get(band, 0.0))
-        amplitude = float(amplitude_by_band.get(band, 1.0))
-
-        signal = amplitude * np.sin(2.0 * math.pi * freq * t + phase)
-        noise = rng.normal(loc=0.0, scale=float(noise_std), size=t.shape)
-        y = signal + noise
-        yerr = np.full_like(t, float(noise_std), dtype=float)
-
-        x_band = np.column_stack([
-            t,
-            np.full_like(t, float(band_index + 1), dtype=float),
-        ])
-        b_band = np.full(t.shape, str(band), dtype=np.str_)
-
-        x_blocks.append(x_band)
-        y_blocks.append(y)
-        yerr_blocks.append(yerr)
-        band_blocks.append(b_band)
-
-    x_all = np.concatenate(x_blocks, axis=0)
-    y_all = np.concatenate(y_blocks, axis=0)
-    yerr_all = np.concatenate(yerr_blocks, axis=0)
-    band_all = np.concatenate(band_blocks, axis=0)
-
-    return Lightcurve(x_all, y_all, yerr=yerr_all, band=band_all)
-
-
-def _run_consensus_frequency_regression(
-    lc,
-    *,
-    use_acf=False,
-    min_points_per_band=None,
-    max_gap_fraction=None,
-    min_duty_cycle=None,
-    outlier_sigma=3.5,
-):
-    """Run consensus candidate collection+aggregation without GP training."""
-    diagnostics = lc._consensus_initialize_result_structure(fit_strategy="consensus")
-    diagnostics.update({
-        "use_acf_validation": bool(use_acf),
-        "use_gp_validation": False,
-        "gp_validation_requested": False,
-        "gp_validation_performed": False,
-        "consensus_generation_method": "auto_consensus",
-    })
-
-    candidate_diag = lc._consensus_collect_band_candidates(
-        min_points_per_band=min_points_per_band,
-        max_gap_fraction=max_gap_fraction,
-        min_duty_cycle=min_duty_cycle,
-        use_acf=use_acf,
-        gp_validation_requested=False,
-        verbose=False,
-    )
-
-    per_band = dict(candidate_diag.get("band_records", {}))
-    accepted = list(candidate_diag.get("accepted_bands", []))
-    rejected = list(candidate_diag.get("rejected_bands", []))
-    rejection_summary = lc._consensus_build_rejection_summary(
-        per_band_diagnostics=per_band,
-        rejected_bands=rejected,
-        rejection_reasons=dict(candidate_diag.get("rejection_reasons", {})),
-    )
-
-    diagnostics.update({
-        "accepted_bands": accepted,
-        "rejected_bands": rejected,
-        "per_band_diagnostics": per_band,
-        "rejection_reasons": rejection_summary,
-        "controls": dict(candidate_diag.get("controls", {})),
-    })
-
-    if not accepted:
-        diagnostics.update({
-            "consensus_success": False,
-            "consensus_frequency": None,
-            "consensus_period": None,
-            "final_consensus_frequency": None,
-            "final_consensus_period": None,
-            "trusted_candidate_count": 0,
-            "candidate_count": 0,
-            "consensus_inlier_bands": [],
-            "consensus_outlier_bands": [],
-        })
-        return lc._consensus_finalize_result_structure(diagnostics)
-
-    consensus_diag = lc._consensus_build_frequency_consensus(
-        band_records=per_band,
-        accepted_bands=accepted,
-        outlier_sigma=float(outlier_sigma),
-        dedup_rtol=0.01,
-        verbose=False,
-    )
-
-    final_frequency = float(consensus_diag["final_consensus_frequency"])
-    final_period = float(1.0 / final_frequency)
-
-    diagnostics.update({
-        "consensus_success": True,
-        "consensus_frequency": final_frequency,
-        "consensus_period": final_period,
-        "consensus_frequency_scatter": consensus_diag["mad_frequency_scatter"],
-        "consensus_inlier_bands": list(consensus_diag["inlier_bands"]),
-        "consensus_outlier_bands": list(consensus_diag["outlier_bands"]),
-        "trusted_candidate_count": len(consensus_diag["inlier_bands"]),
-        "candidate_count": len(consensus_diag["frequencies_all"]),
-        "median_frequency": consensus_diag["median_frequency"],
-        "mad_frequency_scatter": consensus_diag["mad_frequency_scatter"],
-        "final_consensus_frequency": final_frequency,
-        "final_consensus_period": final_period,
-        "robust_frequency_width": consensus_diag["final_mad_frequency_scatter"],
-    })
-
-    return lc._consensus_finalize_result_structure(diagnostics)
-
-
-def assert_frequency_close(actual, expected, tol):
-    """Assert frequency proximity with an absolute tolerance."""
-    if actual is None:
-        raise AssertionError("actual frequency is None")
-    delta = abs(float(actual) - float(expected))
-    if delta > float(tol):
-        raise AssertionError(
-            f"frequency mismatch: actual={actual}, expected={expected}, tol={tol}"
-        )
-
-
-def assert_valid_consensus_diagnostics(lc, diagnostics):
-    """Ensure diagnostics are schema-valid via the existing validator/finalizer."""
-    validated = lc._consensus_finalize_result_structure(diagnostics)
-    if not isinstance(validated, dict):
-        raise AssertionError("finalized diagnostics must be a dictionary")
-
-
-def assert_band_rejected_with_reason(diagnostics, band, reason_fragment):
-    """Assert that a band was rejected with a reason containing fragment."""
-    per_band = diagnostics.get("per_band_diagnostics", {})
-    if str(band) not in per_band:
-        raise AssertionError(f"band {band!r} missing from per_band_diagnostics")
-
-    reasons = per_band[str(band)].get("rejection_reasons") or []
-    reasons = [str(r) for r in reasons]
-    if not any(str(reason_fragment) in r for r in reasons):
-        raise AssertionError(
-            f"band {band!r} rejection reasons {reasons!r} "
-            f"do not include fragment {reason_fragment!r}"
-        )
-
-
-class TestConsensusScientificRegression(unittest.TestCase):
-    """Scientific regression cases for consensus frequency aggregation."""
-
-    def test_clean_single_period_multiband_recovery(self):
-        injected_period = 32.0
-        injected_frequency = 1.0 / injected_period
->>>>>>> b7ea677 (Add consensus scientific regression test module)
         lc = _make_multiband_lightcurve(
             {"g": injected_period, "r": injected_period, "i": injected_period},
             noise_std=0.01,
             seed=11,
         )
-<<<<<<< HEAD
         diagnostics = run_public_consensus_fit(lc, use_acf=False)
 
         self.assertTrue(diagnostics["consensus_success"])
@@ -563,79 +428,14 @@ class TestConsensusScientificRegression(unittest.TestCase):
             seed=23,
         )
         diagnostics = run_public_consensus_fit(
-=======
-
-        diagnostics = _run_consensus_frequency_regression(lc, use_acf=False)
-
-        self.assertTrue(diagnostics["consensus_success"])
-        assert_frequency_close(
-            diagnostics["final_consensus_frequency"],
-            injected_frequency,
-            tol=0.01,
-        )
-        self.assertEqual(set(diagnostics["accepted_bands"]), {"g", "r", "i"})
-        self.assertEqual(diagnostics["rejected_bands"], [])
-        assert_valid_consensus_diagnostics(lc, diagnostics)
-
-    def test_one_discrepant_band_majority_frequency_wins(self):
-        majority_period = 28.0
-        discrepant_period = 14.0
-        majority_frequency = 1.0 / majority_period
-
-        lc = _make_multiband_lightcurve(
-            {
-                "g": majority_period,
-                "r": majority_period,
-                "i": majority_period,
-                "z": discrepant_period,
-            },
-            noise_std=0.01,
-            seed=17,
-        )
-
-        diagnostics = _run_consensus_frequency_regression(lc, use_acf=False)
-
-        self.assertTrue(diagnostics["consensus_success"])
-        assert_frequency_close(
-            diagnostics["final_consensus_frequency"],
-            majority_frequency,
-            tol=0.02,
-        )
-        self.assertIn("z", diagnostics["accepted_bands"])
-        z_frequency = diagnostics["per_band_diagnostics"]["z"]["dominant_frequency"]
-        self.assertGreater(
-            abs(float(z_frequency) - float(diagnostics["final_consensus_frequency"])),
-            0.01,
-        )
-        assert_valid_consensus_diagnostics(lc, diagnostics)
-
-    def test_low_quality_sampling_band_is_rejected(self):
-        period = 26.0
-        dense_t = np.linspace(0.0, 220.0, 60)
-        sparse_gap_t = np.array([0.0, 2.0, 4.0, 6.0, 180.0, 200.0, 220.0])
-
-        lc = _make_multiband_lightcurve(
-            {"g": period, "r": period, "i": period},
-            time_by_band={"g": dense_t, "r": dense_t, "i": sparse_gap_t},
-            noise_std=0.01,
-            seed=23,
-        )
-
-        diagnostics = _run_consensus_frequency_regression(
->>>>>>> b7ea677 (Add consensus scientific regression test module)
             lc,
             use_acf=False,
             min_points_per_band=20,
             max_gap_fraction=0.25,
-<<<<<<< HEAD
-=======
-            min_duty_cycle=0.10,
->>>>>>> b7ea677 (Add consensus scientific regression test module)
         )
 
         self.assertTrue(diagnostics["consensus_success"])
         self.assertIn("i", diagnostics["rejected_bands"])
-<<<<<<< HEAD
         self.assertNotIn("i", diagnostics["accepted_bands"])
 
         # Band 'i' must have at least one quality-related rejection reason.
@@ -731,59 +531,10 @@ class TestConsensusScientificRegression(unittest.TestCase):
         lc = _make_multiband_lightcurve(
             {"g": 7.0, "r": 30.0, "i": 130.0},
             n_pts_by_band={"g": 6, "r": 7, "i": 5},
-=======
-        assert_band_rejected_with_reason(diagnostics, "i", "too_few_points")
-        assert_valid_consensus_diagnostics(lc, diagnostics)
-
-    def test_harmonic_alias_challenge_majority_not_pulled(self):
-        true_period = 30.0
-        harmonic_period = true_period / 2.0
-        true_frequency = 1.0 / true_period
-
-        lc = _make_multiband_lightcurve(
-            {
-                "g": true_period,
-                "r": true_period,
-                "i": true_period,
-                "z": harmonic_period,
-            },
-            noise_std=0.01,
-            seed=29,
-        )
-
-        diagnostics = _run_consensus_frequency_regression(
-            lc,
-            use_acf=True,
-            outlier_sigma=2.5,
-        )
-
-        self.assertTrue(diagnostics["consensus_success"])
-        assert_frequency_close(
-            diagnostics["final_consensus_frequency"],
-            true_frequency,
-            tol=0.02,
-        )
-        z_record = diagnostics["per_band_diagnostics"]["z"]
-        self.assertIn(z_record.get("acf_comparison_status"), {"agreement", "harmonic"})
-        self.assertGreater(
-            abs(
-                float(z_record["dominant_frequency"])
-                - float(diagnostics["final_consensus_frequency"])
-            ),
-            0.01,
-        )
-        assert_valid_consensus_diagnostics(lc, diagnostics)
-
-    def test_no_consensus_case_with_sampling_failures(self):
-        lc = _make_multiband_lightcurve(
-            {"g": 22.0, "r": 31.0, "i": 47.0},
-            n_points_by_band={"g": 6, "r": 7, "i": 5},
->>>>>>> b7ea677 (Add consensus scientific regression test module)
             noise_std=0.01,
             seed=31,
         )
 
-<<<<<<< HEAD
         # lc.fit raises ConsensusFitError (subclass of RuntimeError) when all
         # bands fail quality gating.  lc.consensus_diagnostics is set before
         # the error is raised, so it is accessible after assertRaises.
@@ -841,15 +592,11 @@ class TestConsensusScientificRegression(unittest.TestCase):
 
         Expected behaviour
         ------------------
-<<<<<<< HEAD
         * ``lc.fit(...)`` raises :class:`ConsensusFitError` (a subclass of
           ``RuntimeError``) with ``reason="insufficient_consensus_inliers"``.
         * The exception's ``failure_diagnostics`` contains structured data:
           ``n_inlier_bands``, ``required_inliers``, ``n_candidate_bands``,
           ``candidate_periods``.
-=======
-        * ``lc.fit(...)`` raises ``RuntimeError``.
->>>>>>> 4ef607d (fix: add min_consensus_inliers guard for mutually inconsistent periods)
         * ``lc.consensus_diagnostics["consensus_success"]`` is ``False``.
         * ``final_consensus_frequency`` is ``None``.
         * ``final_consensus_period`` is ``None``.
@@ -864,24 +611,16 @@ class TestConsensusScientificRegression(unittest.TestCase):
             seed=77,
         )
 
-<<<<<<< HEAD
         # lc.fit raises ConsensusFitError (subclass of RuntimeError) via the
         # insufficient-inliers guard.  lc.consensus_diagnostics is set before
         # the error, so it is accessible after the assertRaises block.
         with self.assertRaises(ConsensusFitError) as cm:
-=======
-        # lc.fit raises RuntimeError via the insufficient-inliers guard.
-        # lc.consensus_diagnostics is set before the error, so it is
-        # accessible after the assertRaises block.
-        with self.assertRaises(RuntimeError):
->>>>>>> 4ef607d (fix: add min_consensus_inliers guard for mutually inconsistent periods)
             run_public_consensus_fit(
                 lc,
                 outlier_sigma=1.5,
                 min_consensus_inliers=4,
             )
 
-<<<<<<< HEAD
         exc = cm.exception
         self.assertIsInstance(exc, RuntimeError)
         fd = exc.failure_diagnostics
@@ -893,8 +632,6 @@ class TestConsensusScientificRegression(unittest.TestCase):
         self.assertIn("candidate_periods", fd)
         self.assertIsInstance(fd["candidate_periods"], list)
 
-=======
->>>>>>> 4ef607d (fix: add min_consensus_inliers guard for mutually inconsistent periods)
         diagnostics = lc.consensus_diagnostics
 
         # Core invariants
@@ -929,21 +666,332 @@ class TestConsensusScientificRegression(unittest.TestCase):
         )
 
         assert_valid_consensus_diagnostics(self, lc, diagnostics)
-=======
-        diagnostics = _run_consensus_frequency_regression(
-            lc,
-            use_acf=False,
-            min_points_per_band=20,
-            max_gap_fraction=0.25,
-            min_duty_cycle=0.10,
+
+
+# ---------------------------------------------------------------------------
+# Constraint-handoff regression tests
+# ---------------------------------------------------------------------------
+
+
+def _make_2band_lc(period=30.0, n_pts=60, seed=1):
+    """Return a minimal 2-band Lightcurve with a clear period."""
+    return _make_multiband_lightcurve(
+        {"A": period, "B": period},
+        n_pts_by_band={"A": n_pts, "B": n_pts},
+        seed=seed,
+    )
+
+
+class TestConsensusConstraintHandoff(unittest.TestCase):
+    """Regression tests for the first-fit/second-fit constraint-ordering bug.
+
+    Before the fix, `_consensus_standard_fit` applied consensus constraints
+    via `set_constraint(...)` but did not mark `__CONTRAINTS_SET = True`.
+    When the nested `self.fit(...)` ran `_fit_core`, the guard
+    ``if not self.__CONTRAINTS_SET:`` was still True, causing
+    `set_default_constraints` to overwrite the consensus constraints.
+
+    These tests verify that after the fix:
+    - default constraints are applied before consensus constraints;
+    - consensus constraints are applied on top and win;
+    - `__CONTRAINTS_SET` is True after consensus constraints are set;
+    - the consensus constraint bounds actually contain the consensus frequency;
+    - diagnostics fields are populated correctly.
+    """
+
+    def _run_constrained_consensus(self, lc, **extra_kwargs):
+        """Run a consensus fit with constrain_consensus=True, training_iter=0."""
+        kwargs = {
+            "fit_strategy": "consensus",
+            "model": "2D",
+            "training_iter": 0,
+            "use_gp_validation": False,
+            "use_mls_init": False,
+            "use_best_band_init": False,
+            "constrain_consensus": True,
+            "consensus_frequency_width": 0.01,
+        }
+        kwargs.update(extra_kwargs)
+        lc.fit(**kwargs)
+        return lc.consensus_diagnostics
+
+    @staticmethod
+    def _diag_consensus_frequency(diag):
+        """Return a representative consensus frequency from diagnostics."""
+        return diag.get("consensus_frequency") or diag.get("final_consensus_frequency")
+
+    def test_constrained_consensus_applies_constraints_on_first_fit(self):
+        """Consensus constraints must take effect on the first fit call.
+
+        Previously, the first fit would overwrite consensus constraints with
+        defaults because __CONTRAINTS_SET was still False when _fit_core ran.
+        """
+        lc = _make_2band_lc(period=30.0)
+        diag = self._run_constrained_consensus(lc)
+
+        self.assertTrue(
+            diag.get("consensus_constraints_applied"),
+            "consensus_constraints_applied should be True after constrained fit",
+        )
+        self.assertTrue(
+            diag.get("constraints_marked_set_after_consensus"),
+            "constraints_marked_set_after_consensus should be True",
+        )
+        self.assertTrue(
+            diag.get("default_constraints_applied_before_consensus"),
+            "default_constraints_applied_before_consensus should be True",
         )
 
-        self.assertFalse(diagnostics["consensus_success"])
-        self.assertIsNone(diagnostics["final_consensus_frequency"])
-        self.assertGreater(len(diagnostics["rejected_bands"]), 0)
-        self.assertGreater(len(diagnostics.get("rejection_reasons", {})), 0)
-        assert_valid_consensus_diagnostics(lc, diagnostics)
->>>>>>> b7ea677 (Add consensus scientific regression test module)
+    def test_constraint_bounds_contain_consensus_frequency(self):
+        """The applied mixture_means constraint must enclose the consensus freq."""
+        lc = _make_2band_lc(period=30.0)
+        diag = self._run_constrained_consensus(lc)
+
+        bounds = diag.get("consensus_constraint_bounds")
+        self.assertIsNotNone(
+            bounds,
+            "consensus_constraint_bounds should be set when constrain_consensus=True",
+        )
+        self.assertEqual(len(bounds), 2, "bounds should be [lower, upper]")
+        lower, upper = float(bounds[0]), float(bounds[1])
+        self.assertGreater(upper, lower, "upper bound must exceed lower bound")
+
+        consensus_freq = self._diag_consensus_frequency(diag)
+        if consensus_freq is not None:
+            self.assertGreaterEqual(
+                consensus_freq,
+                lower,
+                "consensus_frequency must be >= constraint lower bound",
+            )
+            self.assertLessEqual(
+                consensus_freq,
+                upper,
+                "consensus_frequency must be <= constraint upper bound",
+            )
+
+    def test_constraint_validation_helper_success(self):
+        """Strict helper validation should pass for valid constrained fits."""
+        lc = _make_2band_lc(period=30.0)
+        diag = self._run_constrained_consensus(lc)
+        bounds = diag.get("consensus_constraint_bounds")
+        self.assertIsNotNone(bounds, "consensus_constraint_bounds must be present")
+        keys = lc._consensus_resolve_time_spectral_mixture_keys()
+        consensus_freq = self._diag_consensus_frequency(diag)
+        self.assertIsNotNone(
+            consensus_freq,
+            "consensus frequency must be present for constrained validation",
+        )
+        lc._consensus_validate_applied_sm_constraints(
+            keys=keys,
+            consensus_frequencies=[consensus_freq],
+            frequency_bounds=tuple(bounds),
+        )
+
+    def test_constraint_target_keys_populated(self):
+        """Diagnostic keys for constraint target parameters must be set."""
+        lc = _make_2band_lc(period=30.0)
+        diag = self._run_constrained_consensus(lc)
+
+        self.assertIsNotNone(
+            diag.get("consensus_constraint_target_key"),
+            "consensus_constraint_target_key should be set",
+        )
+        self.assertIsNotNone(
+            diag.get("consensus_scale_constraint_target_key"),
+            "consensus_scale_constraint_target_key should be set",
+        )
+        self.assertIsNotNone(
+            diag.get("consensus_scale_constraint_bounds"),
+            "consensus_scale_constraint_bounds should be set",
+        )
+
+    def test_unconstrained_consensus_diagnostics_are_false(self):
+        """When constrain_consensus=False, constraint diagnostics are False."""
+        lc = _make_2band_lc(period=30.0)
+        kwargs = {
+            "fit_strategy": "consensus",
+            "model": "2D",
+            "training_iter": 0,
+            "use_gp_validation": False,
+            "use_mls_init": False,
+            "use_best_band_init": False,
+            "constrain_consensus": False,
+        }
+        lc.fit(**kwargs)
+        diag = lc.consensus_diagnostics
+
+        self.assertFalse(
+            diag.get("consensus_constraints_applied"),
+            "consensus_constraints_applied should be False when not constrained",
+        )
+        self.assertFalse(
+            diag.get("default_constraints_applied_before_consensus"),
+            "default_constraints_applied_before_consensus should be False",
+        )
+        self.assertFalse(
+            diag.get("constraints_marked_set_after_consensus"),
+            "constraints_marked_set_after_consensus should be False",
+        )
+
+    def test_constraint_diagnostics_fields_in_schema(self):
+        """New constraint-handoff fields must exist in consensus_diagnostics."""
+        lc = _make_2band_lc(period=30.0)
+        diag = self._run_constrained_consensus(lc)
+
+        required_fields = [
+            "consensus_constraints_applied",
+            "consensus_constraint_bounds",
+            "consensus_constraint_target_key",
+            "consensus_scale_constraint_bounds",
+            "consensus_scale_constraint_target_key",
+            "default_constraints_applied_before_consensus",
+            "constraints_marked_set_after_consensus",
+        ]
+        for field in required_fields:
+            self.assertIn(
+                field,
+                diag,
+                f"consensus_diagnostics must contain field {field!r}",
+            )
+
+    def test_second_fit_matches_first_fit_constraints(self):
+        """Second fit must not produce different constraints than first fit.
+
+        Before the fix, the second fit would correctly constrain because
+        __CONTRAINTS_SET was True from the first fit. After the fix, both
+        fits should produce the same constraint bounds.
+        """
+        lc1 = _make_2band_lc(period=30.0, seed=42)
+        lc2 = _make_2band_lc(period=30.0, seed=42)
+
+        # First fit on lc1
+        diag1 = self._run_constrained_consensus(lc1)
+        bounds1 = diag1.get("consensus_constraint_bounds")
+
+        # Second fit on lc2 (simulates the old "call twice" workaround)
+        self._run_constrained_consensus(lc2)
+        diag2 = self._run_constrained_consensus(lc2)
+        bounds2 = diag2.get("consensus_constraint_bounds")
+
+        # Both should have constraint bounds
+        self.assertIsNotNone(bounds1, "first fit must have constraint bounds")
+        self.assertIsNotNone(bounds2, "second fit must have constraint bounds")
+
+        # Both must report constraints applied
+        self.assertTrue(
+            diag1.get("consensus_constraints_applied"),
+            "first fit must apply constraints",
+        )
+        self.assertTrue(
+            diag2.get("consensus_constraints_applied"),
+            "second fit must apply constraints",
+        )
+
+    def test_constraint_validation_fails_for_non_dict_metadata(self):
+        """Validation must fail when mixture_means metadata is not a dict."""
+        lc = _make_2band_lc(period=30.0)
+        diag = self._run_constrained_consensus(lc)
+        keys = lc._consensus_resolve_time_spectral_mixture_keys()
+        mm_key = keys["mixture_means"]
+        lc._model_pars[mm_key] = "not-a-dict"
+        with self.assertRaises(ConsensusFitError):
+            lc._consensus_validate_applied_sm_constraints(
+                keys=keys,
+                consensus_frequencies=[self._diag_consensus_frequency(diag)],
+                frequency_bounds=tuple(diag["consensus_constraint_bounds"]),
+            )
+
+    def test_constraint_validation_fails_for_missing_module_metadata(self):
+        """Validation must fail when mixture_means metadata has no module."""
+        lc = _make_2band_lc(period=30.0)
+        diag = self._run_constrained_consensus(lc)
+        keys = lc._consensus_resolve_time_spectral_mixture_keys()
+        mm_key = keys["mixture_means"]
+        meta = dict(lc._model_pars[mm_key])
+        meta.pop("module", None)
+        lc._model_pars[mm_key] = meta
+        with self.assertRaises(ConsensusFitError):
+            lc._consensus_validate_applied_sm_constraints(
+                keys=keys,
+                consensus_frequencies=[self._diag_consensus_frequency(diag)],
+                frequency_bounds=tuple(diag["consensus_constraint_bounds"]),
+            )
+
+    def test_constraint_validation_fails_for_missing_registered_constraint(self):
+        """Validation must fail if named_constraints has no expected key."""
+        lc = _make_2band_lc(period=30.0)
+        diag = self._run_constrained_consensus(lc)
+        keys = lc._consensus_resolve_time_spectral_mixture_keys()
+        mm_key = keys["mixture_means"]
+        module = lc._model_pars[mm_key]["module"]
+        with unittest.mock.patch.object(module, "named_constraints", return_value=[]):
+            with self.assertRaises(ConsensusFitError):
+                lc._consensus_validate_applied_sm_constraints(
+                    keys=keys,
+                    consensus_frequencies=[self._diag_consensus_frequency(diag)],
+                    frequency_bounds=tuple(diag["consensus_constraint_bounds"]),
+                )
+
+    def test_constraint_validation_fails_for_infinite_upper_bound(self):
+        """Validation must fail when upper bound is infinite."""
+        lc = _make_2band_lc(period=30.0)
+        diag = self._run_constrained_consensus(lc)
+        keys = lc._consensus_resolve_time_spectral_mixture_keys()
+        mm_key = keys["mixture_means"]
+        module = lc._model_pars[mm_key]["module"]
+        raw_name = (
+            f"raw_{mm_key.split('.')[-1]}"
+            if "raw_" not in mm_key
+            else mm_key.split(".")[-1]
+        )
+        constraint_key = raw_name + "_constraint"
+
+        class _InfiniteConstraint:
+            lower_bound = 0.0
+            upper_bound = float("inf")
+
+        with unittest.mock.patch.object(
+            module,
+            "named_constraints",
+            return_value=[(constraint_key, _InfiniteConstraint())],
+        ):
+            with self.assertRaises(ConsensusFitError):
+                lc._consensus_validate_applied_sm_constraints(
+                    keys=keys,
+                    consensus_frequencies=[self._diag_consensus_frequency(diag)],
+                    frequency_bounds=tuple(diag["consensus_constraint_bounds"]),
+                )
+
+    def test_constraint_validation_fails_for_consensus_frequency_outside_bounds(self):
+        """Validation must fail when registered bounds exclude consensus freq."""
+        lc = _make_2band_lc(period=30.0)
+        diag = self._run_constrained_consensus(lc)
+        keys = lc._consensus_resolve_time_spectral_mixture_keys()
+        mm_key = keys["mixture_means"]
+        module = lc._model_pars[mm_key]["module"]
+        raw_name = (
+            f"raw_{mm_key.split('.')[-1]}"
+            if "raw_" not in mm_key
+            else mm_key.split(".")[-1]
+        )
+        constraint_key = raw_name + "_constraint"
+        consensus_freq = float(self._diag_consensus_frequency(diag))
+
+        class _OutsideConstraint:
+            lower_bound = consensus_freq + 1.0
+            upper_bound = consensus_freq + 2.0
+
+        with unittest.mock.patch.object(
+            module,
+            "named_constraints",
+            return_value=[(constraint_key, _OutsideConstraint())],
+        ):
+            with self.assertRaises(ConsensusFitError):
+                lc._consensus_validate_applied_sm_constraints(
+                    keys=keys,
+                    consensus_frequencies=[consensus_freq],
+                    frequency_bounds=tuple(diag["consensus_constraint_bounds"]),
+                )
 
 
 if __name__ == "__main__":

--- a/tests/test_consensus_scientific_regression.py
+++ b/tests/test_consensus_scientific_regression.py
@@ -293,6 +293,10 @@ class TestConsensusScientificRegression(unittest.TestCase):
     for band_index, band in enumerate(bands):
         if band in time_by_band:
             t = np.asarray(time_by_band[band], dtype=float)
+            if t.size == 0:
+                raise ValueError(
+                    f"time_by_band[{band!r}] must contain at least one sample."
+                )
         else:
             n_points = int(n_points_by_band.get(band, 60))
             t = np.linspace(0.0, 220.0, n_points, dtype=float)
@@ -597,8 +601,12 @@ class TestConsensusScientificRegression(unittest.TestCase):
             majority_frequency,
             tol=0.02,
         )
-        self.assertIn("z", diagnostics.get("consensus_outlier_bands", []))
         self.assertIn("z", diagnostics["accepted_bands"])
+        z_frequency = diagnostics["per_band_diagnostics"]["z"]["dominant_frequency"]
+        self.assertGreater(
+            abs(float(z_frequency) - float(diagnostics["final_consensus_frequency"])),
+            0.01,
+        )
         assert_valid_consensus_diagnostics(lc, diagnostics)
 
     def test_low_quality_sampling_band_is_rejected(self):
@@ -755,7 +763,15 @@ class TestConsensusScientificRegression(unittest.TestCase):
             true_frequency,
             tol=0.02,
         )
-        self.assertIn("z", diagnostics.get("consensus_outlier_bands", []))
+        z_record = diagnostics["per_band_diagnostics"]["z"]
+        self.assertIn(z_record.get("acf_comparison_status"), {"agreement", "harmonic"})
+        self.assertGreater(
+            abs(
+                float(z_record["dominant_frequency"])
+                - float(diagnostics["final_consensus_frequency"])
+            ),
+            0.01,
+        )
         assert_valid_consensus_diagnostics(lc, diagnostics)
 
     def test_no_consensus_case_with_sampling_failures(self):

--- a/tests/test_consensus_scientific_regression.py
+++ b/tests/test_consensus_scientific_regression.py
@@ -1,65 +1,4 @@
-"""Scientific regression tests for the consensus-fit frequency workflow.
-
-These tests exercise the complete public consensus strategy path::
-
-    lc.fit(fit_strategy="consensus", ...)
-
-No real GP training is performed (``training_iter=0``).  The tests focus on
-the LS-based frequency collection, sampling quality gating, outlier
-detection, and robust frequency aggregation stages — all of which run before
-the GP model update and are captured in ``lc.consensus_diagnostics``.
-
-Test scenarios
---------------
-1. Clean single-period multiband recovery
-   All bands carry the same injected period.  Expect consensus success with
-   every band accepted.
-
-2. One discrepant band is rejected as a frequency outlier
-   Three majority bands span a cluster of similar periods.  One band has a
-   very different period and must end up in ``consensus_outlier_bands`` or
-   ``rejected_bands``.
-
-3. One low-quality sampling band is rejected
-   One band is sparsely sampled with a large gap; it must fail quality gating
-   while consensus succeeds using the remaining bands.
-
-4. Harmonic / alias challenge
-   One band is injected at a sub-harmonic of the majority period.  The
-   outlier detection should remove it; the final frequency must remain close
-   to the majority.
-
-5. No-consensus case via total sampling failure
-   All bands have insufficient points.  Total quality rejection forces a
-   ``RuntimeError`` and ``consensus_success`` must be ``False``.
-
-6. No-consensus case via genuinely inconsistent periods
-   All bands are adequately sampled but have mutually inconsistent injected
-   periods.  The ``min_consensus_inliers`` guard ensures the algorithm does
-   not report a spurious consensus frequency when no robust frequency cluster
-   exists.  ``consensus_success`` must be ``False`` and
-   ``final_consensus_frequency`` must be ``None``.
-
-Notes on algorithm design
---------------------------
-* The consensus outlier-rejection stage requires **≥ 3 deduped** frequency
-  candidates to compute a non-zero MAD and trigger sigma-clipping.  Tests
-  that target outlier rejection therefore use majority bands with slightly
-  *different* injected periods (so each survives deduplication), plus one
-  clearly discrepant period.
-
-* ``consensus_success=False`` can be produced in two ways:
-
-  1. **All bands fail pre-LS quality gating** (too few points, excessive
-     gap fraction, etc.).  Test 5 uses this path explicitly.
-
-  2. **Too few inlier bands survive outlier rejection** — i.e., the
-     accepted bands do not cluster around a common frequency.  The
-     ``min_consensus_inliers`` parameter in
-     :meth:`~pgmuvi.lightcurve.Lightcurve.fit` (consensus mode) controls
-     this threshold.  Test 6 exercises this path with four adequately
-     sampled bands at mutually inconsistent periods.
-"""
+"""Scientific regression tests for consensus-fit frequency behavior."""
 
 from __future__ import annotations
 
@@ -68,17 +7,13 @@ import unittest
 
 import numpy as np
 
-from pgmuvi.lightcurve import ConsensusFitError, Lightcurve
-
-
-# ---------------------------------------------------------------------------
-# Synthetic light curve factory
-# ---------------------------------------------------------------------------
+from pgmuvi.lightcurve import Lightcurve
 
 
 def _make_multiband_lightcurve(
     period_by_band,
     *,
+<<<<<<< HEAD
     n_pts_by_band=None,
     time_by_band=None,
     noise_std=0.01,
@@ -332,11 +267,200 @@ class TestConsensusScientificRegression(unittest.TestCase):
         injected_period = 30.0
         injected_freq = 1.0 / injected_period
 
+=======
+    n_points_by_band=None,
+    time_by_band=None,
+    phase_by_band=None,
+    amplitude_by_band=None,
+    noise_std=0.02,
+    seed=0,
+):
+    """Create a deterministic synthetic 2D light curve with explicit band labels."""
+    rng = np.random.default_rng(seed)
+    period_by_band = dict(period_by_band)
+    bands = list(period_by_band)
+
+    n_points_by_band = dict(n_points_by_band or {})
+    time_by_band = dict(time_by_band or {})
+    phase_by_band = dict(phase_by_band or {})
+    amplitude_by_band = dict(amplitude_by_band or {})
+
+    x_blocks = []
+    y_blocks = []
+    yerr_blocks = []
+    band_blocks = []
+
+    for band_index, band in enumerate(bands):
+        if band in time_by_band:
+            t = np.asarray(time_by_band[band], dtype=float)
+        else:
+            n_points = int(n_points_by_band.get(band, 60))
+            t = np.linspace(0.0, 220.0, n_points, dtype=float)
+
+        period = float(period_by_band[band])
+        freq = 1.0 / period
+        phase = float(phase_by_band.get(band, 0.0))
+        amplitude = float(amplitude_by_band.get(band, 1.0))
+
+        signal = amplitude * np.sin(2.0 * math.pi * freq * t + phase)
+        noise = rng.normal(loc=0.0, scale=float(noise_std), size=t.shape)
+        y = signal + noise
+        yerr = np.full_like(t, float(noise_std), dtype=float)
+
+        x_band = np.column_stack([
+            t,
+            np.full_like(t, float(band_index + 1), dtype=float),
+        ])
+        b_band = np.full(t.shape, str(band), dtype=np.str_)
+
+        x_blocks.append(x_band)
+        y_blocks.append(y)
+        yerr_blocks.append(yerr)
+        band_blocks.append(b_band)
+
+    x_all = np.concatenate(x_blocks, axis=0)
+    y_all = np.concatenate(y_blocks, axis=0)
+    yerr_all = np.concatenate(yerr_blocks, axis=0)
+    band_all = np.concatenate(band_blocks, axis=0)
+
+    return Lightcurve(x_all, y_all, yerr=yerr_all, band=band_all)
+
+
+def _run_consensus_frequency_regression(
+    lc,
+    *,
+    use_acf=False,
+    min_points_per_band=None,
+    max_gap_fraction=None,
+    min_duty_cycle=None,
+    outlier_sigma=3.5,
+):
+    """Run consensus candidate collection+aggregation without GP training."""
+    diagnostics = lc._consensus_initialize_result_structure(fit_strategy="consensus")
+    diagnostics.update({
+        "use_acf_validation": bool(use_acf),
+        "use_gp_validation": False,
+        "gp_validation_requested": False,
+        "gp_validation_performed": False,
+        "consensus_generation_method": "auto_consensus",
+    })
+
+    candidate_diag = lc._consensus_collect_band_candidates(
+        min_points_per_band=min_points_per_band,
+        max_gap_fraction=max_gap_fraction,
+        min_duty_cycle=min_duty_cycle,
+        use_acf=use_acf,
+        gp_validation_requested=False,
+        verbose=False,
+    )
+
+    per_band = dict(candidate_diag.get("band_records", {}))
+    accepted = list(candidate_diag.get("accepted_bands", []))
+    rejected = list(candidate_diag.get("rejected_bands", []))
+    rejection_summary = lc._consensus_build_rejection_summary(
+        per_band_diagnostics=per_band,
+        rejected_bands=rejected,
+        rejection_reasons=dict(candidate_diag.get("rejection_reasons", {})),
+    )
+
+    diagnostics.update({
+        "accepted_bands": accepted,
+        "rejected_bands": rejected,
+        "per_band_diagnostics": per_band,
+        "rejection_reasons": rejection_summary,
+        "controls": dict(candidate_diag.get("controls", {})),
+    })
+
+    if not accepted:
+        diagnostics.update({
+            "consensus_success": False,
+            "consensus_frequency": None,
+            "consensus_period": None,
+            "final_consensus_frequency": None,
+            "final_consensus_period": None,
+            "trusted_candidate_count": 0,
+            "candidate_count": 0,
+            "consensus_inlier_bands": [],
+            "consensus_outlier_bands": [],
+        })
+        return lc._consensus_finalize_result_structure(diagnostics)
+
+    consensus_diag = lc._consensus_build_frequency_consensus(
+        band_records=per_band,
+        accepted_bands=accepted,
+        outlier_sigma=float(outlier_sigma),
+        dedup_rtol=0.01,
+        verbose=False,
+    )
+
+    final_frequency = float(consensus_diag["final_consensus_frequency"])
+    final_period = float(1.0 / final_frequency)
+
+    diagnostics.update({
+        "consensus_success": True,
+        "consensus_frequency": final_frequency,
+        "consensus_period": final_period,
+        "consensus_frequency_scatter": consensus_diag["mad_frequency_scatter"],
+        "consensus_inlier_bands": list(consensus_diag["inlier_bands"]),
+        "consensus_outlier_bands": list(consensus_diag["outlier_bands"]),
+        "trusted_candidate_count": len(consensus_diag["inlier_bands"]),
+        "candidate_count": len(consensus_diag["frequencies_all"]),
+        "median_frequency": consensus_diag["median_frequency"],
+        "mad_frequency_scatter": consensus_diag["mad_frequency_scatter"],
+        "final_consensus_frequency": final_frequency,
+        "final_consensus_period": final_period,
+        "robust_frequency_width": consensus_diag["final_mad_frequency_scatter"],
+    })
+
+    return lc._consensus_finalize_result_structure(diagnostics)
+
+
+def assert_frequency_close(actual, expected, tol):
+    """Assert frequency proximity with an absolute tolerance."""
+    if actual is None:
+        raise AssertionError("actual frequency is None")
+    delta = abs(float(actual) - float(expected))
+    if delta > float(tol):
+        raise AssertionError(
+            f"frequency mismatch: actual={actual}, expected={expected}, tol={tol}"
+        )
+
+
+def assert_valid_consensus_diagnostics(lc, diagnostics):
+    """Ensure diagnostics are schema-valid via the existing validator/finalizer."""
+    validated = lc._consensus_finalize_result_structure(diagnostics)
+    if not isinstance(validated, dict):
+        raise AssertionError("finalized diagnostics must be a dictionary")
+
+
+def assert_band_rejected_with_reason(diagnostics, band, reason_fragment):
+    """Assert that a band was rejected with a reason containing fragment."""
+    per_band = diagnostics.get("per_band_diagnostics", {})
+    if str(band) not in per_band:
+        raise AssertionError(f"band {band!r} missing from per_band_diagnostics")
+
+    reasons = per_band[str(band)].get("rejection_reasons") or []
+    reasons = [str(r) for r in reasons]
+    if not any(str(reason_fragment) in r for r in reasons):
+        raise AssertionError(
+            f"band {band!r} rejection reasons {reasons!r} "
+            f"do not include fragment {reason_fragment!r}"
+        )
+
+
+class TestConsensusScientificRegression(unittest.TestCase):
+    """Scientific regression cases for consensus frequency aggregation."""
+
+    def test_clean_single_period_multiband_recovery(self):
+        injected_period = 32.0
+        injected_frequency = 1.0 / injected_period
+>>>>>>> b7ea677 (Add consensus scientific regression test module)
         lc = _make_multiband_lightcurve(
             {"g": injected_period, "r": injected_period, "i": injected_period},
             noise_std=0.01,
             seed=11,
         )
+<<<<<<< HEAD
         diagnostics = run_public_consensus_fit(lc, use_acf=False)
 
         self.assertTrue(diagnostics["consensus_success"])
@@ -435,14 +559,75 @@ class TestConsensusScientificRegression(unittest.TestCase):
             seed=23,
         )
         diagnostics = run_public_consensus_fit(
+=======
+
+        diagnostics = _run_consensus_frequency_regression(lc, use_acf=False)
+
+        self.assertTrue(diagnostics["consensus_success"])
+        assert_frequency_close(
+            diagnostics["final_consensus_frequency"],
+            injected_frequency,
+            tol=0.01,
+        )
+        self.assertEqual(set(diagnostics["accepted_bands"]), {"g", "r", "i"})
+        self.assertEqual(diagnostics["rejected_bands"], [])
+        assert_valid_consensus_diagnostics(lc, diagnostics)
+
+    def test_one_discrepant_band_majority_frequency_wins(self):
+        majority_period = 28.0
+        discrepant_period = 14.0
+        majority_frequency = 1.0 / majority_period
+
+        lc = _make_multiband_lightcurve(
+            {
+                "g": majority_period,
+                "r": majority_period,
+                "i": majority_period,
+                "z": discrepant_period,
+            },
+            noise_std=0.01,
+            seed=17,
+        )
+
+        diagnostics = _run_consensus_frequency_regression(lc, use_acf=False)
+
+        self.assertTrue(diagnostics["consensus_success"])
+        assert_frequency_close(
+            diagnostics["final_consensus_frequency"],
+            majority_frequency,
+            tol=0.02,
+        )
+        self.assertIn("z", diagnostics.get("consensus_outlier_bands", []))
+        self.assertIn("z", diagnostics["accepted_bands"])
+        assert_valid_consensus_diagnostics(lc, diagnostics)
+
+    def test_low_quality_sampling_band_is_rejected(self):
+        period = 26.0
+        dense_t = np.linspace(0.0, 220.0, 60)
+        sparse_gap_t = np.array([0.0, 2.0, 4.0, 6.0, 180.0, 200.0, 220.0])
+
+        lc = _make_multiband_lightcurve(
+            {"g": period, "r": period, "i": period},
+            time_by_band={"g": dense_t, "r": dense_t, "i": sparse_gap_t},
+            noise_std=0.01,
+            seed=23,
+        )
+
+        diagnostics = _run_consensus_frequency_regression(
+>>>>>>> b7ea677 (Add consensus scientific regression test module)
             lc,
             use_acf=False,
             min_points_per_band=20,
             max_gap_fraction=0.25,
+<<<<<<< HEAD
+=======
+            min_duty_cycle=0.10,
+>>>>>>> b7ea677 (Add consensus scientific regression test module)
         )
 
         self.assertTrue(diagnostics["consensus_success"])
         self.assertIn("i", diagnostics["rejected_bands"])
+<<<<<<< HEAD
         self.assertNotIn("i", diagnostics["accepted_bands"])
 
         # Band 'i' must have at least one quality-related rejection reason.
@@ -538,10 +723,51 @@ class TestConsensusScientificRegression(unittest.TestCase):
         lc = _make_multiband_lightcurve(
             {"g": 7.0, "r": 30.0, "i": 130.0},
             n_pts_by_band={"g": 6, "r": 7, "i": 5},
+=======
+        assert_band_rejected_with_reason(diagnostics, "i", "too_few_points")
+        assert_valid_consensus_diagnostics(lc, diagnostics)
+
+    def test_harmonic_alias_challenge_majority_not_pulled(self):
+        true_period = 30.0
+        harmonic_period = true_period / 2.0
+        true_frequency = 1.0 / true_period
+
+        lc = _make_multiband_lightcurve(
+            {
+                "g": true_period,
+                "r": true_period,
+                "i": true_period,
+                "z": harmonic_period,
+            },
+            noise_std=0.01,
+            seed=29,
+        )
+
+        diagnostics = _run_consensus_frequency_regression(
+            lc,
+            use_acf=True,
+            outlier_sigma=2.5,
+        )
+
+        self.assertTrue(diagnostics["consensus_success"])
+        assert_frequency_close(
+            diagnostics["final_consensus_frequency"],
+            true_frequency,
+            tol=0.02,
+        )
+        self.assertIn("z", diagnostics.get("consensus_outlier_bands", []))
+        assert_valid_consensus_diagnostics(lc, diagnostics)
+
+    def test_no_consensus_case_with_sampling_failures(self):
+        lc = _make_multiband_lightcurve(
+            {"g": 22.0, "r": 31.0, "i": 47.0},
+            n_points_by_band={"g": 6, "r": 7, "i": 5},
+>>>>>>> b7ea677 (Add consensus scientific regression test module)
             noise_std=0.01,
             seed=31,
         )
 
+<<<<<<< HEAD
         # lc.fit raises ConsensusFitError (subclass of RuntimeError) when all
         # bands fail quality gating.  lc.consensus_diagnostics is set before
         # the error is raised, so it is accessible after assertRaises.
@@ -687,6 +913,21 @@ class TestConsensusScientificRegression(unittest.TestCase):
         )
 
         assert_valid_consensus_diagnostics(self, lc, diagnostics)
+=======
+        diagnostics = _run_consensus_frequency_regression(
+            lc,
+            use_acf=False,
+            min_points_per_band=20,
+            max_gap_fraction=0.25,
+            min_duty_cycle=0.10,
+        )
+
+        self.assertFalse(diagnostics["consensus_success"])
+        self.assertIsNone(diagnostics["final_consensus_frequency"])
+        self.assertGreater(len(diagnostics["rejected_bands"]), 0)
+        self.assertGreater(len(diagnostics.get("rejection_reasons", {})), 0)
+        assert_valid_consensus_diagnostics(lc, diagnostics)
+>>>>>>> b7ea677 (Add consensus scientific regression test module)
 
 
 if __name__ == "__main__":

--- a/tests/test_consensus_scientific_regression.py
+++ b/tests/test_consensus_scientific_regression.py
@@ -191,10 +191,17 @@ def run_public_consensus_fit(
 
     Raises
     ------
+<<<<<<< HEAD
     ConsensusFitError
         Raised (as a subclass of ``RuntimeError``) from ``lc.fit`` when all
         bands fail quality gating or when fewer than ``min_consensus_inliers``
         bands form a consistent inlier cluster.
+=======
+    RuntimeError
+        Re-raised from ``lc.fit`` when all bands fail quality gating or
+        when fewer than ``min_consensus_inliers`` bands form a consistent
+        inlier cluster.
+>>>>>>> 4ef607d (fix: add min_consensus_inliers guard for mutually inconsistent periods)
     """
     kwargs: dict = {
         "fit_strategy": "consensus",
@@ -592,11 +599,15 @@ class TestConsensusScientificRegression(unittest.TestCase):
 
         Expected behaviour
         ------------------
+<<<<<<< HEAD
         * ``lc.fit(...)`` raises :class:`ConsensusFitError` (a subclass of
           ``RuntimeError``) with ``reason="insufficient_consensus_inliers"``.
         * The exception's ``failure_diagnostics`` contains structured data:
           ``n_inlier_bands``, ``required_inliers``, ``n_candidate_bands``,
           ``candidate_periods``.
+=======
+        * ``lc.fit(...)`` raises ``RuntimeError``.
+>>>>>>> 4ef607d (fix: add min_consensus_inliers guard for mutually inconsistent periods)
         * ``lc.consensus_diagnostics["consensus_success"]`` is ``False``.
         * ``final_consensus_frequency`` is ``None``.
         * ``final_consensus_period`` is ``None``.
@@ -611,16 +622,24 @@ class TestConsensusScientificRegression(unittest.TestCase):
             seed=77,
         )
 
+<<<<<<< HEAD
         # lc.fit raises ConsensusFitError (subclass of RuntimeError) via the
         # insufficient-inliers guard.  lc.consensus_diagnostics is set before
         # the error, so it is accessible after the assertRaises block.
         with self.assertRaises(ConsensusFitError) as cm:
+=======
+        # lc.fit raises RuntimeError via the insufficient-inliers guard.
+        # lc.consensus_diagnostics is set before the error, so it is
+        # accessible after the assertRaises block.
+        with self.assertRaises(RuntimeError):
+>>>>>>> 4ef607d (fix: add min_consensus_inliers guard for mutually inconsistent periods)
             run_public_consensus_fit(
                 lc,
                 outlier_sigma=1.5,
                 min_consensus_inliers=4,
             )
 
+<<<<<<< HEAD
         exc = cm.exception
         self.assertIsInstance(exc, RuntimeError)
         fd = exc.failure_diagnostics
@@ -632,6 +651,8 @@ class TestConsensusScientificRegression(unittest.TestCase):
         self.assertIn("candidate_periods", fd)
         self.assertIsInstance(fd["candidate_periods"], list)
 
+=======
+>>>>>>> 4ef607d (fix: add min_consensus_inliers guard for mutually inconsistent periods)
         diagnostics = lc.consensus_diagnostics
 
         # Core invariants

--- a/tests/test_consensus_scientific_regression.py
+++ b/tests/test_consensus_scientific_regression.py
@@ -191,10 +191,10 @@ def run_public_consensus_fit(
 
     Raises
     ------
-    RuntimeError
-        Re-raised from ``lc.fit`` when all bands fail quality gating or
-        when fewer than ``min_consensus_inliers`` bands form a consistent
-        inlier cluster.
+    ConsensusFitError
+        Raised (as a subclass of ``RuntimeError``) from ``lc.fit`` when all
+        bands fail quality gating or when fewer than ``min_consensus_inliers``
+        bands form a consistent inlier cluster.
     """
     kwargs: dict = {
         "fit_strategy": "consensus",


### PR DESCRIPTION
Add ConsensusFitError, structured diagnostics, and regression tests

Agent-Logs-Url: https://github.com/ICSM/pgmuvi/sessions/5767726f-9572-4d78-8223-457ee1ff2878

Co-authored-by: sundarjhu <15619959+sundarjhu@users.noreply.github.com>

Fix docstring: RuntimeError → ConsensusFitError in run_public_consensus_fit

Agent-Logs-Url: https://github.com/ICSM/pgmuvi/sessions/5767726f-9572-4d78-8223-457ee1ff2878

Co-authored-by: sundarjhu <15619959+sundarjhu@users.noreply.github.com>

Add consensus failure state guards and regression tests

Agent-Logs-Url: https://github.com/ICSM/pgmuvi/sessions/3a11f2ae-02a7-43e0-9c46-1409cfc78e69

Co-authored-by: sundarjhu <15619959+sundarjhu@users.noreply.github.com>

Fix consensus-fit model-state contamination and SM key-resolution bug

- _consensus_standard_fit: always rebuild model when model= is
  explicitly specified; clear stale model/likelihood/_model_pars state
  and reset __SET_LIKELIHOOD_CALLED before set_model()
- Add _consensus_clear_model_state() helper
- Add _consensus_validate_final_model_supports_sm_time_kernel() that
  raises ConsensusFitError (not RuntimeError) when the requested model
  lacks SM time-kernel parameters
- Improve _consensus_resolve_time_spectral_mixture_keys() error
  messages to include available keys and actionable guidance

Agent-Logs-Url: https://github.com/ICSM/pgmuvi/sessions/f2e00d17-6ae6-4326-8101-40731277f5a1

Co-authored-by: sundarjhu <15619959+sundarjhu@users.noreply.github.com>

fix: add min_consensus_inliers guard for mutually inconsistent periods

Production change:
- Add `min_consensus_inliers=2` parameter to
  `_consensus_build_frequency_consensus`. After sigma-clipping, count
  original (pre-dedup) bands in the inlier frequency window. If fewer
  than `min_consensus_inliers` original bands agree, return a failure
  dict (insufficient_inliers=True, final_consensus_frequency=nan) so
  the caller can finalize diagnostics and raise RuntimeError.

- In `_consensus_standard_fit`, extract `min_consensus_inliers` from
  fit_kwargs (default 2), pass it through, and handle the new failure
  path by populating consensus_outlier_bands / trusted_candidate_count
  before finalizing diagnostics and raising RuntimeError.

Test change:
- Add test 6: four adequately-sampled bands (18/31/47/73 d) with
  mutually inconsistent periods, outlier_sigma=1.5,
  min_consensus_inliers=4. Asserts consensus_success=False,
  final_consensus_frequency=None, consensus_outlier_bands populated,
  and trusted_candidate_count < 4.
- Update module docstring: remove stale claim that consensus_success=
  False can only arise from pre-LS quality gating; document both
  failure paths.
- Extend run_public_consensus_fit helper to accept
  min_consensus_inliers kwarg.

Agent-Logs-Url: https://github.com/ICSM/pgmuvi/sessions/c266d1e3-db25-4173-87d9-9d9a156edd3a

Co-authored-by: sundarjhu <15619959+sundarjhu@users.noreply.github.com>

Add consensus scientific regression test module

Agent-Logs-Url: https://github.com/ICSM/pgmuvi/sessions/040df7b1-cb7b-4ab3-a5ed-283278a6f080

Co-authored-by: sundarjhu <15619959+sundarjhu@users.noreply.github.com>

Add publication-grade consensus scientific regression tests

Agent-Logs-Url: https://github.com/ICSM/pgmuvi/sessions/040df7b1-cb7b-4ab3-a5ed-283278a6f080

Co-authored-by: sundarjhu <15619959+sundarjhu@users.noreply.github.com>

refactor: rewrite consensus scientific regression tests to use public fit path

- Remove _run_consensus_frequency_regression() which called private methods
  _consensus_collect_band_candidates and _consensus_build_frequency_consensus
- Add run_public_consensus_fit() helper that uses lc.fit(fit_strategy='consensus',
  model='2D', training_iter=0, use_gp_validation=False, ...) with GP skipped
- All 5 test cases now drive the full public consensus pipeline through
  lc.fit() and assert on lc.consensus_diagnostics

Test design changes:
- Test 2 (discrepant band): Uses 3 majority bands at 26/30/34 days
  (distinct enough to survive dedup, giving ≥3 candidates) + 1 discrepant
  at 10 days; asserts z is in consensus_outlier_bands (not silently inlier)
- Test 4 (harmonic): Same structure (26/30/34 + 15 days as 2:1 sub-harmonic);
  asserts z is in consensus_outlier_bands; ACF enabled
- Test 5 (no-consensus): Uses assertRaises(RuntimeError) to catch the
  lc.fit() exception; asserts on lc.consensus_diagnostics for consensus_success=False
  and populated rejection_reasons; bands have genuinely inconsistent periods
  (7, 30, 130 days) with insufficient sampling

All 5 tests pass in ~3.5 s; ruff finds no issues in pgmuvi/

Agent-Logs-Url: https://github.com/ICSM/pgmuvi/sessions/3e91da8e-0210-4bb9-b4a1-1f8c40383186

Co-authored-by: sundarjhu <15619959+sundarjhu@users.noreply.github.com>

Polish failure-summary test serialization input

Agent-Logs-Url: https://github.com/ICSM/pgmuvi/sessions/3a11f2ae-02a7-43e0-9c46-1409cfc78e69

Co-authored-by: sundarjhu <15619959+sundarjhu@users.noreply.github.com>

Fix consensus failure diagnostics and constraint validation