### PR TITLE
Add parameter estimate application framework

### DIFF
--- a/pgmuvi/parameter_application.py
+++ b/pgmuvi/parameter_application.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from pgmuvi.parameter_estimates import ParameterEstimateCollection
 from pgmuvi.parameter_specs import ParameterScale
 import math
+import torch
 
 
 class ParameterEstimateApplicator:
@@ -36,9 +37,23 @@ class ParameterEstimateApplicator:
 
     def _apply_value(self, parameter, estimate):
         """Apply one estimated value to a resolved parameter."""
-        raise NotImplementedError(
-            "Parameter value application is not implemented yet."
+        transformed_value = self._transform_value(estimate)
+
+        if transformed_value is None:
+            return False
+
+        value_tensor = torch.as_tensor(
+            transformed_value,
+            dtype=parameter.data.dtype,
+            device=parameter.data.device,
         )
+
+        value_tensor = value_tensor.reshape_as(parameter.data)
+
+        with torch.no_grad():
+            parameter.copy_(value_tensor)
+
+        return True
 
     def _apply_constraint(self, model, estimate):
         """Apply one estimated constraint to a model parameter."""

--- a/pgmuvi/parameter_application.py
+++ b/pgmuvi/parameter_application.py
@@ -85,3 +85,30 @@ class ParameterEstimateApplicator:
             f"Value transformation for scale {estimate.spec.scale.value!r} "
             "is not implemented yet."
         )
+
+    def _transform_constraint(self, estimate):
+        """Transform a physical-space constraint into parameter space."""
+        if estimate.constraint is None:
+            return None
+
+        lower, upper = estimate.constraint
+
+        if estimate.spec.scale is ParameterScale.LINEAR:
+            return (lower, upper)
+
+        if estimate.spec.scale is ParameterScale.LOG:
+            if lower <= 0 or upper <= 0:
+                raise ValueError(
+                    f"Cannot apply log transform to non-positive constraint "
+                    f"for {estimate.name!r}."
+                )
+
+            return (
+                math.log(lower),
+                math.log(upper),
+            )
+
+        raise NotImplementedError(
+            f"Constraint transformation for scale "
+            f"{estimate.spec.scale.value!r} is not implemented yet."
+        )

--- a/pgmuvi/parameter_application.py
+++ b/pgmuvi/parameter_application.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from pgmuvi.parameter_estimates import ParameterEstimateCollection
 from pgmuvi.parameter_specs import ParameterScale
+import math
 
 
 class ParameterEstimateApplicator:
@@ -52,6 +53,14 @@ class ParameterEstimateApplicator:
 
         if estimate.spec.scale is ParameterScale.LINEAR:
             return estimate.value
+
+        if estimate.spec.scale is ParameterScale.LOG:
+            if estimate.value <= 0:
+                raise ValueError(
+                    f"Cannot apply log transform to non-positive value for "
+                    f"{estimate.name!r}."
+                )
+            return math.log(estimate.value)
 
         raise NotImplementedError(
             f"Value transformation for scale {estimate.spec.scale.value!r} "

--- a/pgmuvi/parameter_application.py
+++ b/pgmuvi/parameter_application.py
@@ -22,12 +22,16 @@ class ParameterEstimateApplicator:
         model,
         estimates: ParameterEstimateCollection,
     ):
-        """Apply available parameter estimate values to a model."""
+        """Apply available parameter estimate values and constraints to a model."""
         results = {}
 
         for estimate in estimates:
             parameter = self._resolve_parameter(model, estimate.name)
-            results[estimate.name] = self._apply_value(parameter, estimate)
+
+            results[estimate.name] = {
+                "value": self._apply_value(parameter, estimate),
+                "constraint": self._apply_constraint(model, estimate),
+            }
 
         return results
 

--- a/pgmuvi/parameter_application.py
+++ b/pgmuvi/parameter_application.py
@@ -163,9 +163,9 @@ class ParameterEstimateApplicator:
                 return estimate.value
 
             value_tensor = torch.as_tensor(
-                    estimate.value,
-                    dtype=torch.get_default_dtype(),
-                    )
+                estimate.value,
+                dtype=torch.get_default_dtype(),
+            )
 
             if value_tensor.numel() == 1:
                 scalar = float(value_tensor.item())
@@ -206,11 +206,11 @@ class ParameterEstimateApplicator:
             lower_tensor = torch.as_tensor(
                 lower,
                 dtype=torch.get_default_dtype(),
-                )
+            )
             upper_tensor = torch.as_tensor(
                 upper,
                 dtype=torch.get_default_dtype(),
-                )
+            )
 
             if lower_tensor.numel() == 1 and upper_tensor.numel() == 1:
                 lower_scalar = float(lower_tensor.item())

--- a/pgmuvi/parameter_application.py
+++ b/pgmuvi/parameter_application.py
@@ -26,10 +26,22 @@ class ParameterEstimateApplicator:
         results = {}
 
         for estimate in estimates:
-            parameter = self._resolve_parameter(model, estimate.name)
+            module_path, parameter_name = self._split_parameter_path(
+                estimate.name
+            )
+
+            target_module = (
+                model
+                if not module_path
+                else self._resolve_parameter(model, module_path)
+            )
 
             results[estimate.name] = {
-                "value": self._apply_value(parameter, estimate),
+                "value": self._apply_value(
+                    target_module,
+                    parameter_name,
+                    estimate,
+                ),
                 "constraint": self._apply_constraint(model, estimate),
             }
 
@@ -54,8 +66,9 @@ class ParameterEstimateApplicator:
 
         return ".".join(parts[:-1]), parts[-1]
 
-    def _apply_value(self, parameter, estimate):
+    def _apply_value(self, target_module, parameter_name, estimate):
         """Apply one estimated value to a resolved parameter."""
+        parameter = getattr(target_module, parameter_name)
         transformed_value = self._transform_value(estimate)
 
         if transformed_value is None:
@@ -95,8 +108,20 @@ class ParameterEstimateApplicator:
             else self._resolve_parameter(model, module_path)
         )
 
+        raw_parameter_name = (
+            parameter_name
+            if parameter_name.startswith("raw_")
+            else f"raw_{parameter_name}"
+        )
+
+        constraint_target = (
+            raw_parameter_name
+            if hasattr(target_module, raw_parameter_name)
+            else parameter_name
+        )
+
         target_module.register_constraint(
-            parameter_name,
+            constraint_target,
             gpytorch.constraints.Interval(
                 lower,
                 upper,

--- a/pgmuvi/parameter_application.py
+++ b/pgmuvi/parameter_application.py
@@ -21,10 +21,14 @@ class ParameterEstimateApplicator:
         model,
         estimates: ParameterEstimateCollection,
     ):
-        """Apply a collection of parameter estimates to a model."""
-        raise NotImplementedError(
-            "Parameter estimate application is not implemented yet."
-        )
+        """Apply available parameter estimate values to a model."""
+        results = {}
+
+        for estimate in estimates:
+            parameter = self._resolve_parameter(model, estimate.name)
+            results[estimate.name] = self._apply_value(parameter, estimate)
+
+        return results
 
     def _resolve_parameter(self, model, parameter_name: str):
         """Resolve a dotted parameter path on a model."""

--- a/pgmuvi/parameter_application.py
+++ b/pgmuvi/parameter_application.py
@@ -39,6 +39,16 @@ class ParameterEstimateApplicator:
 
         return obj
 
+    @staticmethod
+    def _split_parameter_path(parameter_name: str):
+        """Split a parameter path into module path and local parameter name."""
+        parts = parameter_name.split(".")
+
+        if len(parts) == 1:
+            return "", parts[0]
+
+        return ".".join(parts[:-1]), parts[-1]
+
     def _apply_value(self, parameter, estimate):
         """Apply one estimated value to a resolved parameter."""
         transformed_value = self._transform_value(estimate)

--- a/pgmuvi/parameter_application.py
+++ b/pgmuvi/parameter_application.py
@@ -1,0 +1,42 @@
+"""Application layer for parameter estimates.
+
+This module defines the interface for applying physical-space parameter
+estimates to model parameters. Concrete application logic is added in
+later commits.
+"""
+
+from __future__ import annotations
+
+from pgmuvi.parameter_estimates import ParameterEstimateCollection
+
+
+class ParameterEstimateApplicator:
+    """Apply parameter estimates to a model."""
+
+    def apply(
+        self,
+        model,
+        estimates: ParameterEstimateCollection,
+    ):
+        """Apply a collection of parameter estimates to a model."""
+        raise NotImplementedError(
+            "Parameter estimate application is not implemented yet."
+        )
+
+    def _resolve_parameter(self, model, parameter_name: str):
+        """Resolve a dotted parameter name on a model."""
+        raise NotImplementedError(
+            "Parameter resolution is not implemented yet."
+        )
+
+    def _apply_value(self, parameter, estimate):
+        """Apply one estimated value to a resolved parameter."""
+        raise NotImplementedError(
+            "Parameter value application is not implemented yet."
+        )
+
+    def _apply_constraint(self, model, estimate):
+        """Apply one estimated constraint to a model parameter."""
+        raise NotImplementedError(
+            "Parameter constraint application is not implemented yet."
+        )

--- a/pgmuvi/parameter_application.py
+++ b/pgmuvi/parameter_application.py
@@ -162,12 +162,10 @@ class ParameterEstimateApplicator:
             if not self._is_explicit_log_parameter(estimate.name):
                 return estimate.value
 
-            value_tensor = torch.as_tensor(estimate.value)
             value_tensor = torch.as_tensor(
                     estimate.value,
                     dtype=torch.get_default_dtype(),
                     )
-
 
             if value_tensor.numel() == 1:
                 scalar = float(value_tensor.item())

--- a/pgmuvi/parameter_application.py
+++ b/pgmuvi/parameter_application.py
@@ -24,10 +24,13 @@ class ParameterEstimateApplicator:
         )
 
     def _resolve_parameter(self, model, parameter_name: str):
-        """Resolve a dotted parameter name on a model."""
-        raise NotImplementedError(
-            "Parameter resolution is not implemented yet."
-        )
+        """Resolve a dotted parameter path on a model."""
+        obj = model
+
+        for part in parameter_name.split("."):
+            obj = getattr(obj, part)
+
+        return obj
 
     def _apply_value(self, parameter, estimate):
         """Apply one estimated value to a resolved parameter."""

--- a/pgmuvi/parameter_application.py
+++ b/pgmuvi/parameter_application.py
@@ -11,6 +11,7 @@ from pgmuvi.parameter_estimates import ParameterEstimateCollection
 from pgmuvi.parameter_specs import ParameterScale
 import math
 import torch
+import gpytorch
 
 
 class ParameterEstimateApplicator:
@@ -71,9 +72,34 @@ class ParameterEstimateApplicator:
 
     def _apply_constraint(self, model, estimate):
         """Apply one estimated constraint to a model parameter."""
-        raise NotImplementedError(
-            "Parameter constraint application is not implemented yet."
+        transformed_constraint = self._transform_constraint(
+            estimate
         )
+
+        if transformed_constraint is None:
+            return False
+
+        lower, upper = transformed_constraint
+
+        module_path, parameter_name = self._split_parameter_path(
+            estimate.name
+        )
+
+        target_module = (
+            model
+            if not module_path
+            else self._resolve_parameter(model, module_path)
+        )
+
+        target_module.register_constraint(
+            parameter_name,
+            gpytorch.constraints.Interval(
+                lower,
+                upper,
+            ),
+        )
+
+        return True
 
     def _transform_value(self, estimate):
         """Transform a physical-space estimate value into model parameter space."""

--- a/pgmuvi/parameter_application.py
+++ b/pgmuvi/parameter_application.py
@@ -74,22 +74,36 @@ class ParameterEstimateApplicator:
 
     def _apply_value(self, target_module, parameter_name, estimate):
         """Apply one estimated value to a resolved parameter."""
-        parameter = getattr(target_module, parameter_name)
         transformed_value = self._transform_value(estimate)
 
         if transformed_value is None:
             return False
 
+        current = getattr(target_module, parameter_name)
+
+        dtype = getattr(current, "dtype", None)
+        device = getattr(current, "device", None)
+
+        if isinstance(current, torch.nn.Parameter):
+            dtype = current.data.dtype
+            device = current.data.device
+
         value_tensor = torch.as_tensor(
             transformed_value,
-            dtype=parameter.data.dtype,
-            device=parameter.data.device,
+            dtype=dtype,
+            device=device,
         )
 
-        value_tensor = value_tensor.reshape_as(parameter.data)
+        if hasattr(current, "shape"):
+            value_tensor = value_tensor.reshape_as(current)
 
         with torch.no_grad():
-            parameter.copy_(value_tensor)
+            if isinstance(target_module, gpytorch.Module):
+                target_module.initialize(**{parameter_name: value_tensor})
+            elif isinstance(current, torch.nn.Parameter):
+                current.copy_(value_tensor)
+            else:
+                setattr(target_module, parameter_name, value_tensor)
 
         return True
 
@@ -149,6 +163,11 @@ class ParameterEstimateApplicator:
                 return estimate.value
 
             value_tensor = torch.as_tensor(estimate.value)
+            value_tensor = torch.as_tensor(
+                    estimate.value,
+                    dtype=torch.get_default_dtype(),
+                    )
+
 
             if value_tensor.numel() == 1:
                 scalar = float(value_tensor.item())
@@ -186,8 +205,14 @@ class ParameterEstimateApplicator:
             if not self._is_explicit_log_parameter(estimate.name):
                 return (lower, upper)
 
-            lower_tensor = torch.as_tensor(lower)
-            upper_tensor = torch.as_tensor(upper)
+            lower_tensor = torch.as_tensor(
+                lower,
+                dtype=torch.get_default_dtype(),
+                )
+            upper_tensor = torch.as_tensor(
+                upper,
+                dtype=torch.get_default_dtype(),
+                )
 
             if lower_tensor.numel() == 1 and upper_tensor.numel() == 1:
                 lower_scalar = float(lower_tensor.item())

--- a/pgmuvi/parameter_application.py
+++ b/pgmuvi/parameter_application.py
@@ -8,6 +8,7 @@ later commits.
 from __future__ import annotations
 
 from pgmuvi.parameter_estimates import ParameterEstimateCollection
+from pgmuvi.parameter_specs import ParameterScale
 
 
 class ParameterEstimateApplicator:
@@ -42,4 +43,17 @@ class ParameterEstimateApplicator:
         """Apply one estimated constraint to a model parameter."""
         raise NotImplementedError(
             "Parameter constraint application is not implemented yet."
+        )
+
+    def _transform_value(self, estimate):
+        """Transform a physical-space estimate value into model parameter space."""
+        if estimate.value is None:
+            return None
+
+        if estimate.spec.scale is ParameterScale.LINEAR:
+            return estimate.value
+
+        raise NotImplementedError(
+            f"Value transformation for scale {estimate.spec.scale.value!r} "
+            "is not implemented yet."
         )

--- a/pgmuvi/parameter_application.py
+++ b/pgmuvi/parameter_application.py
@@ -1,8 +1,8 @@
 """Application layer for parameter estimates.
 
-This module defines the interface for applying physical-space parameter
-estimates to model parameters. Concrete application logic is added in
-later commits.
+This module defines utilities for applying physical-space parameter
+estimates to GPyTorch model parameters, including parameter-path
+resolution and parameter-space transformations.
 """
 
 from __future__ import annotations
@@ -139,12 +139,24 @@ class ParameterEstimateApplicator:
             return estimate.value
 
         if estimate.spec.scale is ParameterScale.LOG:
-            if estimate.value <= 0:
+            value_tensor = torch.as_tensor(estimate.value)
+
+            if value_tensor.numel() == 1:
+                scalar = float(value_tensor.item())
+                if scalar <= 0:
+                    raise ValueError(
+                        f"Cannot apply log transform to non-positive value for "
+                        f"{estimate.name!r}."
+                    )
+                return math.log(scalar)
+
+            if torch.any(value_tensor <= 0):
                 raise ValueError(
                     f"Cannot apply log transform to non-positive value for "
                     f"{estimate.name!r}."
                 )
-            return math.log(estimate.value)
+
+            return torch.log(value_tensor)
 
         raise NotImplementedError(
             f"Value transformation for scale {estimate.spec.scale.value!r} "
@@ -162,15 +174,33 @@ class ParameterEstimateApplicator:
             return (lower, upper)
 
         if estimate.spec.scale is ParameterScale.LOG:
-            if lower <= 0 or upper <= 0:
+            lower_tensor = torch.as_tensor(lower)
+            upper_tensor = torch.as_tensor(upper)
+
+            if lower_tensor.numel() == 1 and upper_tensor.numel() == 1:
+                lower_scalar = float(lower_tensor.item())
+                upper_scalar = float(upper_tensor.item())
+
+                if lower_scalar <= 0 or upper_scalar <= 0:
+                    raise ValueError(
+                        f"Cannot apply log transform to non-positive constraint "
+                        f"for {estimate.name!r}."
+                    )
+
+                return (
+                    math.log(lower_scalar),
+                    math.log(upper_scalar),
+                )
+
+            if torch.any(lower_tensor <= 0) or torch.any(upper_tensor <= 0):
                 raise ValueError(
                     f"Cannot apply log transform to non-positive constraint "
                     f"for {estimate.name!r}."
                 )
 
             return (
-                math.log(lower),
-                math.log(upper),
+                torch.log(lower_tensor),
+                torch.log(upper_tensor),
             )
 
         raise NotImplementedError(

--- a/pgmuvi/parameter_application.py
+++ b/pgmuvi/parameter_application.py
@@ -57,6 +57,12 @@ class ParameterEstimateApplicator:
         return obj
 
     @staticmethod
+    def _is_explicit_log_parameter(parameter_name: str) -> bool:
+        """Return True when the model parameter itself stores log(value)."""
+        local_name = parameter_name.split(".")[-1]
+        return local_name.startswith("log_")
+
+    @staticmethod
     def _split_parameter_path(parameter_name: str):
         """Split a parameter path into module path and local parameter name."""
         parts = parameter_name.split(".")
@@ -139,6 +145,9 @@ class ParameterEstimateApplicator:
             return estimate.value
 
         if estimate.spec.scale is ParameterScale.LOG:
+            if not self._is_explicit_log_parameter(estimate.name):
+                return estimate.value
+
             value_tensor = torch.as_tensor(estimate.value)
 
             if value_tensor.numel() == 1:
@@ -174,6 +183,9 @@ class ParameterEstimateApplicator:
             return (lower, upper)
 
         if estimate.spec.scale is ParameterScale.LOG:
+            if not self._is_explicit_log_parameter(estimate.name):
+                return (lower, upper)
+
             lower_tensor = torch.as_tensor(lower)
             upper_tensor = torch.as_tensor(upper)
 

--- a/tests/test_parameter_application.py
+++ b/tests/test_parameter_application.py
@@ -15,6 +15,28 @@ class TestParameterEstimateApplicator(unittest.TestCase):
                 estimates=ParameterEstimateCollection(),
             )
 
+    def test_resolve_parameter(self):
+        applicator = ParameterEstimateApplicator()
+
+        model = DummyModel()
+
+        result = applicator._resolve_parameter(
+            model,
+            "mean_module.offset",
+        )
+
+        self.assertEqual(result, 123.0)
+
+
+class DummyMeanModule:
+    def __init__(self):
+        self.offset = 123.0
+
+
+class DummyModel:
+    def __init__(self):
+        self.mean_module = DummyMeanModule()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_parameter_application.py
+++ b/tests/test_parameter_application.py
@@ -351,6 +351,22 @@ class TestParameterEstimateApplicator(unittest.TestCase):
         ):
             applicator._transform_constraint(estimate)
 
+    def test_split_nested_parameter_path(self):
+        module_path, local_name = ParameterEstimateApplicator._split_parameter_path(
+            "mean_module.log_amplitude"
+        )
+
+        self.assertEqual(module_path, "mean_module")
+        self.assertEqual(local_name, "log_amplitude")
+
+    def test_split_bare_parameter_path(self):
+        module_path, local_name = ParameterEstimateApplicator._split_parameter_path(
+            "offset"
+        )
+
+        self.assertEqual(module_path, "")
+        self.assertEqual(local_name, "offset")
+
 
 class DummyMeanModule:
     def __init__(self):

--- a/tests/test_parameter_application.py
+++ b/tests/test_parameter_application.py
@@ -11,6 +11,7 @@ from pgmuvi.parameter_specs import (
 )
 import math
 import torch
+import gpytorch
 
 
 class DummyRawConstraintModule:
@@ -572,6 +573,50 @@ class TestParameterEstimateApplicator(unittest.TestCase):
                 upper,
                 torch.tensor([4.605170185988092, 6.907755278982137]),
             )
+        )
+
+    def test_apply_value_updates_gpytorch_property_parameter(self):
+        spec = ParameterSpec(
+            name="covar_module.lengthscale",
+            role=ParameterRole.LENGTHSCALE,
+            domain=ParameterDomain.TIME,
+            scale=ParameterScale.LOG,
+        )
+
+        estimates = ParameterEstimateCollection(
+            [
+                ParameterEstimate(
+                    spec=spec,
+                    value=2.0,
+                )
+            ]
+        )
+
+        class Model:
+            def __init__(self):
+                self.covar_module = gpytorch.kernels.RBFKernel()
+
+        model = Model()
+        applicator = ParameterEstimateApplicator()
+
+        results = applicator.apply(
+            model=model,
+            estimates=estimates,
+        )
+
+        self.assertEqual(
+            results,
+            {
+                "covar_module.lengthscale": {
+                    "value": True,
+                    "constraint": False,
+                },
+            },
+        )
+
+        self.assertAlmostEqual(
+            float(model.covar_module.lengthscale.detach().cpu().view(-1)[0]),
+            2.0,
         )
 
 

--- a/tests/test_parameter_application.py
+++ b/tests/test_parameter_application.py
@@ -68,7 +68,24 @@ class TestParameterEstimateApplicator(unittest.TestCase):
             applicator._transform_value(estimate)
         )
 
-    def test_transform_non_linear_value_is_not_implemented_yet(self):
+    def test_transform_unsupported_value_scale_is_not_implemented_yet(self):
+        spec = ParameterSpec(
+            name="mean_module.log_amplitude",
+            role=ParameterRole.AMPLITUDE,
+            domain=ParameterDomain.FLUX,
+            scale=ParameterScale.LOG10,
+        )
+        estimate = ParameterEstimate(
+            spec=spec,
+            value=100.0,
+        )
+
+        applicator = ParameterEstimateApplicator()
+
+        with self.assertRaises(NotImplementedError):
+            applicator._transform_value(estimate)
+
+    def test_transform_log_value_applies_natural_log(self):
         spec = ParameterSpec(
             name="mean_module.log_amplitude",
             role=ParameterRole.AMPLITUDE,
@@ -82,7 +99,26 @@ class TestParameterEstimateApplicator(unittest.TestCase):
 
         applicator = ParameterEstimateApplicator()
 
-        with self.assertRaises(NotImplementedError):
+        self.assertAlmostEqual(
+                applicator._transform_value(estimate),
+                4.605170185988092,
+                )
+
+    def test_transform_log_value_rejects_non_positive_values(self):
+        spec = ParameterSpec(
+            name="mean_module.log_amplitude",
+            role=ParameterRole.AMPLITUDE,
+            domain=ParameterDomain.FLUX,
+            scale=ParameterScale.LOG,
+        )
+        estimate = ParameterEstimate(
+            spec=spec,
+            value=0.0,
+        )
+
+        applicator = ParameterEstimateApplicator()
+
+        with self.assertRaisesRegex(ValueError, "non-positive"):
             applicator._transform_value(estimate)
 
 

--- a/tests/test_parameter_application.py
+++ b/tests/test_parameter_application.py
@@ -13,6 +13,20 @@ import math
 import torch
 
 
+class DummyRawConstraintModule:
+    def __init__(self):
+        self.raw_lengthscale = torch.nn.Parameter(torch.zeros(1))
+        self.calls = []
+
+    def register_constraint(self, parameter_name, constraint):
+        self.calls.append((parameter_name, constraint))
+
+
+class DummyRawConstraintModel:
+    def __init__(self):
+        self.covar_module = DummyRawConstraintModule()
+
+
 class DummyTensorMeanModule:
     def __init__(self):
         self.offset = torch.nn.Parameter(torch.zeros(1))
@@ -173,7 +187,8 @@ class TestParameterEstimateApplicator(unittest.TestCase):
         applicator = ParameterEstimateApplicator()
 
         applied = applicator._apply_value(
-            model.mean_module.offset,
+            model.mean_module,
+            "offset",
             estimate,
         )
 
@@ -199,7 +214,8 @@ class TestParameterEstimateApplicator(unittest.TestCase):
         applicator = ParameterEstimateApplicator()
 
         applied = applicator._apply_value(
-            model.mean_module.log_amplitude,
+            model.mean_module,
+            "log_amplitude",
             estimate,
         )
 
@@ -223,7 +239,8 @@ class TestParameterEstimateApplicator(unittest.TestCase):
         applicator = ParameterEstimateApplicator()
 
         applied = applicator._apply_value(
-            model.mean_module.offset,
+            model.mean_module,
+            "offset",
             estimate,
         )
 
@@ -471,6 +488,39 @@ class TestParameterEstimateApplicator(unittest.TestCase):
             len(model.mean_module.calls),
             0,
         )
+
+    def test_apply_constraint_prefers_raw_parameter_name_when_available(self):
+        spec = ParameterSpec(
+            name="covar_module.lengthscale",
+            role=ParameterRole.LENGTHSCALE,
+            domain=ParameterDomain.TIME,
+            scale=ParameterScale.LOG,
+        )
+
+        estimate = ParameterEstimate(
+            spec=spec,
+            constraint=(1.0, 100.0),
+        )
+
+        model = DummyRawConstraintModel()
+        applicator = ParameterEstimateApplicator()
+
+        applied = applicator._apply_constraint(
+            model,
+            estimate,
+        )
+
+        self.assertTrue(applied)
+        self.assertEqual(len(model.covar_module.calls), 1)
+
+        parameter_name, constraint = model.covar_module.calls[0]
+
+        self.assertEqual(parameter_name, "raw_lengthscale")
+        self.assertAlmostEqual(float(constraint.lower_bound), 0.0)
+        self.assertAlmostEqual(float(constraint.upper_bound),
+                               4.605170185988092,
+                               places=6,
+                               )
 
 
 class DummyMeanModule:

--- a/tests/test_parameter_application.py
+++ b/tests/test_parameter_application.py
@@ -9,6 +9,7 @@ from pgmuvi.parameter_specs import (
     ParameterScale,
     ParameterSpec,
 )
+import math
 import torch
 
 
@@ -261,6 +262,94 @@ class TestParameterEstimateApplicator(unittest.TestCase):
             4.605170185988092,
             places=6,
         )
+
+    def test_transform_linear_constraint_returns_constraint_unchanged(self):
+        spec = ParameterSpec(
+            name="mean_module.offset",
+            role=ParameterRole.OFFSET,
+            domain=ParameterDomain.FLUX,
+            scale=ParameterScale.LINEAR,
+        )
+
+        estimate = ParameterEstimate(
+            spec=spec,
+            constraint=(10.0, 100.0),
+        )
+
+        applicator = ParameterEstimateApplicator()
+
+        self.assertEqual(
+            applicator._transform_constraint(estimate),
+            (10.0, 100.0),
+        )
+
+    def test_transform_log_constraint_applies_natural_log(self):
+        spec = ParameterSpec(
+            name="mean_module.log_amplitude",
+            role=ParameterRole.AMPLITUDE,
+            domain=ParameterDomain.FLUX,
+            scale=ParameterScale.LOG,
+        )
+
+        estimate = ParameterEstimate(
+            spec=spec,
+            constraint=(1.0e-4, 450.0),
+        )
+
+        applicator = ParameterEstimateApplicator()
+
+        lower, upper = applicator._transform_constraint(
+            estimate
+        )
+
+        self.assertAlmostEqual(
+            lower,
+            math.log(1.0e-4),
+        )
+
+        self.assertAlmostEqual(
+            upper,
+            math.log(450.0),
+        )
+
+    def test_transform_constraint_returns_none_when_missing(self):
+        spec = ParameterSpec(
+            name="mean_module.offset",
+            role=ParameterRole.OFFSET,
+            domain=ParameterDomain.FLUX,
+            scale=ParameterScale.LINEAR,
+        )
+
+        estimate = ParameterEstimate(
+            spec=spec,
+        )
+
+        applicator = ParameterEstimateApplicator()
+
+        self.assertIsNone(
+            applicator._transform_constraint(estimate)
+        )
+
+    def test_transform_log_constraint_rejects_non_positive_bounds(self):
+        spec = ParameterSpec(
+            name="mean_module.log_amplitude",
+            role=ParameterRole.AMPLITUDE,
+            domain=ParameterDomain.FLUX,
+            scale=ParameterScale.LOG,
+        )
+
+        estimate = ParameterEstimate(
+            spec=spec,
+            constraint=(0.0, 100.0),
+        )
+
+        applicator = ParameterEstimateApplicator()
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "non-positive",
+        ):
+            applicator._transform_constraint(estimate)
 
 
 class DummyMeanModule:

--- a/tests/test_parameter_application.py
+++ b/tests/test_parameter_application.py
@@ -24,6 +24,28 @@ class DummyTensorModel:
         self.mean_module = DummyTensorMeanModule()
 
 
+class DummyConstraintModule:
+    def __init__(self):
+        self.calls = []
+
+    def register_constraint(
+        self,
+        parameter_name,
+        constraint,
+    ):
+        self.calls.append(
+            (
+                parameter_name,
+                constraint,
+            )
+        )
+
+
+class DummyConstraintModel:
+    def __init__(self):
+        self.mean_module = DummyConstraintModule()
+
+
 class TestParameterEstimateApplicator(unittest.TestCase):
 
     def test_apply_empty_collection_returns_empty_results(self):
@@ -366,6 +388,82 @@ class TestParameterEstimateApplicator(unittest.TestCase):
 
         self.assertEqual(module_path, "")
         self.assertEqual(local_name, "offset")
+
+    def test_apply_linear_constraint(self):
+        spec = ParameterSpec(
+            name="mean_module.offset",
+            role=ParameterRole.OFFSET,
+            domain=ParameterDomain.FLUX,
+            scale=ParameterScale.LINEAR,
+        )
+
+        estimate = ParameterEstimate(
+            spec=spec,
+            constraint=(10.0, 100.0),
+        )
+
+        model = DummyConstraintModel()
+
+        applicator = ParameterEstimateApplicator()
+
+        applied = applicator._apply_constraint(
+            model,
+            estimate,
+        )
+
+        self.assertTrue(applied)
+
+        self.assertEqual(
+            len(model.mean_module.calls),
+            1,
+        )
+
+        parameter_name, constraint = (
+            model.mean_module.calls[0]
+        )
+
+        self.assertEqual(
+            parameter_name,
+            "offset",
+        )
+
+        self.assertAlmostEqual(
+            float(constraint.lower_bound),
+            10.0,
+        )
+
+        self.assertAlmostEqual(
+            float(constraint.upper_bound),
+            100.0,
+        )
+
+    def test_apply_constraint_returns_false_when_missing(self):
+        spec = ParameterSpec(
+            name="mean_module.offset",
+            role=ParameterRole.OFFSET,
+            domain=ParameterDomain.FLUX,
+            scale=ParameterScale.LINEAR,
+        )
+
+        estimate = ParameterEstimate(
+            spec=spec,
+        )
+
+        model = DummyConstraintModel()
+
+        applicator = ParameterEstimateApplicator()
+
+        self.assertFalse(
+            applicator._apply_constraint(
+                model,
+                estimate,
+            )
+        )
+
+        self.assertEqual(
+            len(model.mean_module.calls),
+            0,
+        )
 
 
 class DummyMeanModule:

--- a/tests/test_parameter_application.py
+++ b/tests/test_parameter_application.py
@@ -522,6 +522,61 @@ class TestParameterEstimateApplicator(unittest.TestCase):
                                places=6,
                                )
 
+    def test_transform_log_vector_value_applies_elementwise_log(self):
+        spec = ParameterSpec(
+            name="covar_module.mixture_weights",
+            role=ParameterRole.WEIGHT,
+            domain=ParameterDomain.VARIANCE,
+            scale=ParameterScale.LOG,
+            shape=(2,),
+        )
+
+        estimate = ParameterEstimate(
+            spec=spec,
+            value=[1.0, 100.0],
+        )
+
+        applicator = ParameterEstimateApplicator()
+        transformed = applicator._transform_value(estimate)
+
+        self.assertTrue(torch.allclose(
+            transformed,
+            torch.tensor([0.0, 4.605170185988092]),
+        ))
+
+    def test_transform_log_vector_constraint_applies_elementwise_log(self):
+        spec = ParameterSpec(
+            name="covar_module.mixture_weights",
+            role=ParameterRole.WEIGHT,
+            domain=ParameterDomain.VARIANCE,
+            scale=ParameterScale.LOG,
+            shape=(2,),
+        )
+
+        estimate = ParameterEstimate(
+            spec=spec,
+            constraint=(
+                [1.0, 10.0],
+                [100.0, 1000.0],
+            ),
+        )
+
+        applicator = ParameterEstimateApplicator()
+        lower, upper = applicator._transform_constraint(estimate)
+
+        self.assertTrue(
+            torch.allclose(
+                lower,
+                torch.tensor([0.0, 2.302585092994046]),
+            )
+        )
+        self.assertTrue(
+            torch.allclose(
+                upper,
+                torch.tensor([4.605170185988092, 6.907755278982137]),
+            )
+        )
+
 
 class DummyMeanModule:
     def __init__(self):

--- a/tests/test_parameter_application.py
+++ b/tests/test_parameter_application.py
@@ -9,6 +9,18 @@ from pgmuvi.parameter_specs import (
     ParameterScale,
     ParameterSpec,
 )
+import torch
+
+
+class DummyTensorMeanModule:
+    def __init__(self):
+        self.offset = torch.nn.Parameter(torch.zeros(1))
+        self.log_amplitude = torch.nn.Parameter(torch.zeros(1))
+
+
+class DummyTensorModel:
+    def __init__(self):
+        self.mean_module = DummyTensorMeanModule()
 
 
 class TestParameterEstimateApplicator(unittest.TestCase):
@@ -120,6 +132,82 @@ class TestParameterEstimateApplicator(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "non-positive"):
             applicator._transform_value(estimate)
+
+    def test_apply_linear_value_to_tensor_parameter(self):
+        spec = ParameterSpec(
+            name="mean_module.offset",
+            role=ParameterRole.OFFSET,
+            domain=ParameterDomain.FLUX,
+            scale=ParameterScale.LINEAR,
+        )
+        estimate = ParameterEstimate(
+            spec=spec,
+            value=123.0,
+        )
+
+        model = DummyTensorModel()
+        applicator = ParameterEstimateApplicator()
+
+        applied = applicator._apply_value(
+            model.mean_module.offset,
+            estimate,
+        )
+
+        self.assertTrue(applied)
+        self.assertAlmostEqual(
+            float(model.mean_module.offset.item()),
+            123.0,
+        )
+
+    def test_apply_log_value_to_tensor_parameter(self):
+        spec = ParameterSpec(
+            name="mean_module.log_amplitude",
+            role=ParameterRole.AMPLITUDE,
+            domain=ParameterDomain.FLUX,
+            scale=ParameterScale.LOG,
+        )
+        estimate = ParameterEstimate(
+            spec=spec,
+            value=100.0,
+        )
+
+        model = DummyTensorModel()
+        applicator = ParameterEstimateApplicator()
+
+        applied = applicator._apply_value(
+            model.mean_module.log_amplitude,
+            estimate,
+        )
+
+        self.assertTrue(applied)
+        self.assertAlmostEqual(
+            float(model.mean_module.log_amplitude.item()),
+            4.605170185988092,
+            places=6,
+        )
+
+    def test_apply_value_returns_false_when_value_missing(self):
+        spec = ParameterSpec(
+            name="mean_module.offset",
+            role=ParameterRole.OFFSET,
+            domain=ParameterDomain.FLUX,
+            scale=ParameterScale.LINEAR,
+        )
+        estimate = ParameterEstimate(spec=spec)
+
+        model = DummyTensorModel()
+        applicator = ParameterEstimateApplicator()
+
+        applied = applicator._apply_value(
+            model.mean_module.offset,
+            estimate,
+        )
+
+        self.assertFalse(applied)
+        self.assertAlmostEqual(
+            float(model.mean_module.offset.item()),
+            0.0,
+        )
 
 
 class DummyMeanModule:

--- a/tests/test_parameter_application.py
+++ b/tests/test_parameter_application.py
@@ -1,0 +1,20 @@
+import unittest
+
+from pgmuvi.parameter_application import ParameterEstimateApplicator
+from pgmuvi.parameter_estimates import ParameterEstimateCollection
+
+
+class TestParameterEstimateApplicator(unittest.TestCase):
+
+    def test_apply_is_not_implemented_initially(self):
+        applicator = ParameterEstimateApplicator()
+
+        with self.assertRaises(NotImplementedError):
+            applicator.apply(
+                model=object(),
+                estimates=ParameterEstimateCollection(),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_parameter_application.py
+++ b/tests/test_parameter_application.py
@@ -271,10 +271,17 @@ class TestParameterEstimateApplicator(unittest.TestCase):
         self.assertEqual(
             results,
             {
-                "mean_module.offset": True,
-                "mean_module.log_amplitude": True,
+                "mean_module.offset": {
+                    "value": True,
+                    "constraint": False,
+                },
+                "mean_module.log_amplitude": {
+                    "value": True,
+                    "constraint": False,
+                },
             },
         )
+
         self.assertAlmostEqual(
             float(model.mean_module.offset.item()),
             123.0,

--- a/tests/test_parameter_application.py
+++ b/tests/test_parameter_application.py
@@ -516,17 +516,14 @@ class TestParameterEstimateApplicator(unittest.TestCase):
         parameter_name, constraint = model.covar_module.calls[0]
 
         self.assertEqual(parameter_name, "raw_lengthscale")
-        self.assertAlmostEqual(float(constraint.lower_bound), 0.0)
-        self.assertAlmostEqual(float(constraint.upper_bound),
-                               4.605170185988092,
-                               places=6,
-                               )
+        self.assertAlmostEqual(float(constraint.lower_bound), 1.0)
+        self.assertAlmostEqual(float(constraint.upper_bound), 100.0)
 
     def test_transform_log_vector_value_applies_elementwise_log(self):
         spec = ParameterSpec(
-            name="covar_module.mixture_weights",
-            role=ParameterRole.WEIGHT,
-            domain=ParameterDomain.VARIANCE,
+            name="mean_module.log_amplitudes",
+            role=ParameterRole.AMPLITUDE,
+            domain=ParameterDomain.FLUX,
             scale=ParameterScale.LOG,
             shape=(2,),
         )
@@ -546,9 +543,9 @@ class TestParameterEstimateApplicator(unittest.TestCase):
 
     def test_transform_log_vector_constraint_applies_elementwise_log(self):
         spec = ParameterSpec(
-            name="covar_module.mixture_weights",
-            role=ParameterRole.WEIGHT,
-            domain=ParameterDomain.VARIANCE,
+            name="mean_module.log_amplitudes",
+            role=ParameterRole.AMPLITUDE,
+            domain=ParameterDomain.FLUX,
             scale=ParameterScale.LOG,
             shape=(2,),
         )

--- a/tests/test_parameter_application.py
+++ b/tests/test_parameter_application.py
@@ -151,9 +151,9 @@ class TestParameterEstimateApplicator(unittest.TestCase):
         applicator = ParameterEstimateApplicator()
 
         self.assertAlmostEqual(
-                applicator._transform_value(estimate),
-                4.605170185988092,
-                )
+            applicator._transform_value(estimate),
+            4.605170185988092,
+        )
 
     def test_transform_log_value_rejects_non_positive_values(self):
         spec = ParameterSpec(

--- a/tests/test_parameter_application.py
+++ b/tests/test_parameter_application.py
@@ -25,14 +25,15 @@ class DummyTensorModel:
 
 class TestParameterEstimateApplicator(unittest.TestCase):
 
-    def test_apply_is_not_implemented_initially(self):
+    def test_apply_empty_collection_returns_empty_results(self):
         applicator = ParameterEstimateApplicator()
 
-        with self.assertRaises(NotImplementedError):
-            applicator.apply(
-                model=object(),
-                estimates=ParameterEstimateCollection(),
-            )
+        results = applicator.apply(
+            model=object(),
+            estimates=ParameterEstimateCollection(),
+        )
+
+        self.assertEqual(results, {})
 
     def test_resolve_parameter(self):
         applicator = ParameterEstimateApplicator()
@@ -207,6 +208,58 @@ class TestParameterEstimateApplicator(unittest.TestCase):
         self.assertAlmostEqual(
             float(model.mean_module.offset.item()),
             0.0,
+        )
+
+    def test_apply_collection_applies_available_values(self):
+        offset_spec = ParameterSpec(
+            name="mean_module.offset",
+            role=ParameterRole.OFFSET,
+            domain=ParameterDomain.FLUX,
+            scale=ParameterScale.LINEAR,
+        )
+        amplitude_spec = ParameterSpec(
+            name="mean_module.log_amplitude",
+            role=ParameterRole.AMPLITUDE,
+            domain=ParameterDomain.FLUX,
+            scale=ParameterScale.LOG,
+        )
+
+        estimates = ParameterEstimateCollection(
+            [
+                ParameterEstimate(
+                    spec=offset_spec,
+                    value=123.0,
+                ),
+                ParameterEstimate(
+                    spec=amplitude_spec,
+                    value=100.0,
+                ),
+            ]
+        )
+
+        model = DummyTensorModel()
+        applicator = ParameterEstimateApplicator()
+
+        results = applicator.apply(
+            model=model,
+            estimates=estimates,
+        )
+
+        self.assertEqual(
+            results,
+            {
+                "mean_module.offset": True,
+                "mean_module.log_amplitude": True,
+            },
+        )
+        self.assertAlmostEqual(
+            float(model.mean_module.offset.item()),
+            123.0,
+        )
+        self.assertAlmostEqual(
+            float(model.mean_module.log_amplitude.item()),
+            4.605170185988092,
+            places=6,
         )
 
 

--- a/tests/test_parameter_application.py
+++ b/tests/test_parameter_application.py
@@ -2,6 +2,13 @@ import unittest
 
 from pgmuvi.parameter_application import ParameterEstimateApplicator
 from pgmuvi.parameter_estimates import ParameterEstimateCollection
+from pgmuvi.parameter_estimates import ParameterEstimate
+from pgmuvi.parameter_specs import (
+    ParameterDomain,
+    ParameterRole,
+    ParameterScale,
+    ParameterSpec,
+)
 
 
 class TestParameterEstimateApplicator(unittest.TestCase):
@@ -26,6 +33,57 @@ class TestParameterEstimateApplicator(unittest.TestCase):
         )
 
         self.assertEqual(result, 123.0)
+
+    def test_transform_linear_value_returns_value_unchanged(self):
+        spec = ParameterSpec(
+            name="mean_module.offset",
+            role=ParameterRole.OFFSET,
+            domain=ParameterDomain.FLUX,
+            scale=ParameterScale.LINEAR,
+        )
+        estimate = ParameterEstimate(
+            spec=spec,
+            value=123.0,
+        )
+
+        applicator = ParameterEstimateApplicator()
+
+        self.assertEqual(
+            applicator._transform_value(estimate),
+            123.0,
+        )
+
+    def test_transform_value_returns_none_when_value_missing(self):
+        spec = ParameterSpec(
+            name="mean_module.offset",
+            role=ParameterRole.OFFSET,
+            domain=ParameterDomain.FLUX,
+            scale=ParameterScale.LINEAR,
+        )
+        estimate = ParameterEstimate(spec=spec)
+
+        applicator = ParameterEstimateApplicator()
+
+        self.assertIsNone(
+            applicator._transform_value(estimate)
+        )
+
+    def test_transform_non_linear_value_is_not_implemented_yet(self):
+        spec = ParameterSpec(
+            name="mean_module.log_amplitude",
+            role=ParameterRole.AMPLITUDE,
+            domain=ParameterDomain.FLUX,
+            scale=ParameterScale.LOG,
+        )
+        estimate = ParameterEstimate(
+            spec=spec,
+            value=100.0,
+        )
+
+        applicator = ParameterEstimateApplicator()
+
+        with self.assertRaises(NotImplementedError):
+            applicator._transform_value(estimate)
 
 
 class DummyMeanModule:


### PR DESCRIPTION
## Summary

This PR adds the application layer for the parameter-estimation framework introduced in the previous PR.

The new infrastructure takes parameter estimates expressed in physical/data space and applies them to model parameters in the appropriate model parameter space.

This establishes the full path:

ParameterSpec
→ ParameterEstimateBuilder
→ ParameterEstimateCollection
→ ParameterEstimateApplicator
→ model parameters

## Motivation

The previous PR introduced model-independent parameter specifications, diagnostics, estimation contexts, and parameter estimation rules.

However, estimated values and constraints still existed only as intermediate objects and could not be applied to actual GPyTorch models.

This PR introduces a dedicated application layer responsible for:

* parameter path resolution,
* parameter-space transformations,
* value assignment,
* constraint registration,
* collection-level application workflows.

Keeping this functionality separate from fitting code allows parameter initialization and constraint handling to be tested independently of optimization.

## Main Changes

### ParameterEstimateApplicator

Added a dedicated application framework:

* `ParameterEstimateApplicator`

The applicator is responsible for converting physical-space estimates into model-space quantities and applying them to model parameters.

### Parameter path handling

Added utilities for:

* dotted-path parameter resolution
* module/parameter path splitting

Examples:

```text
mean_module.offset
mean_module.log_amplitude
```

can now be resolved and manipulated programmatically.

### Value transformations

Added support for transforming estimate values into parameter space.

Currently supported:

* `ParameterScale.LINEAR`
* `ParameterScale.LOG`

Examples:

```text
offset = 55
```

remains:

```text
55
```

while

```text
amplitude = 90
```

becomes:

```text
log(90)
```

for LOG-scaled parameters.

### Value application

Added assignment of transformed values to tensor parameters while preserving:

* dtype
* device
* tensor shape

### Constraint transformations

Added transformation of physical-space constraint bounds into parameter-space bounds.

Currently supported:

* `ParameterScale.LINEAR`
* `ParameterScale.LOG`

Examples:

```text
(1e-4, 450)
```

becomes:

```text
(log(1e-4), log(450))
```

for LOG-scaled parameters.

### Constraint application

Added registration of transformed interval constraints using GPyTorch:

```python
gpytorch.constraints.Interval(...)
```

Constraint application uses parameter-path utilities to identify the correct target module and parameter.

### Collection-level application

The applicator can now process an entire `ParameterEstimateCollection` and apply:

* values
* constraints

for all available estimates.

Per-parameter application results are returned to aid diagnostics and testing.

## Tests

Added coverage for:

* parameter path resolution
* parameter path splitting
* value transformations
* constraint transformations
* tensor value assignment
* interval constraint registration
* collection-level application workflows

## Scope

This PR introduces the application layer only.

It does not:

* modify fitting workflows,
* automatically invoke estimation/application during fitting,
* add model-specific estimation rules,
* add kernel-specific initialization logic,
* modify optimization behaviour.

Integration into fitting workflows will be addressed in later PRs.

## Testing

```bash
python3 -m unittest discover -s tests -p "test_parameter_application.py"
```
