### PR TITLE
Add parameter estimate builder framework and DustMean estimation strategies

### DIFF
--- a/pgmuvi/gps.py
+++ b/pgmuvi/gps.py
@@ -23,6 +23,8 @@ from gpytorch.variational import CholeskyVariationalDistribution
 from gpytorch.variational import VariationalStrategy
 
 from pgmuvi.parameter_specs import (
+    ConstraintStrategy,
+    GuessStrategy,
     ParameterDomain,
     ParameterRole,
     ParameterScale,
@@ -377,6 +379,8 @@ class DustMean(gpt.means.Mean):
                     role=ParameterRole.OFFSET,
                     domain=ParameterDomain.FLUX,
                     scale=ParameterScale.LINEAR,
+                    guess_strategy=GuessStrategy.ROBUST_FLUX_SPAN,
+                    constraint_strategy=ConstraintStrategy.ROBUST_FLUX_RANGE,
                     description=(
                         "Constant additive flux offset shared across "
                         "wavelengths."
@@ -387,6 +391,8 @@ class DustMean(gpt.means.Mean):
                     role=ParameterRole.AMPLITUDE,
                     domain=ParameterDomain.FLUX,
                     scale=ParameterScale.LOG,
+                    guess_strategy=GuessStrategy.ROBUST_FLUX_SPAN,
+                    constraint_strategy=ConstraintStrategy.ROBUST_POSITIVE_FLUX_SPAN,
                     description=(
                         "Positive amplitude of the dust-attenuated "
                         "wavelength-dependent mean function, represented in "

--- a/pgmuvi/parameter_builders.py
+++ b/pgmuvi/parameter_builders.py
@@ -76,8 +76,25 @@ class ParameterEstimateBuilder:
         """Estimate a constraint for one parameter specification."""
         if spec.constraint_strategy is ConstraintStrategy.ROBUST_FLUX_RANGE:
             return self._estimate_robust_flux_range(context)
+        if spec.constraint_strategy is ConstraintStrategy.ROBUST_POSITIVE_FLUX_SPAN:
+            return self._estimate_robust_positive_flux_span_constraint(context)
 
         return None
+
+    def _estimate_robust_positive_flux_span_constraint(
+        self,
+        context: ParameterEstimationContext,
+    ):
+        """Return a positive amplitude constraint based on robust flux span."""
+        span = self._estimate_robust_flux_span(context)
+
+        if span is None or span <= 0:
+            return None
+
+        lower = max(1e-12, 1e-6 * span)
+        upper = 5.0 * span
+
+        return (lower, upper)
 
     @staticmethod
     def _estimate_median_flux(context: ParameterEstimationContext):

--- a/pgmuvi/parameter_builders.py
+++ b/pgmuvi/parameter_builders.py
@@ -1,8 +1,7 @@
 """Parameter-estimate builder infrastructure.
 
 This module defines builder classes that convert parameter schemas and
-diagnostic contexts into parameter estimates. Scientific estimation
-rules are intentionally deferred to later commits.
+diagnostic contexts into parameter estimates.
 """
 
 from __future__ import annotations
@@ -12,7 +11,12 @@ from pgmuvi.parameter_estimates import (
     ParameterEstimate,
     ParameterEstimateCollection,
 )
-from pgmuvi.parameter_specs import ParameterSpecCollection
+from pgmuvi.parameter_specs import (
+    ConstraintStrategy,
+    GuessStrategy,
+    ParameterSpec,
+    ParameterSpecCollection,
+)
 
 
 class ParameterEstimateBuilder:
@@ -23,19 +27,72 @@ class ParameterEstimateBuilder:
         schema: ParameterSpecCollection,
         context: ParameterEstimationContext,
     ) -> ParameterEstimateCollection:
-        """Build parameter estimates.
-
-        The initial implementation only creates empty estimates for each
-        parameter specification. Scientific estimation rules are added in
-        later commits.
-        """
+        """Build parameter estimates from a schema and diagnostic context."""
         estimates = ParameterEstimateCollection()
 
         for spec in schema:
-            estimates.add(
-                ParameterEstimate(
-                    spec=spec,
-                )
-            )
+            estimates.add(self.build_one(spec, context))
 
         return estimates
+
+    def build_one(
+        self,
+        spec: ParameterSpec,
+        context: ParameterEstimationContext,
+    ) -> ParameterEstimate:
+        """Build one parameter estimate."""
+        value = self._estimate_value(spec, context)
+        constraint = self._estimate_constraint(spec, context)
+
+        return ParameterEstimate(
+            spec=spec,
+            value=value,
+            constraint=constraint,
+            value_source=spec.guess_strategy.value if spec.guess_strategy else None,
+            constraint_source=(
+                spec.constraint_strategy.value if spec.constraint_strategy else None
+            ),
+        )
+
+    def _estimate_value(
+        self,
+        spec: ParameterSpec,
+        context: ParameterEstimationContext,
+    ):
+        """Estimate an initial value for one parameter specification."""
+        if spec.guess_strategy is GuessStrategy.MEDIAN_FLUX:
+            return self._estimate_median_flux(context)
+
+        return None
+
+    def _estimate_constraint(
+        self,
+        spec: ParameterSpec,
+        context: ParameterEstimationContext,
+    ):
+        """Estimate a constraint for one parameter specification."""
+        if spec.constraint_strategy is ConstraintStrategy.ROBUST_FLUX_RANGE:
+            return self._estimate_robust_flux_range(context)
+
+        return None
+
+    @staticmethod
+    def _estimate_median_flux(context: ParameterEstimationContext):
+        """Estimate a flux-level value from global median-flux diagnostics."""
+        if context.global_diagnostics is None:
+            return None
+
+        return context.global_diagnostics.median_flux
+
+    @staticmethod
+    def _estimate_robust_flux_range(context: ParameterEstimationContext):
+        """Estimate a robust global flux range using p2.5 and p97.5."""
+        if context.global_diagnostics is None:
+            return None
+
+        percentiles = context.global_diagnostics.flux_percentiles
+
+        if 2.5 not in percentiles or 97.5 not in percentiles:
+            return None
+
+        return (percentiles[2.5], percentiles[97.5])

--- a/pgmuvi/parameter_builders.py
+++ b/pgmuvi/parameter_builders.py
@@ -1,0 +1,41 @@
+"""Parameter-estimate builder infrastructure.
+
+This module defines builder classes that convert parameter schemas and
+diagnostic contexts into parameter estimates. Scientific estimation
+rules are intentionally deferred to later commits.
+"""
+
+from __future__ import annotations
+
+from pgmuvi.parameter_context import ParameterEstimationContext
+from pgmuvi.parameter_estimates import (
+    ParameterEstimate,
+    ParameterEstimateCollection,
+)
+from pgmuvi.parameter_specs import ParameterSpecCollection
+
+
+class ParameterEstimateBuilder:
+    """Construct parameter estimates from schemas and diagnostics."""
+
+    def build(
+        self,
+        schema: ParameterSpecCollection,
+        context: ParameterEstimationContext,
+    ) -> ParameterEstimateCollection:
+        """Build parameter estimates.
+
+        The initial implementation only creates empty estimates for each
+        parameter specification. Scientific estimation rules are added in
+        later commits.
+        """
+        estimates = ParameterEstimateCollection()
+
+        for spec in schema:
+            estimates.add(
+                ParameterEstimate(
+                    spec=spec,
+                )
+            )
+
+        return estimates

--- a/pgmuvi/parameter_builders.py
+++ b/pgmuvi/parameter_builders.py
@@ -96,3 +96,40 @@ class ParameterEstimateBuilder:
             return None
 
         return (percentiles[2.5], percentiles[97.5])
+
+    @staticmethod
+    def _get_flux_percentile(
+        context: ParameterEstimationContext,
+        percentile: float,
+    ):
+        """Return a global flux percentile value if available."""
+        if context.global_diagnostics is None:
+            return None
+
+        return context.global_diagnostics.flux_percentiles.get(percentile)
+
+    def _estimate_robust_flux_interval(
+        self,
+        context: ParameterEstimationContext,
+    ):
+        """Return (p2.5, p97.5) if available."""
+        p025 = self._get_flux_percentile(context, 2.5)
+        p975 = self._get_flux_percentile(context, 97.5)
+
+        if p025 is None or p975 is None:
+            return None
+
+        return (p025, p975)
+
+    def _estimate_robust_flux_span(
+        self,
+        context: ParameterEstimationContext,
+    ):
+        """Return p97.5 - p2.5 if available."""
+        interval = self._estimate_robust_flux_interval(context)
+
+        if interval is None:
+            return None
+
+        lower, upper = interval
+        return upper - lower

--- a/pgmuvi/parameter_builders.py
+++ b/pgmuvi/parameter_builders.py
@@ -63,6 +63,9 @@ class ParameterEstimateBuilder:
         if spec.guess_strategy is GuessStrategy.MEDIAN_FLUX:
             return self._estimate_median_flux(context)
 
+        if spec.guess_strategy is GuessStrategy.ROBUST_FLUX_SPAN:
+            return self._estimate_robust_flux_span(context)
+
         return None
 
     def _estimate_constraint(

--- a/pgmuvi/parameter_context.py
+++ b/pgmuvi/parameter_context.py
@@ -19,7 +19,7 @@ class LightcurveDiagnostics:
     cadence: float | None = None
     median_flux: float | None = None
     mad_flux: float | None = None
-    flux_percentiles: tuple[float, float] | None = None
+    flux_percentiles: dict[float, float] = field(default_factory=dict)
     n_points: int | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
 
@@ -34,7 +34,7 @@ class BandDiagnostics:
     cadence: float | None = None
     median_flux: float | None = None
     mad_flux: float | None = None
-    flux_percentiles: tuple[float, float] | None = None
+    flux_percentiles: dict[float, float] = field(default_factory=dict)
     n_points: int | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
 

--- a/pgmuvi/parameter_specs.py
+++ b/pgmuvi/parameter_specs.py
@@ -75,6 +75,7 @@ class ConstraintStrategy(str, Enum):
 
     MEDIAN_FLUX = "median_flux"
     ROBUST_FLUX_RANGE = "robust_flux_range"
+    ROBUST_POSITIVE_FLUX_SPAN = "robust_positive_flux_span"
     ROBUST_FLUX_SPAN = "robust_flux_span"
     FLUX_STD = "flux_std"
     MAD = "mad"

--- a/pgmuvi/parameter_specs.py
+++ b/pgmuvi/parameter_specs.py
@@ -69,6 +69,7 @@ class GuessStrategy(str, Enum):
 
     CUSTOM = "custom"
 
+
 class ConstraintStrategy(str, Enum):
     USER = "user"
     DEFAULT = "default"

--- a/pgmuvi/parameter_specs.py
+++ b/pgmuvi/parameter_specs.py
@@ -51,6 +51,7 @@ class GuessStrategy(str, Enum):
 
     MEDIAN_FLUX = "median_flux"
     ROBUST_FLUX_RANGE = "robust_flux_range"
+    ROBUST_FLUX_SPAN = "robust_flux_span"
     FLUX_STD = "flux_std"
     MAD = "mad"
 
@@ -68,13 +69,13 @@ class GuessStrategy(str, Enum):
 
     CUSTOM = "custom"
 
-
 class ConstraintStrategy(str, Enum):
     USER = "user"
     DEFAULT = "default"
 
     MEDIAN_FLUX = "median_flux"
     ROBUST_FLUX_RANGE = "robust_flux_range"
+    ROBUST_FLUX_SPAN = "robust_flux_span"
     FLUX_STD = "flux_std"
     MAD = "mad"
 

--- a/tests/test_dust_mean_parameter_schema.py
+++ b/tests/test_dust_mean_parameter_schema.py
@@ -1,7 +1,13 @@
 import unittest
 
 from pgmuvi.gps import DustMean
-from pgmuvi.parameter_specs import ParameterDomain, ParameterRole, ParameterScale
+from pgmuvi.parameter_specs import (
+        ConstraintStrategy,
+        GuessStrategy,
+        ParameterDomain,
+        ParameterRole,
+        ParameterScale,
+        )
 
 
 class TestDustMeanParameterSchema(unittest.TestCase):
@@ -54,3 +60,42 @@ class TestDustMeanParameterSchema(unittest.TestCase):
                 "log_alpha",
             ],
         )
+
+def test_dust_mean_schema_estimation_strategies(self):
+    schema = DustMean().parameter_schema()
+
+    self.assertEqual(
+        schema["mean_module.offset"].guess_strategy,
+        GuessStrategy.MEDIAN_FLUX,
+    )
+
+    self.assertEqual(
+        schema["mean_module.offset"].constraint_strategy,
+        ConstraintStrategy.ROBUST_FLUX_RANGE,
+    )
+
+    self.assertEqual(
+        schema["mean_module.log_amplitude"].guess_strategy,
+        GuessStrategy.ROBUST_FLUX_SPAN,
+    )
+
+    self.assertEqual(
+        schema["mean_module.log_amplitude"].constraint_strategy,
+        ConstraintStrategy.ROBUST_POSITIVE_FLUX_SPAN,
+    )
+
+    self.assertIsNone(
+        schema["mean_module.log_tau"].guess_strategy,
+    )
+
+    self.assertIsNone(
+        schema["mean_module.log_tau"].constraint_strategy,
+    )
+
+    self.assertIsNone(
+        schema["mean_module.log_alpha"].guess_strategy,
+    )
+
+    self.assertIsNone(
+        schema["mean_module.log_alpha"].constraint_strategy,
+    )

--- a/tests/test_dust_mean_parameter_schema.py
+++ b/tests/test_dust_mean_parameter_schema.py
@@ -8,6 +8,11 @@ from pgmuvi.parameter_specs import (
         ParameterRole,
         ParameterScale,
         )
+from pgmuvi.parameter_builders import ParameterEstimateBuilder
+from pgmuvi.parameter_context import (
+    LightcurveDiagnostics,
+    ParameterEstimationContext,
+)
 
 
 class TestDustMeanParameterSchema(unittest.TestCase):
@@ -98,4 +103,41 @@ def test_dust_mean_schema_estimation_strategies(self):
 
     self.assertIsNone(
         schema["mean_module.log_alpha"].constraint_strategy,
+    )
+
+def test_dust_mean_schema_builds_estimates_from_diagnostics(self):
+    schema = DustMean().parameter_schema()
+
+    context = ParameterEstimationContext(
+        is_multiband=True,
+        global_diagnostics=LightcurveDiagnostics(
+            median_flux=55.0,
+            flux_percentiles={
+                2.5: 10.0,
+                50.0: 55.0,
+                97.5: 100.0,
+            },
+        ),
+    )
+
+    estimates = ParameterEstimateBuilder().build(
+        schema=schema,
+        context=context,
+    )
+
+    offset = estimates["mean_module.offset"]
+    amplitude = estimates["mean_module.log_amplitude"]
+
+    self.assertEqual(offset.value, 55.0)
+    self.assertEqual(offset.constraint, (10.0, 100.0))
+
+    self.assertEqual(amplitude.value, 90.0)
+
+    self.assertAlmostEqual(
+        amplitude.constraint[0],
+        9.0e-5,
+    )
+    self.assertAlmostEqual(
+        amplitude.constraint[1],
+        450.0,
     )

--- a/tests/test_dust_mean_parameter_schema.py
+++ b/tests/test_dust_mean_parameter_schema.py
@@ -2,12 +2,12 @@ import unittest
 
 from pgmuvi.gps import DustMean
 from pgmuvi.parameter_specs import (
-        ConstraintStrategy,
-        GuessStrategy,
-        ParameterDomain,
-        ParameterRole,
-        ParameterScale,
-        )
+    ConstraintStrategy,
+    GuessStrategy,
+    ParameterDomain,
+    ParameterRole,
+    ParameterScale,
+)
 from pgmuvi.parameter_builders import ParameterEstimateBuilder
 from pgmuvi.parameter_context import (
     LightcurveDiagnostics,

--- a/tests/test_parameter_builders.py
+++ b/tests/test_parameter_builders.py
@@ -1,8 +1,13 @@
 import unittest
 
 from pgmuvi.parameter_builders import ParameterEstimateBuilder
-from pgmuvi.parameter_context import ParameterEstimationContext
+from pgmuvi.parameter_context import (
+    LightcurveDiagnostics,
+    ParameterEstimationContext,
+)
 from pgmuvi.parameter_specs import (
+    ConstraintStrategy,
+    GuessStrategy,
     ParameterDomain,
     ParameterRole,
     ParameterSpec,
@@ -33,11 +38,7 @@ class TestParameterEstimateBuilder(unittest.TestCase):
         )
 
         builder = ParameterEstimateBuilder()
-
-        estimates = builder.build(
-            schema=schema,
-            context=context,
-        )
+        estimates = builder.build(schema=schema, context=context)
 
         self.assertEqual(
             estimates.names(),
@@ -47,13 +48,129 @@ class TestParameterEstimateBuilder(unittest.TestCase):
             ],
         )
 
-        self.assertIsNone(
-            estimates["mean_module.offset"].value
+        self.assertIsNone(estimates["mean_module.offset"].value)
+        self.assertIsNone(estimates["mean_module.offset"].constraint)
+        self.assertIsNone(estimates["mean_module.log_amplitude"].value)
+        self.assertIsNone(estimates["mean_module.log_amplitude"].constraint)
+
+    def test_median_flux_guess_strategy_uses_global_diagnostics(self):
+        spec = ParameterSpec(
+            name="mean_module.offset",
+            role=ParameterRole.OFFSET,
+            domain=ParameterDomain.FLUX,
+            guess_strategy=GuessStrategy.MEDIAN_FLUX,
         )
 
-        self.assertIsNone(
-            estimates["mean_module.log_amplitude"].value
+        context = ParameterEstimationContext(
+            is_multiband=False,
+            global_diagnostics=LightcurveDiagnostics(
+                median_flux=123.4,
+            ),
         )
+
+        builder = ParameterEstimateBuilder()
+        estimate = builder.build_one(spec=spec, context=context)
+
+        self.assertEqual(estimate.value, 123.4)
+        self.assertIsNone(estimate.constraint)
+        self.assertEqual(estimate.value_source, "median_flux")
+        self.assertIsNone(estimate.constraint_source)
+
+    def test_median_flux_guess_strategy_returns_none_when_unavailable(self):
+        spec = ParameterSpec(
+            name="mean_module.offset",
+            role=ParameterRole.OFFSET,
+            domain=ParameterDomain.FLUX,
+            guess_strategy=GuessStrategy.MEDIAN_FLUX,
+        )
+
+        context = ParameterEstimationContext(
+            is_multiband=False,
+        )
+
+        builder = ParameterEstimateBuilder()
+        estimate = builder.build_one(spec=spec, context=context)
+
+        self.assertIsNone(estimate.value)
+        self.assertEqual(estimate.value_source, "median_flux")
+
+    def test_robust_flux_range_constraint_uses_global_percentiles(self):
+        spec = ParameterSpec(
+            name="mean_module.offset",
+            role=ParameterRole.OFFSET,
+            domain=ParameterDomain.FLUX,
+            constraint_strategy=ConstraintStrategy.ROBUST_FLUX_RANGE,
+        )
+
+        context = ParameterEstimationContext(
+            is_multiband=False,
+            global_diagnostics=LightcurveDiagnostics(
+                flux_percentiles={
+                    2.5: 10.0,
+                    50.0: 55.0,
+                    97.5: 100.0,
+                },
+            ),
+        )
+
+        builder = ParameterEstimateBuilder()
+        estimate = builder.build_one(spec=spec, context=context)
+
+        self.assertIsNone(estimate.value)
+        self.assertEqual(estimate.constraint, (10.0, 100.0))
+        self.assertEqual(estimate.constraint_source, "robust_flux_range")
+
+    def test_robust_flux_range_constraint_returns_none_when_percentiles_missing(self):
+        spec = ParameterSpec(
+            name="mean_module.offset",
+            role=ParameterRole.OFFSET,
+            domain=ParameterDomain.FLUX,
+            constraint_strategy=ConstraintStrategy.ROBUST_FLUX_RANGE,
+        )
+
+        context = ParameterEstimationContext(
+            is_multiband=False,
+            global_diagnostics=LightcurveDiagnostics(
+                flux_percentiles={
+                    50.0: 55.0,
+                },
+            ),
+        )
+
+        builder = ParameterEstimateBuilder()
+        estimate = builder.build_one(spec=spec, context=context)
+
+        self.assertIsNone(estimate.constraint)
+        self.assertEqual(estimate.constraint_source, "robust_flux_range")
+
+    def test_offset_estimate_can_use_median_and_robust_range_together(self):
+        spec = ParameterSpec(
+            name="mean_module.offset",
+            role=ParameterRole.OFFSET,
+            domain=ParameterDomain.FLUX,
+            guess_strategy=GuessStrategy.MEDIAN_FLUX,
+            constraint_strategy=ConstraintStrategy.ROBUST_FLUX_RANGE,
+        )
+
+        context = ParameterEstimationContext(
+            is_multiband=False,
+            global_diagnostics=LightcurveDiagnostics(
+                median_flux=55.0,
+                flux_percentiles={
+                    2.5: 10.0,
+                    50.0: 55.0,
+                    97.5: 100.0,
+                },
+            ),
+        )
+
+        builder = ParameterEstimateBuilder()
+        estimate = builder.build_one(spec=spec, context=context)
+
+        self.assertEqual(estimate.value, 55.0)
+        self.assertEqual(estimate.constraint, (10.0, 100.0))
+        self.assertEqual(estimate.value_source, "median_flux")
+        self.assertEqual(estimate.constraint_source, "robust_flux_range")
 
 
 if __name__ == "__main__":

--- a/tests/test_parameter_builders.py
+++ b/tests/test_parameter_builders.py
@@ -264,5 +264,57 @@ class TestParameterEstimateBuilder(unittest.TestCase):
             builder._estimate_robust_flux_span(context)
         )
 
+    def test_robust_positive_flux_span_constraint_strategy(self):
+        spec = ParameterSpec(
+            name="mean_module.log_amplitude",
+            role=ParameterRole.AMPLITUDE,
+            domain=ParameterDomain.FLUX,
+            constraint_strategy=ConstraintStrategy.ROBUST_POSITIVE_FLUX_SPAN,
+        )
+
+        context = ParameterEstimationContext(
+            is_multiband=False,
+            global_diagnostics=LightcurveDiagnostics(
+                flux_percentiles={
+                    2.5: 10.0,
+                    97.5: 100.0,
+                },
+            ),
+        )
+
+        builder = ParameterEstimateBuilder()
+        estimate = builder.build_one(spec=spec, context=context)
+
+        self.assertAlmostEqual(estimate.constraint[0], 9.0e-5)
+        self.assertAlmostEqual(estimate.constraint[1], 450.0)
+        self.assertEqual(
+            estimate.constraint_source,
+            "robust_positive_flux_span",
+        )
+
+    def test_robust_positive_flux_span_constraint_returns_none_for_zero_span(self):
+        spec = ParameterSpec(
+            name="mean_module.log_amplitude",
+            role=ParameterRole.AMPLITUDE,
+            domain=ParameterDomain.FLUX,
+            constraint_strategy=ConstraintStrategy.ROBUST_POSITIVE_FLUX_SPAN,
+        )
+
+        context = ParameterEstimationContext(
+            is_multiband=False,
+            global_diagnostics=LightcurveDiagnostics(
+                flux_percentiles={
+                    2.5: 10.0,
+                    97.5: 10.0,
+                },
+            ),
+        )
+
+        builder = ParameterEstimateBuilder()
+        estimate = builder.build_one(spec=spec, context=context)
+
+        self.assertIsNone(estimate.constraint)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_parameter_builders.py
+++ b/tests/test_parameter_builders.py
@@ -172,6 +172,53 @@ class TestParameterEstimateBuilder(unittest.TestCase):
         self.assertEqual(estimate.value_source, "median_flux")
         self.assertEqual(estimate.constraint_source, "robust_flux_range")
 
+    def test_robust_flux_interval_helper(self):
+        context = ParameterEstimationContext(
+            is_multiband=False,
+            global_diagnostics=LightcurveDiagnostics(
+                flux_percentiles={
+                    2.5: 10.0,
+                    50.0: 55.0,
+                    97.5: 100.0,
+                },
+            ),
+        )
+
+        builder = ParameterEstimateBuilder()
+
+        self.assertEqual(
+            builder._estimate_robust_flux_interval(context),
+            (10.0, 100.0),
+        )
+
+    def test_robust_flux_span_helper(self):
+        context = ParameterEstimationContext(
+            is_multiband=False,
+            global_diagnostics=LightcurveDiagnostics(
+                flux_percentiles={
+                    2.5: 10.0,
+                    97.5: 100.0,
+                },
+            ),
+        )
+
+        builder = ParameterEstimateBuilder()
+
+        self.assertEqual(
+            builder._estimate_robust_flux_span(context),
+            90.0,
+        )
+
+    def test_robust_flux_span_helper_returns_none_when_unavailable(self):
+        context = ParameterEstimationContext(
+            is_multiband=False,
+        )
+
+        builder = ParameterEstimateBuilder()
+
+        self.assertIsNone(
+            builder._estimate_robust_flux_span(context)
+        )
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_parameter_builders.py
+++ b/tests/test_parameter_builders.py
@@ -1,0 +1,60 @@
+import unittest
+
+from pgmuvi.parameter_builders import ParameterEstimateBuilder
+from pgmuvi.parameter_context import ParameterEstimationContext
+from pgmuvi.parameter_specs import (
+    ParameterDomain,
+    ParameterRole,
+    ParameterSpec,
+    ParameterSpecCollection,
+)
+
+
+class TestParameterEstimateBuilder(unittest.TestCase):
+
+    def test_build_returns_estimate_collection(self):
+        schema = ParameterSpecCollection(
+            [
+                ParameterSpec(
+                    name="mean_module.offset",
+                    role=ParameterRole.OFFSET,
+                    domain=ParameterDomain.FLUX,
+                ),
+                ParameterSpec(
+                    name="mean_module.log_amplitude",
+                    role=ParameterRole.AMPLITUDE,
+                    domain=ParameterDomain.FLUX,
+                ),
+            ]
+        )
+
+        context = ParameterEstimationContext(
+            is_multiband=False,
+        )
+
+        builder = ParameterEstimateBuilder()
+
+        estimates = builder.build(
+            schema=schema,
+            context=context,
+        )
+
+        self.assertEqual(
+            estimates.names(),
+            [
+                "mean_module.offset",
+                "mean_module.log_amplitude",
+            ],
+        )
+
+        self.assertIsNone(
+            estimates["mean_module.offset"].value
+        )
+
+        self.assertIsNone(
+            estimates["mean_module.log_amplitude"].value
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_parameter_builders.py
+++ b/tests/test_parameter_builders.py
@@ -143,6 +143,50 @@ class TestParameterEstimateBuilder(unittest.TestCase):
         self.assertIsNone(estimate.constraint)
         self.assertEqual(estimate.constraint_source, "robust_flux_range")
 
+    def test_robust_flux_span_guess_strategy(self):
+        spec = ParameterSpec(
+            name="mean_module.log_amplitude",
+            role=ParameterRole.AMPLITUDE,
+            domain=ParameterDomain.FLUX,
+            guess_strategy=GuessStrategy.ROBUST_FLUX_SPAN,
+        )
+
+        context = ParameterEstimationContext(
+            is_multiband=False,
+            global_diagnostics=LightcurveDiagnostics(
+                flux_percentiles={
+                    2.5: 10.0,
+                    97.5: 100.0,
+                },
+            ),
+        )
+
+        builder = ParameterEstimateBuilder()
+        estimate = builder.build_one(spec=spec, context=context)
+
+        self.assertEqual(estimate.value, 90.0)
+        self.assertEqual(
+            estimate.value_source,
+            "robust_flux_span",
+        )
+
+    def test_robust_flux_span_guess_strategy_returns_none_when_unavailable(self):
+        spec = ParameterSpec(
+            name="mean_module.log_amplitude",
+            role=ParameterRole.AMPLITUDE,
+            domain=ParameterDomain.FLUX,
+            guess_strategy=GuessStrategy.ROBUST_FLUX_SPAN,
+        )
+
+        context = ParameterEstimationContext(
+            is_multiband=False,
+        )
+
+        builder = ParameterEstimateBuilder()
+        estimate = builder.build_one(spec=spec, context=context)
+
+        self.assertIsNone(estimate.value)
+
     def test_offset_estimate_can_use_median_and_robust_range_together(self):
         spec = ParameterSpec(
             name="mean_module.offset",

--- a/tests/test_parameter_context.py
+++ b/tests/test_parameter_context.py
@@ -15,14 +15,21 @@ class TestParameterContext(unittest.TestCase):
             cadence=10.0,
             median_flux=123.0,
             mad_flux=5.0,
-            flux_percentiles=(100.0, 150.0),
+            flux_percentiles={2.5: 100.0, 50.0: 125.0, 97.5: 150.0},
             n_points=42,
         )
 
         self.assertEqual(diagnostics.baseline, 1000.0)
         self.assertEqual(diagnostics.cadence, 10.0)
         self.assertEqual(diagnostics.median_flux, 123.0)
-        self.assertEqual(diagnostics.flux_percentiles, (100.0, 150.0))
+        self.assertEqual(
+            diagnostics.flux_percentiles,
+            {
+                2.5: 100.0,
+                50.0: 125.0,
+                97.5: 150.0,
+            },
+        )
 
     def test_band_diagnostics_stores_per_band_quantities(self):
         diagnostics = BandDiagnostics(


### PR DESCRIPTION
## Summary

This PR introduces the foundation for model-independent parameter estimation in PGMUVI.

The new framework separates:

1. Parameter specification (`ParameterSpec`)
2. Diagnostic context (`ParameterEstimationContext`)
3. Parameter estimates (`ParameterEstimate`)
4. Estimation logic (`ParameterEstimateBuilder`)

This allows GP models to describe parameters in physical/data space while keeping initialization and constraint generation independent of any particular GPyTorch implementation.

## Motivation

Historically, parameter guesses and constraints have been generated directly inside fitting code and model-specific workflows. This makes it difficult to:

- reason about initialization behaviour,
- reuse estimation logic across models,
- validate guesses and constraints independently,
- support future consensus-derived parameter estimates,
- ensure guesses and constraints remain internally consistent.

This PR introduces a dedicated estimation layer that can be expanded incrementally in later work.

## Main Changes

### Parameter estimate framework

Added:

- `ParameterEstimate`
- `ParameterEstimateCollection`
- `ParameterEstimationContext`
- `ParameterEstimateBuilder`

These objects provide a model-independent representation of estimated parameter values and constraints.

### Diagnostic infrastructure

Diagnostic containers now support explicitly labelled percentile storage:

```python
{
    2.5: ...,
    50.0: ...,
    97.5: ...,
}