### PR TITLE
Add kernel parameter schemas

### DIFF
--- a/pgmuvi/gps.py
+++ b/pgmuvi/gps.py
@@ -39,6 +39,52 @@ _LOG_1_7 = math.log(1.7)
 # ---------------------------------------------------------------------
 # Parameter schema helpers
 # ---------------------------------------------------------------------
+def rq_kernel_parameter_schema(
+    prefix="covar_module",
+    *,
+    domain,
+    description_context=None,
+):
+    """Return model-independent parameter specifications for an RQ kernel."""
+
+    if domain not in {ParameterDomain.TIME, ParameterDomain.WAVELENGTH}:
+        raise ValueError(
+            "rq_kernel_parameter_schema requires domain to be "
+            "ParameterDomain.TIME or ParameterDomain.WAVELENGTH."
+        )
+
+    def name(local_name):
+        return f"{prefix}.{local_name}" if prefix else local_name
+
+    if description_context is None:
+        description_context = domain.value
+
+    return ParameterSpecCollection(
+        [
+            ParameterSpec(
+                name=name("lengthscale"),
+                role=ParameterRole.LENGTHSCALE,
+                domain=domain,
+                scale=ParameterScale.LOG,
+                description=(
+                    "Positive correlation lengthscale of the Rational Quadratic "
+                    f"kernel in {description_context} space."
+                ),
+            ),
+            ParameterSpec(
+                name=name("alpha"),
+                role=ParameterRole.SHAPE,
+                domain=ParameterDomain.DIMENSIONLESS,
+                scale=ParameterScale.LOG,
+                description=(
+                    "Positive Rational Quadratic shape parameter controlling "
+                    "the mixture of correlation scales."
+                ),
+            ),
+        ]
+    )
+
+
 def lengthscale_kernel_parameter_schema(
     prefix="covar_module",
     *,

--- a/pgmuvi/gps.py
+++ b/pgmuvi/gps.py
@@ -39,6 +39,41 @@ _LOG_1_7 = math.log(1.7)
 # ---------------------------------------------------------------------
 # Parameter schema helpers
 # ---------------------------------------------------------------------
+def lengthscale_kernel_parameter_schema(
+    prefix="covar_module",
+    *,
+    domain,
+    description_context=None,
+):
+    """Return model-independent parameter specifications for a kernel lengthscale."""
+    if domain not in {ParameterDomain.TIME, ParameterDomain.WAVELENGTH}:
+        raise ValueError(
+            "lengthscale_kernel_parameter_schema requires domain to be "
+            "ParameterDomain.TIME or ParameterDomain.WAVELENGTH."
+        )
+
+    def name(local_name):
+        return f"{prefix}.{local_name}" if prefix else local_name
+
+    if description_context is None:
+        description_context = domain.value
+
+    return ParameterSpecCollection(
+        [
+            ParameterSpec(
+                name=name("lengthscale"),
+                role=ParameterRole.LENGTHSCALE,
+                domain=domain,
+                scale=ParameterScale.LOG,
+                description=(
+                    "Positive correlation lengthscale of the kernel in "
+                    f"{description_context} space."
+                ),
+            ),
+        ]
+    )
+
+
 def scale_kernel_parameter_schema(prefix="covar_module"):
     """Return model-independent parameter specifications for a ScaleKernel."""
 

--- a/pgmuvi/gps.py
+++ b/pgmuvi/gps.py
@@ -134,7 +134,8 @@ def scale_kernel_parameter_schema(prefix="covar_module"):
                 domain=ParameterDomain.VARIANCE,
                 scale=ParameterScale.LOG,
                 description=(
-                    "Positive covariance-amplitude scale factor multiplying the base kernel."
+                    "Positive covariance-amplitude scale factor multiplying the base "
+                    "kernel."
                 ),
             ),
         ]

--- a/pgmuvi/gps.py
+++ b/pgmuvi/gps.py
@@ -36,6 +36,59 @@ from pgmuvi.parameter_specs import (
 _LOG_1_7 = math.log(1.7)
 
 
+# ---------------------------------------------------------------------
+# Parameter schema helpers
+# ---------------------------------------------------------------------
+def spectral_mixture_parameter_schema(prefix="covar_module", num_mixtures=None):
+    """Return model-independent parameter specifications for a spectral-mixture kernel."""
+
+    def name(local_name):
+        return f"{prefix}.{local_name}" if prefix else local_name
+
+    shape = None if num_mixtures is None else (num_mixtures,)
+
+    return ParameterSpecCollection(
+        [
+            ParameterSpec(
+                name=name("mixture_means"),
+                role=ParameterRole.FREQUENCY,
+                domain=ParameterDomain.FREQUENCY,
+                scale=ParameterScale.LINEAR,
+                shape=shape,
+                description=(
+                    "Central frequencies of the spectral-mixture components. "
+                    "Period diagnostics should be converted to frequencies before "
+                    "constructing estimates for this parameter."
+                ),
+            ),
+            ParameterSpec(
+                name=name("mixture_scales"),
+                role=ParameterRole.LENGTHSCALE,
+                domain=ParameterDomain.FREQUENCY,
+                scale=ParameterScale.LOG,
+                shape=shape,
+                description=(
+                    "Positive frequency-space widths of the spectral-mixture components."
+                ),
+            ),
+            ParameterSpec(
+                name=name("mixture_weights"),
+                role=ParameterRole.WEIGHT,
+                domain=ParameterDomain.VARIANCE,
+                scale=ParameterScale.LOG,
+                shape=shape,
+                description=(
+                    "Positive variance contributions of the spectral-mixture components, "
+                    "equivalent to integrated PSD power up to kernel convention factors."
+                ),
+            ),
+        ]
+    )
+
+
+# ---------------------------------------------------------------------
+# Mean functions
+# ---------------------------------------------------------------------
 class PowerLawMean(gpt.means.Mean):
     """Mean function with power-law wavelength dependence for 2D GP models.
 

--- a/pgmuvi/gps.py
+++ b/pgmuvi/gps.py
@@ -39,6 +39,27 @@ _LOG_1_7 = math.log(1.7)
 # ---------------------------------------------------------------------
 # Parameter schema helpers
 # ---------------------------------------------------------------------
+def scale_kernel_parameter_schema(prefix="covar_module"):
+    """Return model-independent parameter specifications for a ScaleKernel."""
+
+    def name(local_name):
+        return f"{prefix}.{local_name}" if prefix else local_name
+
+    return ParameterSpecCollection(
+        [
+            ParameterSpec(
+                name=name("outputscale"),
+                role=ParameterRole.WEIGHT,
+                domain=ParameterDomain.VARIANCE,
+                scale=ParameterScale.LOG,
+                description=(
+                    "Positive covariance-amplitude scale factor multiplying the base kernel."
+                ),
+            ),
+        ]
+    )
+
+
 def spectral_mixture_parameter_schema(prefix="covar_module", num_mixtures=None):
     """Return model-independent parameter specifications for a spectral-mixture kernel."""
 

--- a/tests/test_lengthscale_kernel_parameter_schema.py
+++ b/tests/test_lengthscale_kernel_parameter_schema.py
@@ -1,0 +1,57 @@
+import unittest
+
+from pgmuvi.gps import lengthscale_kernel_parameter_schema
+from pgmuvi.parameter_specs import (
+    ParameterDomain,
+    ParameterRole,
+    ParameterScale,
+)
+
+
+class TestLengthscaleKernelParameterSchema(unittest.TestCase):
+
+    def test_time_lengthscale_schema(self):
+        schema = lengthscale_kernel_parameter_schema(
+            prefix="time_kernel",
+            domain=ParameterDomain.TIME,
+        )
+
+        self.assertEqual(schema.names(), ["time_kernel.lengthscale"])
+
+        lengthscale = schema["time_kernel.lengthscale"]
+
+        self.assertIs(lengthscale.role, ParameterRole.LENGTHSCALE)
+        self.assertIs(lengthscale.domain, ParameterDomain.TIME)
+        self.assertIs(lengthscale.scale, ParameterScale.LOG)
+
+    def test_wavelength_lengthscale_schema(self):
+        schema = lengthscale_kernel_parameter_schema(
+            prefix="wavelength_kernel",
+            domain=ParameterDomain.WAVELENGTH,
+        )
+
+        self.assertEqual(schema.names(), ["wavelength_kernel.lengthscale"])
+
+        lengthscale = schema["wavelength_kernel.lengthscale"]
+
+        self.assertIs(lengthscale.role, ParameterRole.LENGTHSCALE)
+        self.assertIs(lengthscale.domain, ParameterDomain.WAVELENGTH)
+        self.assertIs(lengthscale.scale, ParameterScale.LOG)
+
+    def test_accepts_empty_prefix(self):
+        schema = lengthscale_kernel_parameter_schema(
+            prefix="",
+            domain=ParameterDomain.TIME,
+        )
+
+        self.assertEqual(schema.names(), ["lengthscale"])
+
+    def test_rejects_invalid_domain(self):
+        with self.assertRaisesRegex(ValueError, "requires domain"):
+            lengthscale_kernel_parameter_schema(
+                domain=ParameterDomain.FLUX,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rq_kernel_parameter_schema.py
+++ b/tests/test_rq_kernel_parameter_schema.py
@@ -1,0 +1,70 @@
+import unittest
+
+from pgmuvi.gps import rq_kernel_parameter_schema
+from pgmuvi.parameter_specs import (
+    ParameterDomain,
+    ParameterRole,
+    ParameterScale,
+)
+
+
+class TestRQKernelParameterSchema(unittest.TestCase):
+
+    def test_time_domain_schema(self):
+        schema = rq_kernel_parameter_schema(
+            prefix="time_kernel",
+            domain=ParameterDomain.TIME,
+        )
+
+        self.assertEqual(
+            schema.names(),
+            [
+                "time_kernel.lengthscale",
+                "time_kernel.alpha",
+            ],
+        )
+
+        lengthscale = schema["time_kernel.lengthscale"]
+        alpha = schema["time_kernel.alpha"]
+
+        self.assertIs(lengthscale.role, ParameterRole.LENGTHSCALE)
+        self.assertIs(lengthscale.domain, ParameterDomain.TIME)
+        self.assertIs(lengthscale.scale, ParameterScale.LOG)
+
+        self.assertIs(alpha.role, ParameterRole.SHAPE)
+        self.assertIs(alpha.domain, ParameterDomain.DIMENSIONLESS)
+        self.assertIs(alpha.scale, ParameterScale.LOG)
+
+    def test_wavelength_domain_schema(self):
+        schema = rq_kernel_parameter_schema(
+            prefix="wavelength_kernel",
+            domain=ParameterDomain.WAVELENGTH,
+        )
+
+        lengthscale = schema["wavelength_kernel.lengthscale"]
+
+        self.assertIs(lengthscale.domain, ParameterDomain.WAVELENGTH)
+
+    def test_accepts_empty_prefix(self):
+        schema = rq_kernel_parameter_schema(
+            prefix="",
+            domain=ParameterDomain.TIME,
+        )
+
+        self.assertEqual(
+            schema.names(),
+            [
+                "lengthscale",
+                "alpha",
+            ],
+        )
+
+    def test_rejects_invalid_domain(self):
+        with self.assertRaisesRegex(ValueError, "requires domain"):
+            rq_kernel_parameter_schema(
+                domain=ParameterDomain.FLUX,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scale_kernel_parameter_schema.py
+++ b/tests/test_scale_kernel_parameter_schema.py
@@ -1,0 +1,37 @@
+import unittest
+
+from pgmuvi.gps import scale_kernel_parameter_schema
+from pgmuvi.parameter_specs import (
+    ParameterDomain,
+    ParameterRole,
+    ParameterScale,
+)
+
+
+class TestScaleKernelParameterSchema(unittest.TestCase):
+
+    def test_names(self):
+        schema = scale_kernel_parameter_schema()
+
+        self.assertEqual(
+            schema.names(),
+            ["covar_module.outputscale"],
+        )
+
+    def test_semantics(self):
+        schema = scale_kernel_parameter_schema()
+
+        outputscale = schema["covar_module.outputscale"]
+
+        self.assertIs(outputscale.role, ParameterRole.WEIGHT)
+        self.assertIs(outputscale.domain, ParameterDomain.VARIANCE)
+        self.assertIs(outputscale.scale, ParameterScale.LOG)
+
+    def test_accepts_empty_prefix(self):
+        schema = scale_kernel_parameter_schema(prefix="")
+
+        self.assertEqual(schema.names(), ["outputscale"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_spectral_mixture_parameter_schema.py
+++ b/tests/test_spectral_mixture_parameter_schema.py
@@ -1,0 +1,49 @@
+import unittest
+
+from pgmuvi.gps import spectral_mixture_parameter_schema
+from pgmuvi.parameter_specs import (
+    ParameterDomain,
+    ParameterRole,
+    ParameterScale,
+)
+
+
+class TestSpectralMixtureParameterSchema(unittest.TestCase):
+
+    def test_names(self):
+        schema = spectral_mixture_parameter_schema()
+
+        self.assertEqual(
+            schema.names(),
+            [
+                "covar_module.mixture_means",
+                "covar_module.mixture_scales",
+                "covar_module.mixture_weights",
+            ],
+        )
+
+    def test_semantics(self):
+        schema = spectral_mixture_parameter_schema(num_mixtures=3)
+
+        means = schema["covar_module.mixture_means"]
+        scales = schema["covar_module.mixture_scales"]
+        weights = schema["covar_module.mixture_weights"]
+
+        self.assertIs(means.role, ParameterRole.FREQUENCY)
+        self.assertIs(means.domain, ParameterDomain.FREQUENCY)
+        self.assertIs(means.scale, ParameterScale.LINEAR)
+        self.assertEqual(means.shape, (3,))
+
+        self.assertIs(scales.role, ParameterRole.LENGTHSCALE)
+        self.assertIs(scales.domain, ParameterDomain.FREQUENCY)
+        self.assertIs(scales.scale, ParameterScale.LOG)
+        self.assertEqual(scales.shape, (3,))
+
+        self.assertIs(weights.role, ParameterRole.WEIGHT)
+        self.assertIs(weights.domain, ParameterDomain.VARIANCE)
+        self.assertIs(weights.scale, ParameterScale.LOG)
+        self.assertEqual(weights.shape, (3,))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add model-independent parameter schema definitions for the primary GP
kernel parameter families used throughout PGMUVI.

This PR extends the parameter-specification framework introduced in
PR1 by adding semantic descriptions for kernel parameters without
changing any fitting behaviour, initialization logic, or constraint
construction.

## Changes

### Spectral Mixture kernel schema

Add schema support for:

- `mixture_means`
- `mixture_scales`
- `mixture_weights`

using the following semantic interpretations:

| Parameter | Role | Domain | Scale |
|-----------|------|---------|--------|
| mixture_means | FREQUENCY | FREQUENCY | LINEAR |
| mixture_scales | LENGTHSCALE | FREQUENCY | LOG |
| mixture_weights | WEIGHT | VARIANCE | LOG |

### ScaleKernel schema

Add schema support for:

- `outputscale`

interpreted as a positive variance-domain covariance amplitude.

### Lengthscale schema

Add reusable schema support for kernel lengthscales while requiring
callers to specify the physical domain:

- TIME
- WAVELENGTH

This preserves the distinction between temporal and wavelength-domain
correlation scales despite sharing the same underlying GPyTorch
parameter name.

### Rational Quadratic schema

Add schema support for:

- `lengthscale`
- `alpha`

with `alpha` represented as a positive dimensionless shape parameter.

### Tests

Add dedicated unit tests covering:

- spectral mixture schemas
- ScaleKernel schemas
- lengthscale schemas
- Rational Quadratic schemas

## Design Notes

All schema definitions describe parameters in physical space rather
than model-transformed parameter space.

No parameter guesses, constraints, builders, initialization logic,
or fitting behaviour are introduced in this PR. The goal is solely to
provide semantic descriptions of kernel parameters that can later be
used by the parameter-estimation framework.

## Future Work

Subsequent PRs will introduce:

- parameter estimate builders
- data-driven guess generation
- data-driven constraint generation
- model-application layers that transform physical-space estimates
  into model-specific parameter representations