### PR TITLE
Parameter specification and estimation infrastructure

### DIFF
--- a/pgmuvi/gps.py
+++ b/pgmuvi/gps.py
@@ -1498,6 +1498,33 @@ class CustomLinearConstantMean(Mean):
     def forward(self, x):
         return self.bias + self.wavelength_slope * x[:, 1]
 
+    def parameter_schema(self, prefix="mean_module"):
+        """Return model-independent parameter specifications for this mean."""
+        def name(local_name):
+            return f"{prefix}.{local_name}" if prefix else local_name
+
+        return ParameterSpecCollection(
+            [
+                ParameterSpec(
+                    name=name("wavelength_slope"),
+                    role=ParameterRole.WAVELENGTH_SCALE,
+                    domain=ParameterDomain.FLUX,
+                    scale=ParameterScale.LINEAR,
+                    description=(
+                        "Linear coefficient describing how the mean flux changes "
+                        "with wavelength in the transformed wavelength coordinate."
+                    ),
+                ),
+                ParameterSpec(
+                    name=name("bias"),
+                    role=ParameterRole.OFFSET,
+                    domain=ParameterDomain.FLUX,
+                    scale=ParameterScale.LINEAR,
+                    description="Constant flux offset of the wavelength-linear mean function.",
+                ),
+            ]
+        )
+
 
 class CustomQuadConstantMean(Mean):
     """ Custom mean function that is quadratic in wavelength and constant in time.
@@ -1525,6 +1552,34 @@ class CustomQuadConstantMean(Mean):
                           dtype=self.weights.dtype)
         x_powers = x_wl.unsqueeze(-1) ** powers
         return self.bias + t.sum(self.weights * x_powers, dim=-1)
+
+    def parameter_schema(self, prefix="mean_module"):
+        """Return model-independent parameter specifications for this mean."""
+        def name(local_name):
+            return f"{prefix}.{local_name}" if prefix else local_name
+
+        return ParameterSpecCollection(
+            [
+                ParameterSpec(
+                    name=name("weights"),
+                    role=ParameterRole.WAVELENGTH_SCALE,
+                    domain=ParameterDomain.FLUX,
+                    scale=ParameterScale.LINEAR,
+                    shape=(2,),
+                    description=(
+                        "Linear and quadratic coefficients describing how the mean "
+                        "flux changes with wavelength in the transformed wavelength coordinate."
+                    ),
+                ),
+                ParameterSpec(
+                    name=name("bias"),
+                    role=ParameterRole.OFFSET,
+                    domain=ParameterDomain.FLUX,
+                    scale=ParameterScale.LINEAR,
+                    description="Constant flux offset of the wavelength-quadratic mean function.",
+                ),
+            ]
+        )
 
 
 class WavelengthDependentGPModel(SeparableGPModel):

--- a/pgmuvi/gps.py
+++ b/pgmuvi/gps.py
@@ -90,6 +90,45 @@ class PowerLawMean(gpt.means.Mean):
             "exponent", t.nn.Parameter(t.full((*batch_shape, 1), -2.0))
         )
 
+    def parameter_schema(self, prefix="mean_module"):
+        """Return model-independent parameter specifications for PowerLawMean."""
+
+        def name(local_name):
+            return f"{prefix}.{local_name}" if prefix else local_name
+
+        return ParameterSpecCollection(
+            [
+                ParameterSpec(
+                    name=name("offset"),
+                    role=ParameterRole.OFFSET,
+                    domain=ParameterDomain.FLUX,
+                    scale=ParameterScale.LINEAR,
+                    description="Constant additive flux offset of the wavelength power-law mean function.",
+                ),
+                ParameterSpec(
+                    name=name("weight"),
+                    role=ParameterRole.AMPLITUDE,
+                    domain=ParameterDomain.FLUX,
+                    scale=ParameterScale.LINEAR,
+                    description=(
+                        "Linear flux-domain amplitude multiplying the wavelength "
+                        "power-law term. The sign controls whether the mean flux "
+                        "increases or decreases with wavelength."
+                    ),
+                ),
+                ParameterSpec(
+                    name=name("exponent"),
+                    role=ParameterRole.SHAPE,
+                    domain=ParameterDomain.DIMENSIONLESS,
+                    scale=ParameterScale.LINEAR,
+                    description=(
+                        "Dimensionless power-law index controlling the wavelength "
+                        "dependence of the mean flux."
+                    ),
+                ),
+            ]
+        )
+
     def forward(self, x):
         wavelength = x[..., 1]  # second column is wavelength
         return (
@@ -167,17 +206,6 @@ class DustMean(gpt.means.Mean):
             t.nn.Parameter(t.full((*batch_shape, 1), _LOG_1_7)),
         )
 
-    def forward(self, x):
-        # Clamp wavelength to avoid overflow in λ^(-alpha): any physical
-        # wavelength in microns is far above 1e-6, so this guard is only
-        # triggered for pathological inputs.
-        wavelength = x[..., 1].clamp(min=1e-6)
-        amplitude = self.log_amplitude.squeeze(-1).exp()
-        tau = self.log_tau.squeeze(-1).exp()
-        alpha = self.log_alpha.squeeze(-1).exp()
-        extinction = tau * wavelength.pow(-alpha)
-        return self.offset.squeeze(-1) + amplitude * (-extinction).exp()
-
     def parameter_schema(self, prefix="mean_module"):
         """Return model-independent parameter specifications for DustMean."""
         def name(local_name):
@@ -223,6 +251,17 @@ class DustMean(gpt.means.Mean):
                 ),
             ]
         )
+
+    def forward(self, x):
+        # Clamp wavelength to avoid overflow in λ^(-alpha): any physical
+        # wavelength in microns is far above 1e-6, so this guard is only
+        # triggered for pathological inputs.
+        wavelength = x[..., 1].clamp(min=1e-6)
+        amplitude = self.log_amplitude.squeeze(-1).exp()
+        tau = self.log_tau.squeeze(-1).exp()
+        alpha = self.log_alpha.squeeze(-1).exp()
+        extinction = tau * wavelength.pow(-alpha)
+        return self.offset.squeeze(-1) + amplitude * (-extinction).exp()
 
 
 # FIRST WE HAVE SOME Naive GPs
@@ -1495,9 +1534,6 @@ class CustomLinearConstantMean(Mean):
             parameter=t.nn.Parameter(t.tensor(0.0)),
         )
 
-    def forward(self, x):
-        return self.bias + self.wavelength_slope * x[:, 1]
-
     def parameter_schema(self, prefix="mean_module"):
         """Return model-independent parameter specifications for this mean."""
         def name(local_name):
@@ -1525,6 +1561,9 @@ class CustomLinearConstantMean(Mean):
             ]
         )
 
+    def forward(self, x):
+        return self.bias + self.wavelength_slope * x[:, 1]
+
 
 class CustomQuadConstantMean(Mean):
     """ Custom mean function that is quadratic in wavelength and constant in time.
@@ -1544,14 +1583,6 @@ class CustomQuadConstantMean(Mean):
             name="bias",
             parameter=t.nn.Parameter(t.tensor(0.0)),
         )
-
-    def forward(self, x):
-        x_wl = x[:, 1]
-        powers = t.arange(1, len(self.weights) + 1,
-                          device=self.weights.device,
-                          dtype=self.weights.dtype)
-        x_powers = x_wl.unsqueeze(-1) ** powers
-        return self.bias + t.sum(self.weights * x_powers, dim=-1)
 
     def parameter_schema(self, prefix="mean_module"):
         """Return model-independent parameter specifications for this mean."""
@@ -1580,6 +1611,14 @@ class CustomQuadConstantMean(Mean):
                 ),
             ]
         )
+
+    def forward(self, x):
+        x_wl = x[:, 1]
+        powers = t.arange(1, len(self.weights) + 1,
+                          device=self.weights.device,
+                          dtype=self.weights.dtype)
+        x_powers = x_wl.unsqueeze(-1) ** powers
+        return self.bias + t.sum(self.weights * x_powers, dim=-1)
 
 
 class WavelengthDependentGPModel(SeparableGPModel):

--- a/pgmuvi/gps.py
+++ b/pgmuvi/gps.py
@@ -22,6 +22,14 @@ from gpytorch.models import ExactGP, ApproximateGP
 from gpytorch.variational import CholeskyVariationalDistribution
 from gpytorch.variational import VariationalStrategy
 
+from pgmuvi.parameter_specs import (
+    ParameterDomain,
+    ParameterRole,
+    ParameterScale,
+    ParameterSpec,
+    ParameterSpecCollection,
+)
+
 # Module-level constant: log(1.7) used as default initial value for
 # DustMean.log_alpha, corresponding to a typical interstellar dust-extinction
 # power-law index of alpha ≈ 1.7.
@@ -169,6 +177,52 @@ class DustMean(gpt.means.Mean):
         alpha = self.log_alpha.squeeze(-1).exp()
         extinction = tau * wavelength.pow(-alpha)
         return self.offset.squeeze(-1) + amplitude * (-extinction).exp()
+
+    def parameter_schema(self, prefix="mean_module"):
+        """Return model-independent parameter specifications for DustMean."""
+        def name(local_name):
+            return f"{prefix}.{local_name}" if prefix else local_name
+
+        return ParameterSpecCollection(
+            [
+                ParameterSpec(
+                    name=name("offset"),
+                    role=ParameterRole.OFFSET,
+                    domain=ParameterDomain.FLUX,
+                    scale=ParameterScale.LINEAR,
+                    description="Constant additive flux offset shared across wavelengths.",
+                ),
+                ParameterSpec(
+                    name=name("log_amplitude"),
+                    role=ParameterRole.AMPLITUDE,
+                    domain=ParameterDomain.FLUX,
+                    scale=ParameterScale.LOG,
+                    description=(
+                        "Positive amplitude of the dust-attenuated wavelength-dependent "
+                        "mean function, represented in physical flux units before log transformation."
+                    ),
+                ),
+                ParameterSpec(
+                    name=name("log_tau"),
+                    role=ParameterRole.SHAPE,
+                    domain=ParameterDomain.DIMENSIONLESS,
+                    scale=ParameterScale.LOG,
+                    description=(
+                        "Positive effective dust optical-depth parameter controlling the "
+                        "strength of wavelength-dependent attenuation."
+                    ),
+                ),
+                ParameterSpec(
+                    name=name("log_alpha"),
+                    role=ParameterRole.SHAPE,
+                    domain=ParameterDomain.DIMENSIONLESS,
+                    scale=ParameterScale.LOG,
+                    description=(
+                        "Positive power-law index of the wavelength-dependent attenuation law."
+                    ),
+                ),
+            ]
+        )
 
 
 # FIRST WE HAVE SOME Naive GPs

--- a/pgmuvi/gps.py
+++ b/pgmuvi/gps.py
@@ -103,7 +103,10 @@ class PowerLawMean(gpt.means.Mean):
                     role=ParameterRole.OFFSET,
                     domain=ParameterDomain.FLUX,
                     scale=ParameterScale.LINEAR,
-                    description="Constant additive flux offset of the wavelength power-law mean function.",
+                    description=(
+                        "Constant additive flux offset of the wavelength "
+                        "power-law mean function."
+                    ),
                 ),
                 ParameterSpec(
                     name=name("weight"),
@@ -218,7 +221,10 @@ class DustMean(gpt.means.Mean):
                     role=ParameterRole.OFFSET,
                     domain=ParameterDomain.FLUX,
                     scale=ParameterScale.LINEAR,
-                    description="Constant additive flux offset shared across wavelengths.",
+                    description=(
+                        "Constant additive flux offset shared across "
+                        "wavelengths."
+                    ),
                 ),
                 ParameterSpec(
                     name=name("log_amplitude"),
@@ -226,8 +232,9 @@ class DustMean(gpt.means.Mean):
                     domain=ParameterDomain.FLUX,
                     scale=ParameterScale.LOG,
                     description=(
-                        "Positive amplitude of the dust-attenuated wavelength-dependent "
-                        "mean function, represented in physical flux units before log transformation."
+                        "Positive amplitude of the dust-attenuated "
+                        "wavelength-dependent mean function, represented in "
+                        "physical flux units before log transformation."
                     ),
                 ),
                 ParameterSpec(
@@ -236,7 +243,8 @@ class DustMean(gpt.means.Mean):
                     domain=ParameterDomain.DIMENSIONLESS,
                     scale=ParameterScale.LOG,
                     description=(
-                        "Positive effective dust optical-depth parameter controlling the "
+                        "Positive effective dust optical-depth parameter "
+                        "controlling the "
                         "strength of wavelength-dependent attenuation."
                     ),
                 ),
@@ -246,7 +254,8 @@ class DustMean(gpt.means.Mean):
                     domain=ParameterDomain.DIMENSIONLESS,
                     scale=ParameterScale.LOG,
                     description=(
-                        "Positive power-law index of the wavelength-dependent attenuation law."
+                        "Positive power-law index of the "
+                        "wavelength-dependent attenuation law."
                     ),
                 ),
             ]
@@ -1556,7 +1565,10 @@ class CustomLinearConstantMean(Mean):
                     role=ParameterRole.OFFSET,
                     domain=ParameterDomain.FLUX,
                     scale=ParameterScale.LINEAR,
-                    description="Constant flux offset of the wavelength-linear mean function.",
+                    description=(
+                        "Constant flux offset of the wavelength-linear mean "
+                        "function."
+                    ),
                 ),
             ]
         )
@@ -1599,7 +1611,8 @@ class CustomQuadConstantMean(Mean):
                     shape=(2,),
                     description=(
                         "Linear and quadratic coefficients describing how the mean "
-                        "flux changes with wavelength in the transformed wavelength coordinate."
+                        "flux changes with wavelength in the transformed "
+                        "wavelength coordinate."
                     ),
                 ),
                 ParameterSpec(
@@ -1607,7 +1620,10 @@ class CustomQuadConstantMean(Mean):
                     role=ParameterRole.OFFSET,
                     domain=ParameterDomain.FLUX,
                     scale=ParameterScale.LINEAR,
-                    description="Constant flux offset of the wavelength-quadratic mean function.",
+                    description=(
+                        "Constant flux offset of the wavelength-quadratic "
+                        "mean function."
+                    ),
                 ),
             ]
         )
@@ -1913,4 +1929,3 @@ class PowerLawMeanGPModel(WavelengthDependentGPModel):
             mean_module="power_law",
             **kwargs,
         )
-

--- a/pgmuvi/parameter_context.py
+++ b/pgmuvi/parameter_context.py
@@ -1,0 +1,75 @@
+"""Diagnostic containers for parameter estimation.
+
+This module defines model-independent containers for data-derived
+diagnostics that may later be used to build parameter guesses and
+constraints. It does not compute diagnostics or apply values to models.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class LightcurveDiagnostics:
+    """Global diagnostics for a light curve or light-curve collection."""
+
+    baseline: float | None = None
+    cadence: float | None = None
+    median_flux: float | None = None
+    mad_flux: float | None = None
+    flux_percentiles: tuple[float, float] | None = None
+    n_points: int | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class BandDiagnostics:
+    """Diagnostics for one band in a multiband light curve."""
+
+    band: str
+    wavelength: float | None = None
+    baseline: float | None = None
+    cadence: float | None = None
+    median_flux: float | None = None
+    mad_flux: float | None = None
+    flux_percentiles: tuple[float, float] | None = None
+    n_points: int | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ConsensusDiagnostics:
+    """Period/frequency diagnostics from a cross-band consensus analysis."""
+
+    method: str
+    periods: Any | None = None
+    frequencies: Any | None = None
+    period_widths: Any | None = None
+    frequency_widths: Any | None = None
+    powers: Any | None = None
+    component_indices: Any | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ParameterEstimationContext:
+    """Container for diagnostics used by future parameter-estimation logic."""
+
+    is_multiband: bool
+    global_diagnostics: LightcurveDiagnostics | None = None
+    band_diagnostics: dict[str, BandDiagnostics] = field(default_factory=dict)
+    consensus_diagnostics: ConsensusDiagnostics | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def bands(self) -> list[str]:
+        """Return the available band names."""
+        return list(self.band_diagnostics.keys())
+
+    def get_band(self, band: str) -> BandDiagnostics:
+        """Return diagnostics for one band."""
+        try:
+            return self.band_diagnostics[band]
+        except KeyError as exc:
+            raise KeyError(f"No diagnostics found for band {band!r}.") from exc

--- a/pgmuvi/parameter_estimates.py
+++ b/pgmuvi/parameter_estimates.py
@@ -1,0 +1,115 @@
+"""Data-derived parameter estimates.
+
+This module defines containers for parameter values and constraints
+estimated from data in physical space. It does not transform values into
+GPyTorch parameter space or apply them to models.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Iterator
+
+import numpy as np
+
+from pgmuvi.parameter_specs import ParameterSpec
+
+
+@dataclass(frozen=True)
+class ParameterEstimate:
+    """Data-derived estimate for one parameter specification."""
+
+    spec: ParameterSpec
+
+    value: Any | None = None
+    constraint: tuple[Any, Any] | None = None
+
+    value_source: str | None = None
+    constraint_source: str | None = None
+
+    diagnostics: dict[str, Any] = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def name(self) -> str:
+        """Return the parameter name from the associated specification."""
+        return self.spec.name
+
+    def validate(self) -> None:
+        """Validate internal consistency of this parameter estimate."""
+        self.spec.validate()
+
+        if self.constraint is not None:
+            lower, upper = self.constraint
+            lower_arr = np.asarray(lower)
+            upper_arr = np.asarray(upper)
+
+            if np.any(lower_arr >= upper_arr):
+                raise ValueError(
+                    f"Invalid constraint for {self.name!r}: lower bound must be "
+                    "strictly smaller than upper bound."
+                )
+
+            if self.value is not None:
+                value_arr = np.asarray(self.value)
+                if np.any(value_arr < lower_arr) or np.any(value_arr > upper_arr):
+                    raise ValueError(
+                        f"Estimated value for {self.name!r} lies outside its constraint."
+                    )
+
+        if self.spec.shape is not None and self.value is not None:
+            value_shape = np.asarray(self.value).shape
+            if value_shape != self.spec.shape:
+                raise ValueError(
+                    f"Shape mismatch for {self.name!r}: expected {self.spec.shape}, "
+                    f"got {value_shape}."
+                )
+
+
+@dataclass
+class ParameterEstimateCollection:
+    """Container for a set of named parameter estimates."""
+
+    estimates: list[ParameterEstimate] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        self.validate()
+
+    def __iter__(self) -> Iterator[ParameterEstimate]:
+        return iter(self.estimates)
+
+    def __len__(self) -> int:
+        return len(self.estimates)
+
+    def __contains__(self, name: str) -> bool:
+        return any(estimate.name == name for estimate in self.estimates)
+
+    def __getitem__(self, name: str) -> ParameterEstimate:
+        for estimate in self.estimates:
+            if estimate.name == name:
+                return estimate
+        raise KeyError(name)
+
+    def names(self) -> list[str]:
+        """Return parameter names in collection order."""
+        return [estimate.name for estimate in self.estimates]
+
+    def validate(self) -> None:
+        """Validate all estimates and reject duplicate names."""
+        names = self.names()
+        if len(names) != len(set(names)):
+            raise ValueError("ParameterEstimateCollection contains duplicate names.")
+
+        for estimate in self.estimates:
+            estimate.validate()
+
+    def add(self, estimate: ParameterEstimate) -> None:
+        """Add one estimate after validating it."""
+        if estimate.name in self:
+            raise ValueError(f"Duplicate parameter estimate: {estimate.name!r}")
+        estimate.validate()
+        self.estimates.append(estimate)
+
+    def as_dict(self) -> dict[str, ParameterEstimate]:
+        """Return estimates keyed by parameter name."""
+        return {estimate.name: estimate for estimate in self.estimates}

--- a/pgmuvi/parameter_specs.py
+++ b/pgmuvi/parameter_specs.py
@@ -107,6 +107,9 @@ class ParameterSpec:
     domain: ParameterDomain
     scale: ParameterScale = ParameterScale.LINEAR
 
+    required: bool = True
+    trainable: bool = True
+
     initial_value: Any | None = None
     constraint: tuple[Any, Any] | None = None
     shape: tuple[int, ...] | None = None
@@ -116,6 +119,7 @@ class ParameterSpec:
 
     guess_strategy: GuessStrategy | None = None
     constraint_strategy: ConstraintStrategy | None = None
+
     guess_source: str | None = None
     constraint_source: str | None = None
     metadata: dict[str, Any] = field(default_factory=dict)

--- a/pgmuvi/parameter_specs.py
+++ b/pgmuvi/parameter_specs.py
@@ -1,0 +1,142 @@
+"""Model-independent parameter specification schema.
+
+This module defines lightweight containers for describing GP model parameters
+in data/physical space. It does not apply values to GPyTorch models.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Iterator
+
+import numpy as np
+
+
+class ParameterRole(str, Enum):
+    PERIOD = "period"
+    FREQUENCY = "frequency"
+    AMPLITUDE = "amplitude"
+    OFFSET = "offset"
+    TIMESCALE = "timescale"
+    LENGTHSCALE = "lengthscale"
+    WEIGHT = "weight"
+    NOISE = "noise"
+    SHAPE = "shape"
+    WAVELENGTH_SCALE = "wavelength_scale"
+    OTHER = "other"
+
+
+class ParameterDomain(str, Enum):
+    TIME = "time"
+    FREQUENCY = "frequency"
+    FLUX = "flux"
+    WAVELENGTH = "wavelength"
+    VARIANCE = "variance"
+    DIMENSIONLESS = "dimensionless"
+    OTHER = "other"
+
+
+class ParameterScale(str, Enum):
+    LINEAR = "linear"
+    LOG = "log"
+    LOG10 = "log10"
+    LOGIT = "logit"
+    OTHER = "other"
+
+
+@dataclass(frozen=True)
+class ParameterSpec:
+    """Description of one trainable model parameter in data/physical space."""
+
+    name: str
+    role: ParameterRole
+    domain: ParameterDomain
+    scale: ParameterScale = ParameterScale.LINEAR
+
+    initial_value: Any | None = None
+    constraint: tuple[Any, Any] | None = None
+    shape: tuple[int, ...] | None = None
+
+    units: str | None = None
+    description: str | None = None
+
+    guess_source: str | None = None
+    constraint_source: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def validate(self) -> None:
+        """Validate internal consistency of this parameter specification."""
+        if not self.name:
+            raise ValueError("ParameterSpec.name must be non-empty.")
+
+        if self.constraint is not None:
+            lower, upper = self.constraint
+            lower_arr = np.asarray(lower)
+            upper_arr = np.asarray(upper)
+
+            if np.any(lower_arr >= upper_arr):
+                raise ValueError(
+                    f"Invalid constraint for {self.name!r}: lower bound must be "
+                    "strictly smaller than upper bound."
+                )
+
+            if self.initial_value is not None:
+                value_arr = np.asarray(self.initial_value)
+                if np.any(value_arr < lower_arr) or np.any(value_arr > upper_arr):
+                    raise ValueError(
+                        f"Initial value for {self.name!r} lies outside its constraint."
+                    )
+
+        if self.shape is not None and self.initial_value is not None:
+            value_shape = np.asarray(self.initial_value).shape
+            if value_shape != self.shape:
+                raise ValueError(
+                    f"Shape mismatch for {self.name!r}: expected {self.shape}, "
+                    f"got {value_shape}."
+                )
+
+
+@dataclass
+class ParameterSpecCollection:
+    """Container for a set of named parameter specifications."""
+
+    specs: list[ParameterSpec] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        self.validate()
+
+    def __iter__(self) -> Iterator[ParameterSpec]:
+        return iter(self.specs)
+
+    def __len__(self) -> int:
+        return len(self.specs)
+
+    def __contains__(self, name: str) -> bool:
+        return any(spec.name == name for spec in self.specs)
+
+    def __getitem__(self, name: str) -> ParameterSpec:
+        for spec in self.specs:
+            if spec.name == name:
+                return spec
+        raise KeyError(name)
+
+    def names(self) -> list[str]:
+        return [spec.name for spec in self.specs]
+
+    def validate(self) -> None:
+        names = self.names()
+        if len(names) != len(set(names)):
+            raise ValueError("ParameterSpecCollection contains duplicate names.")
+
+        for spec in self.specs:
+            spec.validate()
+
+    def add(self, spec: ParameterSpec) -> None:
+        if spec.name in self:
+            raise ValueError(f"Duplicate parameter specification: {spec.name!r}")
+        spec.validate()
+        self.specs.append(spec)
+
+    def as_dict(self) -> dict[str, ParameterSpec]:
+        return {spec.name: spec for spec in self.specs}

--- a/pgmuvi/parameter_specs.py
+++ b/pgmuvi/parameter_specs.py
@@ -45,9 +45,62 @@ class ParameterScale(str, Enum):
     OTHER = "other"
 
 
+class GuessStrategy(str, Enum):
+    USER = "user"
+    DEFAULT = "default"
+
+    MEDIAN_FLUX = "median_flux"
+    ROBUST_FLUX_RANGE = "robust_flux_range"
+    FLUX_STD = "flux_std"
+    MAD = "mad"
+
+    BASELINE = "baseline"
+    CADENCE = "cadence"
+
+    LS_PERIOD = "ls_period"
+    ACF_PERIOD = "acf_period"
+    CONSENSUS_PERIOD = "consensus_period"
+    CONSENSUS_MULTICOMP_PERIOD = "consensus_multicomp_period"
+
+    VARIABILITY_TIMESCALE = "variability_timescale"
+
+    WAVELENGTH_RANGE = "wavelength_range"
+
+    CUSTOM = "custom"
+
+
+class ConstraintStrategy(str, Enum):
+    USER = "user"
+    DEFAULT = "default"
+
+    MEDIAN_FLUX = "median_flux"
+    ROBUST_FLUX_RANGE = "robust_flux_range"
+    FLUX_STD = "flux_std"
+    MAD = "mad"
+
+    BASELINE = "baseline"
+    CADENCE = "cadence"
+
+    LS_PERIOD = "ls_period"
+    ACF_PERIOD = "acf_period"
+    CONSENSUS_PERIOD = "consensus_period"
+    CONSENSUS_MULTICOMP_PERIOD = "consensus_multicomp_period"
+
+    VARIABILITY_TIMESCALE = "variability_timescale"
+
+    WAVELENGTH_RANGE = "wavelength_range"
+
+    CUSTOM = "custom"
+
+
 @dataclass(frozen=True)
 class ParameterSpec:
-    """Description of one trainable model parameter in data/physical space."""
+    """Description of one trainable model parameter in data/physical space.
+
+    The specification describes the parameter semantically and records
+    how initial values and constraints should be constructed. It does
+    not contain any model-specific transformation logic.
+    """
 
     name: str
     role: ParameterRole
@@ -61,6 +114,8 @@ class ParameterSpec:
     units: str | None = None
     description: str | None = None
 
+    guess_strategy: GuessStrategy | None = None
+    constraint_strategy: ConstraintStrategy | None = None
     guess_source: str | None = None
     constraint_source: str | None = None
     metadata: dict[str, Any] = field(default_factory=dict)

--- a/tests/test_dust_mean_parameter_schema.py
+++ b/tests/test_dust_mean_parameter_schema.py
@@ -1,0 +1,49 @@
+from pgmuvi.gps import DustMean
+from pgmuvi.parameter_specs import ParameterDomain, ParameterRole, ParameterScale
+
+
+def test_dust_mean_parameter_schema_names():
+    schema = DustMean().parameter_schema()
+
+    assert schema.names() == [
+        "mean_module.offset",
+        "mean_module.log_amplitude",
+        "mean_module.log_tau",
+        "mean_module.log_alpha",
+    ]
+
+
+def test_dust_mean_parameter_schema_semantics():
+    schema = DustMean().parameter_schema()
+
+    offset = schema["mean_module.offset"]
+    amplitude = schema["mean_module.log_amplitude"]
+    tau = schema["mean_module.log_tau"]
+    alpha = schema["mean_module.log_alpha"]
+
+    assert offset.role is ParameterRole.OFFSET
+    assert offset.domain is ParameterDomain.FLUX
+    assert offset.scale is ParameterScale.LINEAR
+
+    assert amplitude.role is ParameterRole.AMPLITUDE
+    assert amplitude.domain is ParameterDomain.FLUX
+    assert amplitude.scale is ParameterScale.LOG
+
+    assert tau.role is ParameterRole.SHAPE
+    assert tau.domain is ParameterDomain.DIMENSIONLESS
+    assert tau.scale is ParameterScale.LOG
+
+    assert alpha.role is ParameterRole.SHAPE
+    assert alpha.domain is ParameterDomain.DIMENSIONLESS
+    assert alpha.scale is ParameterScale.LOG
+
+
+def test_dust_mean_parameter_schema_accepts_empty_prefix():
+    schema = DustMean().parameter_schema(prefix="")
+
+    assert schema.names() == [
+        "offset",
+        "log_amplitude",
+        "log_tau",
+        "log_alpha",
+    ]

--- a/tests/test_dust_mean_parameter_schema.py
+++ b/tests/test_dust_mean_parameter_schema.py
@@ -1,49 +1,56 @@
+import unittest
+
 from pgmuvi.gps import DustMean
 from pgmuvi.parameter_specs import ParameterDomain, ParameterRole, ParameterScale
 
 
-def test_dust_mean_parameter_schema_names():
-    schema = DustMean().parameter_schema()
+class TestDustMeanParameterSchema(unittest.TestCase):
+    def test_dust_mean_parameter_schema_names(self):
+        schema = DustMean().parameter_schema()
 
-    assert schema.names() == [
-        "mean_module.offset",
-        "mean_module.log_amplitude",
-        "mean_module.log_tau",
-        "mean_module.log_alpha",
-    ]
+        self.assertEqual(
+            schema.names(),
+            [
+                "mean_module.offset",
+                "mean_module.log_amplitude",
+                "mean_module.log_tau",
+                "mean_module.log_alpha",
+            ],
+        )
 
+    def test_dust_mean_parameter_schema_semantics(self):
+        schema = DustMean().parameter_schema()
 
-def test_dust_mean_parameter_schema_semantics():
-    schema = DustMean().parameter_schema()
+        offset = schema["mean_module.offset"]
+        amplitude = schema["mean_module.log_amplitude"]
+        tau = schema["mean_module.log_tau"]
+        alpha = schema["mean_module.log_alpha"]
 
-    offset = schema["mean_module.offset"]
-    amplitude = schema["mean_module.log_amplitude"]
-    tau = schema["mean_module.log_tau"]
-    alpha = schema["mean_module.log_alpha"]
+        self.assertIs(offset.role, ParameterRole.OFFSET)
+        self.assertIs(offset.domain, ParameterDomain.FLUX)
+        self.assertIs(offset.scale, ParameterScale.LINEAR)
 
-    assert offset.role is ParameterRole.OFFSET
-    assert offset.domain is ParameterDomain.FLUX
-    assert offset.scale is ParameterScale.LINEAR
+        self.assertIs(amplitude.role, ParameterRole.AMPLITUDE)
+        self.assertIs(amplitude.domain, ParameterDomain.FLUX)
+        self.assertIs(amplitude.scale, ParameterScale.LOG)
 
-    assert amplitude.role is ParameterRole.AMPLITUDE
-    assert amplitude.domain is ParameterDomain.FLUX
-    assert amplitude.scale is ParameterScale.LOG
+        self.assertIs(tau.role, ParameterRole.SHAPE)
+        self.assertIs(tau.domain, ParameterDomain.DIMENSIONLESS)
+        self.assertIs(tau.scale, ParameterScale.LOG)
 
-    assert tau.role is ParameterRole.SHAPE
-    assert tau.domain is ParameterDomain.DIMENSIONLESS
-    assert tau.scale is ParameterScale.LOG
+        self.assertIs(alpha.role, ParameterRole.SHAPE)
+        self.assertIs(alpha.domain, ParameterDomain.DIMENSIONLESS)
+        self.assertIs(alpha.scale, ParameterScale.LOG)
 
-    assert alpha.role is ParameterRole.SHAPE
-    assert alpha.domain is ParameterDomain.DIMENSIONLESS
-    assert alpha.scale is ParameterScale.LOG
+    def test_dust_mean_parameter_schema_accepts_empty_prefix(self):
+        schema = DustMean().parameter_schema(prefix="")
 
-
-def test_dust_mean_parameter_schema_accepts_empty_prefix():
-    schema = DustMean().parameter_schema(prefix="")
-
-    assert schema.names() == [
-        "offset",
-        "log_amplitude",
-        "log_tau",
-        "log_alpha",
-    ]
+        self.assertEqual(
+            schema.names(),
+            [
+                "offset",
+                "log_amplitude",
+                "log_tau",
+                "log_alpha",
+            ],
+        )

--- a/tests/test_parameter_context.py
+++ b/tests/test_parameter_context.py
@@ -1,4 +1,4 @@
-import pytest
+import unittest
 
 from pgmuvi.parameter_context import (
     BandDiagnostics,
@@ -8,78 +8,75 @@ from pgmuvi.parameter_context import (
 )
 
 
-def test_lightcurve_diagnostics_stores_global_quantities():
-    diagnostics = LightcurveDiagnostics(
-        baseline=1000.0,
-        cadence=10.0,
-        median_flux=123.0,
-        mad_flux=5.0,
-        flux_percentiles=(100.0, 150.0),
-        n_points=42,
-    )
+class TestParameterContext(unittest.TestCase):
+    def test_lightcurve_diagnostics_stores_global_quantities(self):
+        diagnostics = LightcurveDiagnostics(
+            baseline=1000.0,
+            cadence=10.0,
+            median_flux=123.0,
+            mad_flux=5.0,
+            flux_percentiles=(100.0, 150.0),
+            n_points=42,
+        )
 
-    assert diagnostics.baseline == 1000.0
-    assert diagnostics.cadence == 10.0
-    assert diagnostics.median_flux == 123.0
-    assert diagnostics.flux_percentiles == (100.0, 150.0)
+        self.assertEqual(diagnostics.baseline, 1000.0)
+        self.assertEqual(diagnostics.cadence, 10.0)
+        self.assertEqual(diagnostics.median_flux, 123.0)
+        self.assertEqual(diagnostics.flux_percentiles, (100.0, 150.0))
 
+    def test_band_diagnostics_stores_per_band_quantities(self):
+        diagnostics = BandDiagnostics(
+            band="WISE_W1",
+            wavelength=3.4,
+            baseline=900.0,
+            cadence=8.0,
+            median_flux=200.0,
+            mad_flux=12.0,
+            n_points=30,
+        )
 
-def test_band_diagnostics_stores_per_band_quantities():
-    diagnostics = BandDiagnostics(
-        band="WISE_W1",
-        wavelength=3.4,
-        baseline=900.0,
-        cadence=8.0,
-        median_flux=200.0,
-        mad_flux=12.0,
-        n_points=30,
-    )
+        self.assertEqual(diagnostics.band, "WISE_W1")
+        self.assertEqual(diagnostics.wavelength, 3.4)
+        self.assertEqual(diagnostics.median_flux, 200.0)
 
-    assert diagnostics.band == "WISE_W1"
-    assert diagnostics.wavelength == 3.4
-    assert diagnostics.median_flux == 200.0
+    def test_consensus_diagnostics_stores_period_information(self):
+        diagnostics = ConsensusDiagnostics(
+            method="consensus_multicomp",
+            periods=[300.0, 1200.0],
+            frequencies=[1.0 / 300.0, 1.0 / 1200.0],
+            powers=[0.8, 0.5],
+            component_indices=[0, 1],
+        )
 
+        self.assertEqual(diagnostics.method, "consensus_multicomp")
+        self.assertEqual(diagnostics.periods, [300.0, 1200.0])
+        self.assertEqual(diagnostics.component_indices, [0, 1])
 
-def test_consensus_diagnostics_stores_period_information():
-    diagnostics = ConsensusDiagnostics(
-        method="consensus_multicomp",
-        periods=[300.0, 1200.0],
-        frequencies=[1.0 / 300.0, 1.0 / 1200.0],
-        powers=[0.8, 0.5],
-        component_indices=[0, 1],
-    )
+    def test_context_stores_global_and_band_diagnostics(self):
+        global_diagnostics = LightcurveDiagnostics(median_flux=100.0)
 
-    assert diagnostics.method == "consensus_multicomp"
-    assert diagnostics.periods == [300.0, 1200.0]
-    assert diagnostics.component_indices == [0, 1]
+        w1 = BandDiagnostics(band="WISE_W1", median_flux=120.0)
+        w2 = BandDiagnostics(band="WISE_W2", median_flux=140.0)
 
+        context = ParameterEstimationContext(
+            is_multiband=True,
+            global_diagnostics=global_diagnostics,
+            band_diagnostics={
+                "WISE_W1": w1,
+                "WISE_W2": w2,
+            },
+        )
 
-def test_parameter_estimation_context_stores_global_and_band_diagnostics():
-    global_diagnostics = LightcurveDiagnostics(median_flux=100.0)
+        self.assertIs(context.is_multiband, True)
+        self.assertIs(context.global_diagnostics, global_diagnostics)
+        self.assertEqual(context.bands(), ["WISE_W1", "WISE_W2"])
+        self.assertIs(context.get_band("WISE_W1"), w1)
 
-    w1 = BandDiagnostics(band="WISE_W1", median_flux=120.0)
-    w2 = BandDiagnostics(band="WISE_W2", median_flux=140.0)
+    def test_context_raises_for_missing_band(self):
+        context = ParameterEstimationContext(
+            is_multiband=True,
+            band_diagnostics={"WISE_W1": BandDiagnostics(band="WISE_W1")},
+        )
 
-    context = ParameterEstimationContext(
-        is_multiband=True,
-        global_diagnostics=global_diagnostics,
-        band_diagnostics={
-            "WISE_W1": w1,
-            "WISE_W2": w2,
-        },
-    )
-
-    assert context.is_multiband is True
-    assert context.global_diagnostics is global_diagnostics
-    assert context.bands() == ["WISE_W1", "WISE_W2"]
-    assert context.get_band("WISE_W1") is w1
-
-
-def test_parameter_estimation_context_raises_for_missing_band():
-    context = ParameterEstimationContext(
-        is_multiband=True,
-        band_diagnostics={"WISE_W1": BandDiagnostics(band="WISE_W1")},
-    )
-
-    with pytest.raises(KeyError, match="No diagnostics found"):
-        context.get_band("WISE_W2")
+        with self.assertRaisesRegex(KeyError, "No diagnostics found"):
+            context.get_band("WISE_W2")

--- a/tests/test_parameter_context.py
+++ b/tests/test_parameter_context.py
@@ -1,0 +1,85 @@
+import pytest
+
+from pgmuvi.parameter_context import (
+    BandDiagnostics,
+    ConsensusDiagnostics,
+    LightcurveDiagnostics,
+    ParameterEstimationContext,
+)
+
+
+def test_lightcurve_diagnostics_stores_global_quantities():
+    diagnostics = LightcurveDiagnostics(
+        baseline=1000.0,
+        cadence=10.0,
+        median_flux=123.0,
+        mad_flux=5.0,
+        flux_percentiles=(100.0, 150.0),
+        n_points=42,
+    )
+
+    assert diagnostics.baseline == 1000.0
+    assert diagnostics.cadence == 10.0
+    assert diagnostics.median_flux == 123.0
+    assert diagnostics.flux_percentiles == (100.0, 150.0)
+
+
+def test_band_diagnostics_stores_per_band_quantities():
+    diagnostics = BandDiagnostics(
+        band="WISE_W1",
+        wavelength=3.4,
+        baseline=900.0,
+        cadence=8.0,
+        median_flux=200.0,
+        mad_flux=12.0,
+        n_points=30,
+    )
+
+    assert diagnostics.band == "WISE_W1"
+    assert diagnostics.wavelength == 3.4
+    assert diagnostics.median_flux == 200.0
+
+
+def test_consensus_diagnostics_stores_period_information():
+    diagnostics = ConsensusDiagnostics(
+        method="consensus_multicomp",
+        periods=[300.0, 1200.0],
+        frequencies=[1.0 / 300.0, 1.0 / 1200.0],
+        powers=[0.8, 0.5],
+        component_indices=[0, 1],
+    )
+
+    assert diagnostics.method == "consensus_multicomp"
+    assert diagnostics.periods == [300.0, 1200.0]
+    assert diagnostics.component_indices == [0, 1]
+
+
+def test_parameter_estimation_context_stores_global_and_band_diagnostics():
+    global_diagnostics = LightcurveDiagnostics(median_flux=100.0)
+
+    w1 = BandDiagnostics(band="WISE_W1", median_flux=120.0)
+    w2 = BandDiagnostics(band="WISE_W2", median_flux=140.0)
+
+    context = ParameterEstimationContext(
+        is_multiband=True,
+        global_diagnostics=global_diagnostics,
+        band_diagnostics={
+            "WISE_W1": w1,
+            "WISE_W2": w2,
+        },
+    )
+
+    assert context.is_multiband is True
+    assert context.global_diagnostics is global_diagnostics
+    assert context.bands() == ["WISE_W1", "WISE_W2"]
+    assert context.get_band("WISE_W1") is w1
+
+
+def test_parameter_estimation_context_raises_for_missing_band():
+    context = ParameterEstimationContext(
+        is_multiband=True,
+        band_diagnostics={"WISE_W1": BandDiagnostics(band="WISE_W1")},
+    )
+
+    with pytest.raises(KeyError, match="No diagnostics found"):
+        context.get_band("WISE_W2")

--- a/tests/test_parameter_estimates.py
+++ b/tests/test_parameter_estimates.py
@@ -1,10 +1,7 @@
 import numpy as np
-import pytest
+import unittest
 
-from pgmuvi.parameter_estimates import (
-    ParameterEstimate,
-    ParameterEstimateCollection,
-)
+from pgmuvi.parameter_estimates import ParameterEstimate, ParameterEstimateCollection
 from pgmuvi.parameter_specs import (
     ParameterDomain,
     ParameterRole,
@@ -13,131 +10,126 @@ from pgmuvi.parameter_specs import (
 )
 
 
-def test_parameter_estimate_stores_value_and_constraint():
-    spec = ParameterSpec(
-        name="mean_module.log_amplitude",
-        role=ParameterRole.AMPLITUDE,
-        domain=ParameterDomain.FLUX,
-        scale=ParameterScale.LOG,
-    )
+class TestParameterEstimates(unittest.TestCase):
+    def test_parameter_estimate_stores_value_and_constraint(self):
+        spec = ParameterSpec(
+            name="mean_module.log_amplitude",
+            role=ParameterRole.AMPLITUDE,
+            domain=ParameterDomain.FLUX,
+            scale=ParameterScale.LOG,
+        )
 
-    estimate = ParameterEstimate(
-        spec=spec,
-        value=100.0,
-        constraint=(10.0, 1000.0),
-        value_source="robust_flux_range",
-        constraint_source="robust_flux_range",
-    )
+        estimate = ParameterEstimate(
+            spec=spec,
+            value=100.0,
+            constraint=(10.0, 1000.0),
+            value_source="robust_flux_range",
+            constraint_source="robust_flux_range",
+        )
 
-    estimate.validate()
-
-    assert estimate.name == "mean_module.log_amplitude"
-    assert estimate.value == 100.0
-    assert estimate.constraint == (10.0, 1000.0)
-    assert estimate.value_source == "robust_flux_range"
-
-
-def test_parameter_estimate_rejects_invalid_constraint():
-    spec = ParameterSpec(
-        name="bad_parameter",
-        role=ParameterRole.OTHER,
-        domain=ParameterDomain.OTHER,
-    )
-
-    estimate = ParameterEstimate(
-        spec=spec,
-        value=1.0,
-        constraint=(2.0, 1.0),
-    )
-
-    with pytest.raises(ValueError, match="lower bound"):
         estimate.validate()
 
+        self.assertEqual(estimate.name, "mean_module.log_amplitude")
+        self.assertEqual(estimate.value, 100.0)
+        self.assertEqual(estimate.constraint, (10.0, 1000.0))
+        self.assertEqual(estimate.value_source, "robust_flux_range")
 
-def test_parameter_estimate_rejects_value_outside_constraint():
-    spec = ParameterSpec(
-        name="mean_module.offset",
-        role=ParameterRole.OFFSET,
-        domain=ParameterDomain.FLUX,
-    )
+    def test_parameter_estimate_rejects_invalid_constraint(self):
+        spec = ParameterSpec(
+            name="bad_parameter",
+            role=ParameterRole.OTHER,
+            domain=ParameterDomain.OTHER,
+        )
 
-    estimate = ParameterEstimate(
-        spec=spec,
-        value=100.0,
-        constraint=(-10.0, 10.0),
-    )
+        estimate = ParameterEstimate(
+            spec=spec,
+            value=1.0,
+            constraint=(2.0, 1.0),
+        )
 
-    with pytest.raises(ValueError, match="outside its constraint"):
+        with self.assertRaisesRegex(ValueError, "lower bound"):
+            estimate.validate()
+
+    def test_parameter_estimate_rejects_value_outside_constraint(self):
+        spec = ParameterSpec(
+            name="mean_module.offset",
+            role=ParameterRole.OFFSET,
+            domain=ParameterDomain.FLUX,
+        )
+
+        estimate = ParameterEstimate(
+            spec=spec,
+            value=100.0,
+            constraint=(-10.0, 10.0),
+        )
+
+        with self.assertRaisesRegex(ValueError, "outside its constraint"):
+            estimate.validate()
+
+    def test_parameter_estimate_validates_shape_from_spec(self):
+        spec = ParameterSpec(
+            name="covar_module.mixture_means",
+            role=ParameterRole.FREQUENCY,
+            domain=ParameterDomain.FREQUENCY,
+            shape=(3,),
+        )
+
+        estimate = ParameterEstimate(
+            spec=spec,
+            value=np.array([0.01, 0.02, 0.03]),
+            constraint=(
+                np.array([0.001, 0.001, 0.001]),
+                np.array([0.1, 0.1, 0.1]),
+            ),
+        )
+
         estimate.validate()
 
+    def test_parameter_estimate_rejects_wrong_shape(self):
+        spec = ParameterSpec(
+            name="covar_module.mixture_means",
+            role=ParameterRole.FREQUENCY,
+            domain=ParameterDomain.FREQUENCY,
+            shape=(3,),
+        )
 
-def test_parameter_estimate_validates_shape_from_spec():
-    spec = ParameterSpec(
-        name="covar_module.mixture_means",
-        role=ParameterRole.FREQUENCY,
-        domain=ParameterDomain.FREQUENCY,
-        shape=(3,),
-    )
+        estimate = ParameterEstimate(
+            spec=spec,
+            value=np.array([0.01, 0.02]),
+        )
 
-    estimate = ParameterEstimate(
-        spec=spec,
-        value=np.array([0.01, 0.02, 0.03]),
-        constraint=(
-            np.array([0.001, 0.001, 0.001]),
-            np.array([0.1, 0.1, 0.1]),
-        ),
-    )
+        with self.assertRaisesRegex(ValueError, "Shape mismatch"):
+            estimate.validate()
 
-    estimate.validate()
+    def test_parameter_estimate_collection_rejects_duplicate_names(self):
+        spec = ParameterSpec(
+            name="same",
+            role=ParameterRole.OTHER,
+            domain=ParameterDomain.OTHER,
+        )
 
+        estimate = ParameterEstimate(spec=spec)
 
-def test_parameter_estimate_rejects_wrong_shape():
-    spec = ParameterSpec(
-        name="covar_module.mixture_means",
-        role=ParameterRole.FREQUENCY,
-        domain=ParameterDomain.FREQUENCY,
-        shape=(3,),
-    )
+        with self.assertRaisesRegex(ValueError, "duplicate"):
+            ParameterEstimateCollection([estimate, estimate])
 
-    estimate = ParameterEstimate(
-        spec=spec,
-        value=np.array([0.01, 0.02]),
-    )
+    def test_parameter_estimate_collection_lookup_and_add(self):
+        spec = ParameterSpec(
+            name="mean_module.offset",
+            role=ParameterRole.OFFSET,
+            domain=ParameterDomain.FLUX,
+        )
 
-    with pytest.raises(ValueError, match="Shape mismatch"):
-        estimate.validate()
+        estimate = ParameterEstimate(
+            spec=spec,
+            value=100.0,
+            constraint=(-1000.0, 1000.0),
+        )
 
+        collection = ParameterEstimateCollection()
+        collection.add(estimate)
 
-def test_parameter_estimate_collection_rejects_duplicate_names():
-    spec = ParameterSpec(
-        name="same",
-        role=ParameterRole.OTHER,
-        domain=ParameterDomain.OTHER,
-    )
-
-    estimate = ParameterEstimate(spec=spec)
-
-    with pytest.raises(ValueError, match="duplicate"):
-        ParameterEstimateCollection([estimate, estimate])
-
-
-def test_parameter_estimate_collection_lookup_and_add():
-    spec = ParameterSpec(
-        name="mean_module.offset",
-        role=ParameterRole.OFFSET,
-        domain=ParameterDomain.FLUX,
-    )
-
-    estimate = ParameterEstimate(
-        spec=spec,
-        value=100.0,
-        constraint=(-1000.0, 1000.0),
-    )
-
-    collection = ParameterEstimateCollection()
-    collection.add(estimate)
-
-    assert "mean_module.offset" in collection
-    assert collection["mean_module.offset"] is estimate
-    assert collection.names() == ["mean_module.offset"]
-    assert collection.as_dict()["mean_module.offset"] is estimate
+        self.assertIn("mean_module.offset", collection)
+        self.assertIs(collection["mean_module.offset"], estimate)
+        self.assertEqual(collection.names(), ["mean_module.offset"])
+        self.assertIs(collection.as_dict()["mean_module.offset"], estimate)

--- a/tests/test_parameter_estimates.py
+++ b/tests/test_parameter_estimates.py
@@ -1,0 +1,143 @@
+import numpy as np
+import pytest
+
+from pgmuvi.parameter_estimates import (
+    ParameterEstimate,
+    ParameterEstimateCollection,
+)
+from pgmuvi.parameter_specs import (
+    ParameterDomain,
+    ParameterRole,
+    ParameterScale,
+    ParameterSpec,
+)
+
+
+def test_parameter_estimate_stores_value_and_constraint():
+    spec = ParameterSpec(
+        name="mean_module.log_amplitude",
+        role=ParameterRole.AMPLITUDE,
+        domain=ParameterDomain.FLUX,
+        scale=ParameterScale.LOG,
+    )
+
+    estimate = ParameterEstimate(
+        spec=spec,
+        value=100.0,
+        constraint=(10.0, 1000.0),
+        value_source="robust_flux_range",
+        constraint_source="robust_flux_range",
+    )
+
+    estimate.validate()
+
+    assert estimate.name == "mean_module.log_amplitude"
+    assert estimate.value == 100.0
+    assert estimate.constraint == (10.0, 1000.0)
+    assert estimate.value_source == "robust_flux_range"
+
+
+def test_parameter_estimate_rejects_invalid_constraint():
+    spec = ParameterSpec(
+        name="bad_parameter",
+        role=ParameterRole.OTHER,
+        domain=ParameterDomain.OTHER,
+    )
+
+    estimate = ParameterEstimate(
+        spec=spec,
+        value=1.0,
+        constraint=(2.0, 1.0),
+    )
+
+    with pytest.raises(ValueError, match="lower bound"):
+        estimate.validate()
+
+
+def test_parameter_estimate_rejects_value_outside_constraint():
+    spec = ParameterSpec(
+        name="mean_module.offset",
+        role=ParameterRole.OFFSET,
+        domain=ParameterDomain.FLUX,
+    )
+
+    estimate = ParameterEstimate(
+        spec=spec,
+        value=100.0,
+        constraint=(-10.0, 10.0),
+    )
+
+    with pytest.raises(ValueError, match="outside its constraint"):
+        estimate.validate()
+
+
+def test_parameter_estimate_validates_shape_from_spec():
+    spec = ParameterSpec(
+        name="covar_module.mixture_means",
+        role=ParameterRole.FREQUENCY,
+        domain=ParameterDomain.FREQUENCY,
+        shape=(3,),
+    )
+
+    estimate = ParameterEstimate(
+        spec=spec,
+        value=np.array([0.01, 0.02, 0.03]),
+        constraint=(
+            np.array([0.001, 0.001, 0.001]),
+            np.array([0.1, 0.1, 0.1]),
+        ),
+    )
+
+    estimate.validate()
+
+
+def test_parameter_estimate_rejects_wrong_shape():
+    spec = ParameterSpec(
+        name="covar_module.mixture_means",
+        role=ParameterRole.FREQUENCY,
+        domain=ParameterDomain.FREQUENCY,
+        shape=(3,),
+    )
+
+    estimate = ParameterEstimate(
+        spec=spec,
+        value=np.array([0.01, 0.02]),
+    )
+
+    with pytest.raises(ValueError, match="Shape mismatch"):
+        estimate.validate()
+
+
+def test_parameter_estimate_collection_rejects_duplicate_names():
+    spec = ParameterSpec(
+        name="same",
+        role=ParameterRole.OTHER,
+        domain=ParameterDomain.OTHER,
+    )
+
+    estimate = ParameterEstimate(spec=spec)
+
+    with pytest.raises(ValueError, match="duplicate"):
+        ParameterEstimateCollection([estimate, estimate])
+
+
+def test_parameter_estimate_collection_lookup_and_add():
+    spec = ParameterSpec(
+        name="mean_module.offset",
+        role=ParameterRole.OFFSET,
+        domain=ParameterDomain.FLUX,
+    )
+
+    estimate = ParameterEstimate(
+        spec=spec,
+        value=100.0,
+        constraint=(-1000.0, 1000.0),
+    )
+
+    collection = ParameterEstimateCollection()
+    collection.add(estimate)
+
+    assert "mean_module.offset" in collection
+    assert collection["mean_module.offset"] is estimate
+    assert collection.names() == ["mean_module.offset"]
+    assert collection.as_dict()["mean_module.offset"] is estimate

--- a/tests/test_parameter_specs.py
+++ b/tests/test_parameter_specs.py
@@ -7,6 +7,8 @@ from pgmuvi.parameter_specs import (
     ParameterScale,
     ParameterSpec,
     ParameterSpecCollection,
+    GuessStrategy,
+    ConstraintStrategy,
 )
 
 
@@ -110,3 +112,20 @@ def test_parameter_spec_collection_lookup_and_add():
     assert "mean_module.offset" in collection
     assert collection["mean_module.offset"] is spec
     assert collection.names() == ["mean_module.offset"]
+
+
+def test_parameter_spec_accepts_strategy_metadata():
+    spec = ParameterSpec(
+        name="mean_module.log_tau",
+        role=ParameterRole.TIMESCALE,
+        domain=ParameterDomain.TIME,
+        scale=ParameterScale.LOG,
+        guess_strategy=GuessStrategy.VARIABILITY_TIMESCALE,
+        constraint_strategy=ConstraintStrategy.VARIABILITY_TIMESCALE,
+    )
+
+    assert spec.guess_strategy is GuessStrategy.VARIABILITY_TIMESCALE
+    assert (
+        spec.constraint_strategy
+        is ConstraintStrategy.VARIABILITY_TIMESCALE
+    )

--- a/tests/test_parameter_specs.py
+++ b/tests/test_parameter_specs.py
@@ -1,145 +1,141 @@
 import numpy as np
-import pytest
+import unittest
 
 from pgmuvi.parameter_specs import (
+    ConstraintStrategy,
+    GuessStrategy,
     ParameterDomain,
     ParameterRole,
     ParameterScale,
     ParameterSpec,
     ParameterSpecCollection,
-    GuessStrategy,
-    ConstraintStrategy,
 )
 
 
-def test_parameter_spec_accepts_physical_space_values():
-    spec = ParameterSpec(
-        name="mean_module.log_tau",
-        role=ParameterRole.TIMESCALE,
-        domain=ParameterDomain.TIME,
-        scale=ParameterScale.LOG,
-        initial_value=250.0,
-        constraint=(50.0, 2000.0),
-        units="days",
-        description="Characteristic variability timescale in physical time units.",
-    )
+class TestParameterSpecs(unittest.TestCase):
+    def test_parameter_spec_accepts_physical_space_values(self):
+        spec = ParameterSpec(
+            name="mean_module.log_tau",
+            role=ParameterRole.TIMESCALE,
+            domain=ParameterDomain.TIME,
+            scale=ParameterScale.LOG,
+            initial_value=250.0,
+            constraint=(50.0, 2000.0),
+            units="days",
+            description="Characteristic variability timescale in physical time units.",
+        )
 
-    spec.validate()
-
-    assert spec.initial_value == 250.0
-    assert spec.constraint == (50.0, 2000.0)
-    assert spec.scale is ParameterScale.LOG
-    assert spec.description is not None
-
-
-def test_parameter_spec_rejects_initial_value_outside_constraint():
-    spec = ParameterSpec(
-        name="mean_module.log_amplitude",
-        role=ParameterRole.AMPLITUDE,
-        domain=ParameterDomain.FLUX,
-        scale=ParameterScale.LOG,
-        initial_value=7.3,
-        constraint=(10.0, 100.0),
-    )
-
-    with pytest.raises(ValueError, match="outside its constraint"):
         spec.validate()
 
+        self.assertEqual(spec.initial_value, 250.0)
+        self.assertEqual(spec.constraint, (50.0, 2000.0))
+        self.assertIs(spec.scale, ParameterScale.LOG)
+        self.assertIsNotNone(spec.description)
 
-def test_parameter_spec_rejects_invalid_constraint():
-    spec = ParameterSpec(
-        name="bad_parameter",
-        role=ParameterRole.OTHER,
-        domain=ParameterDomain.OTHER,
-        initial_value=1.0,
-        constraint=(2.0, 1.0),
-    )
+    def test_parameter_spec_rejects_initial_value_outside_constraint(self):
+        spec = ParameterSpec(
+            name="mean_module.log_amplitude",
+            role=ParameterRole.AMPLITUDE,
+            domain=ParameterDomain.FLUX,
+            scale=ParameterScale.LOG,
+            initial_value=7.3,
+            constraint=(10.0, 100.0),
+        )
 
-    with pytest.raises(ValueError, match="lower bound"):
+        with self.assertRaisesRegex(ValueError, "outside its constraint"):
+            spec.validate()
+
+    def test_parameter_spec_rejects_invalid_constraint(self):
+        spec = ParameterSpec(
+            name="bad_parameter",
+            role=ParameterRole.OTHER,
+            domain=ParameterDomain.OTHER,
+            initial_value=1.0,
+            constraint=(2.0, 1.0),
+        )
+
+        with self.assertRaisesRegex(ValueError, "lower bound"):
+            spec.validate()
+
+    def test_parameter_spec_validates_array_shape(self):
+        spec = ParameterSpec(
+            name="covar_module.mixture_means",
+            role=ParameterRole.FREQUENCY,
+            domain=ParameterDomain.FREQUENCY,
+            initial_value=np.array([0.01, 0.02, 0.03]),
+            constraint=(
+                np.array([0.005, 0.005, 0.005]),
+                np.array([0.05, 0.05, 0.05]),
+            ),
+            shape=(3,),
+        )
+
         spec.validate()
 
+    def test_parameter_spec_rejects_wrong_array_shape(self):
+        spec = ParameterSpec(
+            name="covar_module.mixture_means",
+            role=ParameterRole.FREQUENCY,
+            domain=ParameterDomain.FREQUENCY,
+            initial_value=np.array([0.01, 0.02]),
+            shape=(3,),
+        )
 
-def test_parameter_spec_validates_array_shape():
-    spec = ParameterSpec(
-        name="covar_module.mixture_means",
-        role=ParameterRole.FREQUENCY,
-        domain=ParameterDomain.FREQUENCY,
-        initial_value=np.array([0.01, 0.02, 0.03]),
-        constraint=(np.array([0.005, 0.005, 0.005]), np.array([0.05, 0.05, 0.05])),
-        shape=(3,),
-    )
+        with self.assertRaisesRegex(ValueError, "Shape mismatch"):
+            spec.validate()
 
-    spec.validate()
+    def test_parameter_spec_collection_rejects_duplicate_names(self):
+        spec = ParameterSpec(
+            name="same",
+            role=ParameterRole.OTHER,
+            domain=ParameterDomain.OTHER,
+        )
 
+        with self.assertRaisesRegex(ValueError, "duplicate"):
+            ParameterSpecCollection([spec, spec])
 
-def test_parameter_spec_rejects_wrong_array_shape():
-    spec = ParameterSpec(
-        name="covar_module.mixture_means",
-        role=ParameterRole.FREQUENCY,
-        domain=ParameterDomain.FREQUENCY,
-        initial_value=np.array([0.01, 0.02]),
-        shape=(3,),
-    )
+    def test_parameter_spec_collection_lookup_and_add(self):
+        collection = ParameterSpecCollection()
 
-    with pytest.raises(ValueError, match="Shape mismatch"):
-        spec.validate()
+        spec = ParameterSpec(
+            name="mean_module.offset",
+            role=ParameterRole.OFFSET,
+            domain=ParameterDomain.FLUX,
+            initial_value=100.0,
+            constraint=(-1000.0, 1000.0),
+        )
 
+        collection.add(spec)
 
-def test_parameter_spec_collection_rejects_duplicate_names():
-    spec = ParameterSpec(
-        name="same",
-        role=ParameterRole.OTHER,
-        domain=ParameterDomain.OTHER,
-    )
+        self.assertIn("mean_module.offset", collection)
+        self.assertIs(collection["mean_module.offset"], spec)
+        self.assertEqual(collection.names(), ["mean_module.offset"])
 
-    with pytest.raises(ValueError, match="duplicate"):
-        ParameterSpecCollection([spec, spec])
+    def test_parameter_spec_accepts_strategy_metadata(self):
+        spec = ParameterSpec(
+            name="mean_module.log_tau",
+            role=ParameterRole.TIMESCALE,
+            domain=ParameterDomain.TIME,
+            scale=ParameterScale.LOG,
+            guess_strategy=GuessStrategy.VARIABILITY_TIMESCALE,
+            constraint_strategy=ConstraintStrategy.VARIABILITY_TIMESCALE,
+        )
 
+        self.assertIs(spec.guess_strategy, GuessStrategy.VARIABILITY_TIMESCALE)
+        self.assertIs(
+            spec.constraint_strategy,
+            ConstraintStrategy.VARIABILITY_TIMESCALE,
+        )
 
-def test_parameter_spec_collection_lookup_and_add():
-    collection = ParameterSpecCollection()
+    def test_parameter_spec_supports_fixed_parameters(self):
+        spec = ParameterSpec(
+            name="mean_module.log_alpha",
+            role=ParameterRole.SHAPE,
+            domain=ParameterDomain.DIMENSIONLESS,
+            scale=ParameterScale.LOG,
+            required=True,
+            trainable=False,
+        )
 
-    spec = ParameterSpec(
-        name="mean_module.offset",
-        role=ParameterRole.OFFSET,
-        domain=ParameterDomain.FLUX,
-        initial_value=100.0,
-        constraint=(-1000.0, 1000.0),
-    )
-
-    collection.add(spec)
-
-    assert "mean_module.offset" in collection
-    assert collection["mean_module.offset"] is spec
-    assert collection.names() == ["mean_module.offset"]
-
-
-def test_parameter_spec_accepts_strategy_metadata():
-    spec = ParameterSpec(
-        name="mean_module.log_tau",
-        role=ParameterRole.TIMESCALE,
-        domain=ParameterDomain.TIME,
-        scale=ParameterScale.LOG,
-        guess_strategy=GuessStrategy.VARIABILITY_TIMESCALE,
-        constraint_strategy=ConstraintStrategy.VARIABILITY_TIMESCALE,
-    )
-
-    assert spec.guess_strategy is GuessStrategy.VARIABILITY_TIMESCALE
-    assert (
-        spec.constraint_strategy
-        is ConstraintStrategy.VARIABILITY_TIMESCALE
-    )
-
-
-def test_parameter_spec_supports_fixed_parameters():
-    spec = ParameterSpec(
-        name="mean_module.log_alpha",
-        role=ParameterRole.SHAPE,
-        domain=ParameterDomain.DIMENSIONLESS,
-        scale=ParameterScale.LOG,
-        required=True,
-        trainable=False,
-    )
-
-    assert spec.required is True
-    assert spec.trainable is False
+        self.assertIs(spec.required, True)
+        self.assertIs(spec.trainable, False)

--- a/tests/test_parameter_specs.py
+++ b/tests/test_parameter_specs.py
@@ -1,0 +1,112 @@
+import numpy as np
+import pytest
+
+from pgmuvi.parameter_specs import (
+    ParameterDomain,
+    ParameterRole,
+    ParameterScale,
+    ParameterSpec,
+    ParameterSpecCollection,
+)
+
+
+def test_parameter_spec_accepts_physical_space_values():
+    spec = ParameterSpec(
+        name="mean_module.log_tau",
+        role=ParameterRole.TIMESCALE,
+        domain=ParameterDomain.TIME,
+        scale=ParameterScale.LOG,
+        initial_value=250.0,
+        constraint=(50.0, 2000.0),
+        units="days",
+        description="Characteristic variability timescale in physical time units.",
+    )
+
+    spec.validate()
+
+    assert spec.initial_value == 250.0
+    assert spec.constraint == (50.0, 2000.0)
+    assert spec.scale is ParameterScale.LOG
+    assert spec.description is not None
+
+
+def test_parameter_spec_rejects_initial_value_outside_constraint():
+    spec = ParameterSpec(
+        name="mean_module.log_amplitude",
+        role=ParameterRole.AMPLITUDE,
+        domain=ParameterDomain.FLUX,
+        scale=ParameterScale.LOG,
+        initial_value=7.3,
+        constraint=(10.0, 100.0),
+    )
+
+    with pytest.raises(ValueError, match="outside its constraint"):
+        spec.validate()
+
+
+def test_parameter_spec_rejects_invalid_constraint():
+    spec = ParameterSpec(
+        name="bad_parameter",
+        role=ParameterRole.OTHER,
+        domain=ParameterDomain.OTHER,
+        initial_value=1.0,
+        constraint=(2.0, 1.0),
+    )
+
+    with pytest.raises(ValueError, match="lower bound"):
+        spec.validate()
+
+
+def test_parameter_spec_validates_array_shape():
+    spec = ParameterSpec(
+        name="covar_module.mixture_means",
+        role=ParameterRole.FREQUENCY,
+        domain=ParameterDomain.FREQUENCY,
+        initial_value=np.array([0.01, 0.02, 0.03]),
+        constraint=(np.array([0.005, 0.005, 0.005]), np.array([0.05, 0.05, 0.05])),
+        shape=(3,),
+    )
+
+    spec.validate()
+
+
+def test_parameter_spec_rejects_wrong_array_shape():
+    spec = ParameterSpec(
+        name="covar_module.mixture_means",
+        role=ParameterRole.FREQUENCY,
+        domain=ParameterDomain.FREQUENCY,
+        initial_value=np.array([0.01, 0.02]),
+        shape=(3,),
+    )
+
+    with pytest.raises(ValueError, match="Shape mismatch"):
+        spec.validate()
+
+
+def test_parameter_spec_collection_rejects_duplicate_names():
+    spec = ParameterSpec(
+        name="same",
+        role=ParameterRole.OTHER,
+        domain=ParameterDomain.OTHER,
+    )
+
+    with pytest.raises(ValueError, match="duplicate"):
+        ParameterSpecCollection([spec, spec])
+
+
+def test_parameter_spec_collection_lookup_and_add():
+    collection = ParameterSpecCollection()
+
+    spec = ParameterSpec(
+        name="mean_module.offset",
+        role=ParameterRole.OFFSET,
+        domain=ParameterDomain.FLUX,
+        initial_value=100.0,
+        constraint=(-1000.0, 1000.0),
+    )
+
+    collection.add(spec)
+
+    assert "mean_module.offset" in collection
+    assert collection["mean_module.offset"] is spec
+    assert collection.names() == ["mean_module.offset"]

--- a/tests/test_parameter_specs.py
+++ b/tests/test_parameter_specs.py
@@ -129,3 +129,17 @@ def test_parameter_spec_accepts_strategy_metadata():
         spec.constraint_strategy
         is ConstraintStrategy.VARIABILITY_TIMESCALE
     )
+
+
+def test_parameter_spec_supports_fixed_parameters():
+    spec = ParameterSpec(
+        name="mean_module.log_alpha",
+        role=ParameterRole.SHAPE,
+        domain=ParameterDomain.DIMENSIONLESS,
+        scale=ParameterScale.LOG,
+        required=True,
+        trainable=False,
+    )
+
+    assert spec.required is True
+    assert spec.trainable is False

--- a/tests/test_polynomial_mean_parameter_schema.py
+++ b/tests/test_polynomial_mean_parameter_schema.py
@@ -1,0 +1,59 @@
+from pgmuvi.gps import CustomLinearConstantMean, CustomQuadConstantMean
+from pgmuvi.parameter_specs import ParameterDomain, ParameterRole, ParameterScale
+
+
+def test_custom_linear_constant_mean_schema_names():
+    schema = CustomLinearConstantMean().parameter_schema()
+
+    assert schema.names() == [
+        "mean_module.wavelength_slope",
+        "mean_module.bias",
+    ]
+
+
+def test_custom_linear_constant_mean_schema_semantics():
+    schema = CustomLinearConstantMean().parameter_schema()
+
+    slope = schema["mean_module.wavelength_slope"]
+    bias = schema["mean_module.bias"]
+
+    assert slope.role is ParameterRole.WAVELENGTH_SCALE
+    assert slope.domain is ParameterDomain.FLUX
+    assert slope.scale is ParameterScale.LINEAR
+
+    assert bias.role is ParameterRole.OFFSET
+    assert bias.domain is ParameterDomain.FLUX
+    assert bias.scale is ParameterScale.LINEAR
+
+
+def test_custom_quad_constant_mean_schema_names():
+    schema = CustomQuadConstantMean().parameter_schema()
+
+    assert schema.names() == [
+        "mean_module.weights",
+        "mean_module.bias",
+    ]
+
+
+def test_custom_quad_constant_mean_schema_semantics():
+    schema = CustomQuadConstantMean().parameter_schema()
+
+    weights = schema["mean_module.weights"]
+    bias = schema["mean_module.bias"]
+
+    assert weights.role is ParameterRole.WAVELENGTH_SCALE
+    assert weights.domain is ParameterDomain.FLUX
+    assert weights.scale is ParameterScale.LINEAR
+    assert weights.shape == (2,)
+
+    assert bias.role is ParameterRole.OFFSET
+    assert bias.domain is ParameterDomain.FLUX
+    assert bias.scale is ParameterScale.LINEAR
+
+
+def test_polynomial_mean_schemas_accept_empty_prefix():
+    linear = CustomLinearConstantMean().parameter_schema(prefix="")
+    quadratic = CustomQuadConstantMean().parameter_schema(prefix="")
+
+    assert linear.names() == ["wavelength_slope", "bias"]
+    assert quadratic.names() == ["weights", "bias"]

--- a/tests/test_polynomial_mean_parameter_schema.py
+++ b/tests/test_polynomial_mean_parameter_schema.py
@@ -1,59 +1,64 @@
+import unittest
+
 from pgmuvi.gps import CustomLinearConstantMean, CustomQuadConstantMean
 from pgmuvi.parameter_specs import ParameterDomain, ParameterRole, ParameterScale
 
 
-def test_custom_linear_constant_mean_schema_names():
-    schema = CustomLinearConstantMean().parameter_schema()
+class TestPolynomialMeanParameterSchema(unittest.TestCase):
+    def test_custom_linear_constant_mean_schema_names(self):
+        schema = CustomLinearConstantMean().parameter_schema()
 
-    assert schema.names() == [
-        "mean_module.wavelength_slope",
-        "mean_module.bias",
-    ]
+        self.assertEqual(
+            schema.names(),
+            [
+                "mean_module.wavelength_slope",
+                "mean_module.bias",
+            ],
+        )
 
+    def test_custom_linear_constant_mean_schema_semantics(self):
+        schema = CustomLinearConstantMean().parameter_schema()
 
-def test_custom_linear_constant_mean_schema_semantics():
-    schema = CustomLinearConstantMean().parameter_schema()
+        slope = schema["mean_module.wavelength_slope"]
+        bias = schema["mean_module.bias"]
 
-    slope = schema["mean_module.wavelength_slope"]
-    bias = schema["mean_module.bias"]
+        self.assertIs(slope.role, ParameterRole.WAVELENGTH_SCALE)
+        self.assertIs(slope.domain, ParameterDomain.FLUX)
+        self.assertIs(slope.scale, ParameterScale.LINEAR)
 
-    assert slope.role is ParameterRole.WAVELENGTH_SCALE
-    assert slope.domain is ParameterDomain.FLUX
-    assert slope.scale is ParameterScale.LINEAR
+        self.assertIs(bias.role, ParameterRole.OFFSET)
+        self.assertIs(bias.domain, ParameterDomain.FLUX)
+        self.assertIs(bias.scale, ParameterScale.LINEAR)
 
-    assert bias.role is ParameterRole.OFFSET
-    assert bias.domain is ParameterDomain.FLUX
-    assert bias.scale is ParameterScale.LINEAR
+    def test_custom_quad_constant_mean_schema_names(self):
+        schema = CustomQuadConstantMean().parameter_schema()
 
+        self.assertEqual(
+            schema.names(),
+            [
+                "mean_module.weights",
+                "mean_module.bias",
+            ],
+        )
 
-def test_custom_quad_constant_mean_schema_names():
-    schema = CustomQuadConstantMean().parameter_schema()
+    def test_custom_quad_constant_mean_schema_semantics(self):
+        schema = CustomQuadConstantMean().parameter_schema()
 
-    assert schema.names() == [
-        "mean_module.weights",
-        "mean_module.bias",
-    ]
+        weights = schema["mean_module.weights"]
+        bias = schema["mean_module.bias"]
 
+        self.assertIs(weights.role, ParameterRole.WAVELENGTH_SCALE)
+        self.assertIs(weights.domain, ParameterDomain.FLUX)
+        self.assertIs(weights.scale, ParameterScale.LINEAR)
+        self.assertEqual(weights.shape, (2,))
 
-def test_custom_quad_constant_mean_schema_semantics():
-    schema = CustomQuadConstantMean().parameter_schema()
+        self.assertIs(bias.role, ParameterRole.OFFSET)
+        self.assertIs(bias.domain, ParameterDomain.FLUX)
+        self.assertIs(bias.scale, ParameterScale.LINEAR)
 
-    weights = schema["mean_module.weights"]
-    bias = schema["mean_module.bias"]
+    def test_polynomial_mean_schemas_accept_empty_prefix(self):
+        linear = CustomLinearConstantMean().parameter_schema(prefix="")
+        quadratic = CustomQuadConstantMean().parameter_schema(prefix="")
 
-    assert weights.role is ParameterRole.WAVELENGTH_SCALE
-    assert weights.domain is ParameterDomain.FLUX
-    assert weights.scale is ParameterScale.LINEAR
-    assert weights.shape == (2,)
-
-    assert bias.role is ParameterRole.OFFSET
-    assert bias.domain is ParameterDomain.FLUX
-    assert bias.scale is ParameterScale.LINEAR
-
-
-def test_polynomial_mean_schemas_accept_empty_prefix():
-    linear = CustomLinearConstantMean().parameter_schema(prefix="")
-    quadratic = CustomQuadConstantMean().parameter_schema(prefix="")
-
-    assert linear.names() == ["wavelength_slope", "bias"]
-    assert quadratic.names() == ["weights", "bias"]
+        self.assertEqual(linear.names(), ["wavelength_slope", "bias"])
+        self.assertEqual(quadratic.names(), ["weights", "bias"])

--- a/tests/test_power_law_mean_parameter_schema.py
+++ b/tests/test_power_law_mean_parameter_schema.py
@@ -1,0 +1,42 @@
+from pgmuvi.gps import PowerLawMean
+from pgmuvi.parameter_specs import ParameterDomain, ParameterRole, ParameterScale
+
+
+def test_power_law_mean_parameter_schema_names():
+    schema = PowerLawMean().parameter_schema()
+
+    assert schema.names() == [
+        "mean_module.offset",
+        "mean_module.weight",
+        "mean_module.exponent",
+    ]
+
+
+def test_power_law_mean_parameter_schema_semantics():
+    schema = PowerLawMean().parameter_schema()
+
+    offset = schema["mean_module.offset"]
+    weight = schema["mean_module.weight"]
+    exponent = schema["mean_module.exponent"]
+
+    assert offset.role is ParameterRole.OFFSET
+    assert offset.domain is ParameterDomain.FLUX
+    assert offset.scale is ParameterScale.LINEAR
+
+    assert weight.role is ParameterRole.AMPLITUDE
+    assert weight.domain is ParameterDomain.FLUX
+    assert weight.scale is ParameterScale.LINEAR
+
+    assert exponent.role is ParameterRole.SHAPE
+    assert exponent.domain is ParameterDomain.DIMENSIONLESS
+    assert exponent.scale is ParameterScale.LINEAR
+
+
+def test_power_law_mean_parameter_schema_accepts_empty_prefix():
+    schema = PowerLawMean().parameter_schema(prefix="")
+
+    assert schema.names() == [
+        "offset",
+        "weight",
+        "exponent",
+    ]

--- a/tests/test_power_law_mean_parameter_schema.py
+++ b/tests/test_power_law_mean_parameter_schema.py
@@ -1,42 +1,49 @@
+import unittest
+
 from pgmuvi.gps import PowerLawMean
 from pgmuvi.parameter_specs import ParameterDomain, ParameterRole, ParameterScale
 
 
-def test_power_law_mean_parameter_schema_names():
-    schema = PowerLawMean().parameter_schema()
+class TestPowerLawMeanParameterSchema(unittest.TestCase):
+    def test_power_law_mean_parameter_schema_names(self):
+        schema = PowerLawMean().parameter_schema()
 
-    assert schema.names() == [
-        "mean_module.offset",
-        "mean_module.weight",
-        "mean_module.exponent",
-    ]
+        self.assertEqual(
+            schema.names(),
+            [
+                "mean_module.offset",
+                "mean_module.weight",
+                "mean_module.exponent",
+            ],
+        )
 
+    def test_power_law_mean_parameter_schema_semantics(self):
+        schema = PowerLawMean().parameter_schema()
 
-def test_power_law_mean_parameter_schema_semantics():
-    schema = PowerLawMean().parameter_schema()
+        offset = schema["mean_module.offset"]
+        weight = schema["mean_module.weight"]
+        exponent = schema["mean_module.exponent"]
 
-    offset = schema["mean_module.offset"]
-    weight = schema["mean_module.weight"]
-    exponent = schema["mean_module.exponent"]
+        self.assertIs(offset.role, ParameterRole.OFFSET)
+        self.assertIs(offset.domain, ParameterDomain.FLUX)
+        self.assertIs(offset.scale, ParameterScale.LINEAR)
 
-    assert offset.role is ParameterRole.OFFSET
-    assert offset.domain is ParameterDomain.FLUX
-    assert offset.scale is ParameterScale.LINEAR
+        self.assertIs(weight.role, ParameterRole.AMPLITUDE)
+        self.assertIs(weight.domain, ParameterDomain.FLUX)
+        self.assertIs(weight.scale, ParameterScale.LINEAR)
 
-    assert weight.role is ParameterRole.AMPLITUDE
-    assert weight.domain is ParameterDomain.FLUX
-    assert weight.scale is ParameterScale.LINEAR
+        self.assertIs(exponent.role, ParameterRole.SHAPE)
+        self.assertIs(exponent.domain, ParameterDomain.DIMENSIONLESS)
+        self.assertIs(exponent.scale, ParameterScale.LINEAR)
 
-    assert exponent.role is ParameterRole.SHAPE
-    assert exponent.domain is ParameterDomain.DIMENSIONLESS
-    assert exponent.scale is ParameterScale.LINEAR
+    def test_power_law_mean_parameter_schema_accepts_empty_prefix(self):
+        schema = PowerLawMean().parameter_schema(prefix="")
 
-
-def test_power_law_mean_parameter_schema_accepts_empty_prefix():
-    schema = PowerLawMean().parameter_schema(prefix="")
-
-    assert schema.names() == [
-        "offset",
-        "weight",
-        "exponent",
-    ]
+        self.assertEqual(
+            schema.names(),
+            [
+                "offset",
+                "weight",
+                "exponent",
+            ],
+        )


### PR DESCRIPTION
This PR introduces the initial infrastructure for a model-independent
parameter specification and estimation framework.

Changes include:

- ParameterSpec and ParameterSpecCollection
- GuessStrategy and ConstraintStrategy definitions
- ParameterEstimationContext and diagnostic containers
- ParameterEstimate and ParameterEstimateCollection
- Required/trainable parameter metadata
- Model-owned parameter schemas for:
  - DustMean
  - PowerLawMean
  - CustomLinearConstantMean
  - CustomQuadConstantMean

The framework is intentionally limited to parameter description and
representation. No fitting behaviour is changed and no parameter
initialization or constraint generation logic is introduced yet.

Future PRs will build on this infrastructure to support model-independent
guess and constraint construction from light-curve diagnostics.