### PR TITLE
Add parameter estimation workflow helpers

### DIFF
--- a/pgmuvi/parameter_workflow.py
+++ b/pgmuvi/parameter_workflow.py
@@ -57,3 +57,23 @@ def apply_parameter_estimates(
         model=model,
         estimates=estimates,
     )
+
+
+def build_and_apply_parameter_estimates(
+    model: Any,
+    context: ParameterEstimationContext,
+    builder: ParameterEstimateBuilder | None = None,
+    applicator: ParameterEstimateApplicator | None = None,
+) -> dict[str, dict[str, bool]] | None:
+    """Build and apply parameter estimates for a model when possible."""
+    estimates = build_parameter_estimates(
+        model=model,
+        context=context,
+        builder=builder,
+    )
+
+    return apply_parameter_estimates(
+        model=model,
+        estimates=estimates,
+        applicator=applicator,
+    )

--- a/pgmuvi/parameter_workflow.py
+++ b/pgmuvi/parameter_workflow.py
@@ -2,19 +2,31 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from pgmuvi.parameter_application import ParameterEstimateApplicator
 from pgmuvi.parameter_builders import ParameterEstimateBuilder
+from pgmuvi.parameter_context import ParameterEstimationContext
+from pgmuvi.parameter_estimates import ParameterEstimateCollection
+from pgmuvi.parameter_specs import ParameterSpecCollection
 
 
-def get_parameter_schema(model):
+def get_parameter_schema(model: Any) -> ParameterSpecCollection | None:
     """Return a model parameter schema if one is available."""
-    if not hasattr(model, "parameter_schema"):
+    schema_attr = getattr(model, "parameter_schema", None)
+    if schema_attr is None:
         return None
+
+    return schema_attr()
 
     return model.parameter_schema()
 
 
-def build_parameter_estimates(model, context, builder=None):
+def build_parameter_estimates(
+        model: Any,
+        context: ParameterEstimationContext,
+        builder: ParameterEstimateBuilder | None = None,
+        ) -> ParameterEstimateCollection | None:
     """Build parameter estimates for a model if a schema is available."""
     schema = get_parameter_schema(model)
 
@@ -30,7 +42,11 @@ def build_parameter_estimates(model, context, builder=None):
     )
 
 
-def apply_parameter_estimates(model, estimates, applicator=None):
+def apply_parameter_estimates(
+        model: Any,
+        estimates: ParameterEstimateCollection | None,
+        applicator: ParameterEstimateApplicator | None = None,
+        ) -> dict[str, dict[str, bool]] | None:
     """Apply parameter estimates to a model if estimates are available."""
     if estimates is None:
         return None

--- a/pgmuvi/parameter_workflow.py
+++ b/pgmuvi/parameter_workflow.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from pgmuvi.parameter_application import ParameterEstimateApplicator
+from pgmuvi.parameter_builders import ParameterEstimateBuilder
+
 
 def get_parameter_schema(model):
     """Return a model parameter schema if one is available."""
@@ -9,3 +12,33 @@ def get_parameter_schema(model):
         return None
 
     return model.parameter_schema()
+
+
+def build_parameter_estimates(model, context, builder=None):
+    """Build parameter estimates for a model if a schema is available."""
+    schema = get_parameter_schema(model)
+
+    if schema is None:
+        return None
+
+    if builder is None:
+        builder = ParameterEstimateBuilder()
+
+    return builder.build(
+        schema=schema,
+        context=context,
+    )
+
+
+def apply_parameter_estimates(model, estimates, applicator=None):
+    """Apply parameter estimates to a model if estimates are available."""
+    if estimates is None:
+        return None
+
+    if applicator is None:
+        applicator = ParameterEstimateApplicator()
+
+    return applicator.apply(
+        model=model,
+        estimates=estimates,
+    )

--- a/pgmuvi/parameter_workflow.py
+++ b/pgmuvi/parameter_workflow.py
@@ -14,19 +14,18 @@ from pgmuvi.parameter_specs import ParameterSpecCollection
 def get_parameter_schema(model: Any) -> ParameterSpecCollection | None:
     """Return a model parameter schema if one is available."""
     schema_attr = getattr(model, "parameter_schema", None)
-    if schema_attr is None:
+
+    if schema_attr is None or not callable(schema_attr):
         return None
 
     return schema_attr()
 
-    return model.parameter_schema()
-
 
 def build_parameter_estimates(
-        model: Any,
-        context: ParameterEstimationContext,
-        builder: ParameterEstimateBuilder | None = None,
-        ) -> ParameterEstimateCollection | None:
+    model: Any,
+    context: ParameterEstimationContext,
+    builder: ParameterEstimateBuilder | None = None,
+) -> ParameterEstimateCollection | None:
     """Build parameter estimates for a model if a schema is available."""
     schema = get_parameter_schema(model)
 
@@ -43,10 +42,10 @@ def build_parameter_estimates(
 
 
 def apply_parameter_estimates(
-        model: Any,
-        estimates: ParameterEstimateCollection | None,
-        applicator: ParameterEstimateApplicator | None = None,
-        ) -> dict[str, dict[str, bool]] | None:
+    model: Any,
+    estimates: ParameterEstimateCollection | None,
+    applicator: ParameterEstimateApplicator | None = None,
+) -> dict[str, dict[str, bool]] | None:
     """Apply parameter estimates to a model if estimates are available."""
     if estimates is None:
         return None

--- a/pgmuvi/parameter_workflow.py
+++ b/pgmuvi/parameter_workflow.py
@@ -18,7 +18,15 @@ def get_parameter_schema(model: Any) -> ParameterSpecCollection | None:
     if schema_attr is None or not callable(schema_attr):
         return None
 
-    return schema_attr()
+    try:
+        schema = schema_attr()
+    except TypeError:
+        return None
+
+    if not isinstance(schema, ParameterSpecCollection):
+        return None
+
+    return schema
 
 
 def build_parameter_estimates(

--- a/pgmuvi/parameter_workflow.py
+++ b/pgmuvi/parameter_workflow.py
@@ -11,6 +11,11 @@ from pgmuvi.parameter_estimates import ParameterEstimateCollection
 from pgmuvi.parameter_specs import ParameterSpecCollection
 
 
+def model_supports_parameter_workflow(model: Any) -> bool:
+    """Return whether a model exposes a valid parameter schema."""
+    return get_parameter_schema(model) is not None
+
+
 def get_parameter_schema(model: Any) -> ParameterSpecCollection | None:
     """Return a model parameter schema if one is available."""
     schema_attr = getattr(model, "parameter_schema", None)

--- a/pgmuvi/parameter_workflow.py
+++ b/pgmuvi/parameter_workflow.py
@@ -1,0 +1,11 @@
+"""High-level parameter-estimation workflow helpers."""
+
+from __future__ import annotations
+
+
+def get_parameter_schema(model):
+    """Return a model parameter schema if one is available."""
+    if not hasattr(model, "parameter_schema"):
+        return None
+
+    return model.parameter_schema()

--- a/tests/test_parameter_workflow.py
+++ b/tests/test_parameter_workflow.py
@@ -1,6 +1,25 @@
 import unittest
 
-from pgmuvi.parameter_workflow import get_parameter_schema
+import torch
+
+from pgmuvi.parameter_context import (
+    LightcurveDiagnostics,
+    ParameterEstimationContext,
+)
+from pgmuvi.parameter_specs import (
+    ConstraintStrategy,
+    GuessStrategy,
+    ParameterDomain,
+    ParameterRole,
+    ParameterScale,
+    ParameterSpec,
+    ParameterSpecCollection,
+)
+from pgmuvi.parameter_workflow import (
+    apply_parameter_estimates,
+    build_parameter_estimates,
+    get_parameter_schema,
+)
 
 
 class ModelWithSchema:
@@ -10,6 +29,34 @@ class ModelWithSchema:
 
 class ModelWithoutSchema:
     pass
+
+
+class DummyMeanModule:
+    def __init__(self):
+        self.offset = torch.nn.Parameter(torch.zeros(1))
+        self.calls = []
+
+    def register_constraint(self, parameter_name, constraint):
+        self.calls.append((parameter_name, constraint))
+
+
+class ModelWithRealSchema:
+    def __init__(self):
+        self.mean_module = DummyMeanModule()
+
+    def parameter_schema(self):
+        return ParameterSpecCollection(
+            [
+                ParameterSpec(
+                    name="mean_module.offset",
+                    role=ParameterRole.OFFSET,
+                    domain=ParameterDomain.FLUX,
+                    scale=ParameterScale.LINEAR,
+                    guess_strategy=GuessStrategy.MEDIAN_FLUX,
+                    constraint_strategy=ConstraintStrategy.ROBUST_FLUX_RANGE,
+                ),
+            ]
+        )
 
 
 class TestParameterWorkflow(unittest.TestCase):
@@ -23,6 +70,90 @@ class TestParameterWorkflow(unittest.TestCase):
     def test_returns_none_when_unavailable(self):
         self.assertIsNone(
             get_parameter_schema(ModelWithoutSchema())
+        )
+
+    def test_build_parameter_estimates_returns_none_without_schema(self):
+        context = ParameterEstimationContext(is_multiband=False)
+
+        self.assertIsNone(
+            build_parameter_estimates(
+                model=ModelWithoutSchema(),
+                context=context,
+            )
+        )
+
+    def test_build_parameter_estimates_uses_schema_and_context(self):
+        model = ModelWithRealSchema()
+        context = ParameterEstimationContext(
+            is_multiband=False,
+            global_diagnostics=LightcurveDiagnostics(
+                median_flux=55.0,
+                flux_percentiles={
+                    2.5: 10.0,
+                    97.5: 100.0,
+                },
+            ),
+        )
+
+        estimates = build_parameter_estimates(
+            model=model,
+            context=context,
+        )
+
+        estimate = estimates["mean_module.offset"]
+
+        self.assertEqual(estimate.value, 55.0)
+        self.assertEqual(estimate.constraint, (10.0, 100.0))
+
+    def test_apply_parameter_estimates_returns_none_without_estimates(self):
+        self.assertIsNone(
+            apply_parameter_estimates(
+                model=ModelWithoutSchema(),
+                estimates=None,
+            )
+        )
+
+    def test_apply_parameter_estimates_applies_values_and_constraints(self):
+        model = ModelWithRealSchema()
+        context = ParameterEstimationContext(
+            is_multiband=False,
+            global_diagnostics=LightcurveDiagnostics(
+                median_flux=55.0,
+                flux_percentiles={
+                    2.5: 10.0,
+                    97.5: 100.0,
+                },
+            ),
+        )
+
+        estimates = build_parameter_estimates(
+            model=model,
+            context=context,
+        )
+
+        results = apply_parameter_estimates(
+            model=model,
+            estimates=estimates,
+        )
+
+        self.assertEqual(
+            results,
+            {
+                "mean_module.offset": {
+                    "value": True,
+                    "constraint": True,
+                },
+            },
+        )
+
+        self.assertAlmostEqual(
+            float(model.mean_module.offset.item()),
+            55.0,
+        )
+
+        self.assertEqual(
+            model.mean_module.calls[0][0],
+            "offset",
         )
 
 

--- a/tests/test_parameter_workflow.py
+++ b/tests/test_parameter_workflow.py
@@ -1,0 +1,30 @@
+import unittest
+
+from pgmuvi.parameter_workflow import get_parameter_schema
+
+
+class ModelWithSchema:
+    def parameter_schema(self):
+        return "schema"
+
+
+class ModelWithoutSchema:
+    pass
+
+
+class TestParameterWorkflow(unittest.TestCase):
+
+    def test_returns_schema_when_available(self):
+        self.assertEqual(
+            get_parameter_schema(ModelWithSchema()),
+            "schema",
+        )
+
+    def test_returns_none_when_unavailable(self):
+        self.assertIsNone(
+            get_parameter_schema(ModelWithoutSchema())
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_parameter_workflow.py
+++ b/tests/test_parameter_workflow.py
@@ -17,6 +17,7 @@ from pgmuvi.parameter_specs import (
 )
 from pgmuvi.parameter_workflow import (
     apply_parameter_estimates,
+    build_and_apply_parameter_estimates,
     build_parameter_estimates,
     get_parameter_schema,
 )
@@ -134,6 +135,44 @@ class TestParameterWorkflow(unittest.TestCase):
         results = apply_parameter_estimates(
             model=model,
             estimates=estimates,
+        )
+
+        self.assertEqual(
+            results,
+            {
+                "mean_module.offset": {
+                    "value": True,
+                    "constraint": True,
+                },
+            },
+        )
+
+        self.assertAlmostEqual(
+            float(model.mean_module.offset.item()),
+            55.0,
+        )
+
+        self.assertEqual(
+            model.mean_module.calls[0][0],
+            "offset",
+        )
+
+    def test_build_and_apply_parameter_estimates_runs_full_workflow(self):
+        model = ModelWithRealSchema()
+        context = ParameterEstimationContext(
+            is_multiband=False,
+            global_diagnostics=LightcurveDiagnostics(
+                median_flux=55.0,
+                flux_percentiles={
+                    2.5: 10.0,
+                    97.5: 100.0,
+                },
+            ),
+        )
+
+        results = build_and_apply_parameter_estimates(
+            model=model,
+            context=context,
         )
 
         self.assertEqual(

--- a/tests/test_parameter_workflow.py
+++ b/tests/test_parameter_workflow.py
@@ -20,6 +20,7 @@ from pgmuvi.parameter_workflow import (
     build_and_apply_parameter_estimates,
     build_parameter_estimates,
     get_parameter_schema,
+    model_supports_parameter_workflow,
 )
 
 
@@ -223,6 +224,29 @@ class TestParameterWorkflow(unittest.TestCase):
     def test_returns_none_when_schema_requires_arguments(self):
         self.assertIsNone(
             get_parameter_schema(ModelWithSchemaRequiringArguments())
+        )
+
+    def test_model_supports_parameter_workflow_when_schema_available(self):
+        self.assertTrue(
+            model_supports_parameter_workflow(
+                ModelWithSchema()
+            )
+        )
+
+
+    def test_model_supports_parameter_workflow_when_schema_missing(self):
+        self.assertFalse(
+            model_supports_parameter_workflow(
+                ModelWithoutSchema()
+            )
+        )
+
+
+    def test_model_supports_parameter_workflow_when_schema_invalid(self):
+        self.assertFalse(
+            model_supports_parameter_workflow(
+                ModelWithWrongSchemaType()
+            )
         )
 
 

--- a/tests/test_parameter_workflow.py
+++ b/tests/test_parameter_workflow.py
@@ -23,9 +23,19 @@ from pgmuvi.parameter_workflow import (
 )
 
 
+class ModelWithWrongSchemaType:
+    def parameter_schema(self):
+        return "not-a-schema"
+
+
+class ModelWithSchemaRequiringArguments:
+    def parameter_schema(self, required_argument):
+        return required_argument
+
+
 class ModelWithSchema:
     def parameter_schema(self):
-        return "schema"
+        return ParameterSpecCollection()
 
 
 class ModelWithoutSchema:
@@ -63,9 +73,18 @@ class ModelWithRealSchema:
 class TestParameterWorkflow(unittest.TestCase):
 
     def test_returns_schema_when_available(self):
+        schema = get_parameter_schema(
+            ModelWithSchema()
+        )
+
+        self.assertIsInstance(
+            schema,
+            ParameterSpecCollection,
+        )
+
         self.assertEqual(
-            get_parameter_schema(ModelWithSchema()),
-            "schema",
+            len(schema),
+            0,
         )
 
     def test_returns_none_when_unavailable(self):
@@ -193,6 +212,17 @@ class TestParameterWorkflow(unittest.TestCase):
         self.assertEqual(
             model.mean_module.calls[0][0],
             "offset",
+        )
+
+    def test_returns_none_when_schema_has_wrong_type(self):
+        self.assertIsNone(
+            get_parameter_schema(ModelWithWrongSchemaType())
+        )
+
+
+    def test_returns_none_when_schema_requires_arguments(self):
+        self.assertIsNone(
+            get_parameter_schema(ModelWithSchemaRequiringArguments())
         )
 
 


### PR DESCRIPTION
## Summary

Add high-level workflow helpers that connect parameter schema discovery,
parameter estimate construction, and parameter estimate application.

## Changes

This PR adds:

- `pgmuvi/parameter_workflow.py`
- `tests/test_parameter_workflow.py`

The workflow helpers support:

- detecting whether a model exposes `parameter_schema()`
- building parameter estimates from a model schema and diagnostic context
- applying parameter estimates back to a model
- safely returning `None` when schema or estimates are unavailable

## Scope

This PR does **not** modify:

- `Lightcurve.fit()`
- fitting strategies
- optimization behavior
- consensus workflows

It only adds orchestration helpers around the parameter framework added in earlier PRs.

## Testing

```bash
python3 -m unittest discover -s tests -p "test_parameter_workflow.py"
python3 -m unittest discover -s tests -p "test_parameter_application.py"
python3 -m unittest discover -s tests -p "test_parameter_builders.py"