### PR TITLE
Integrate parameter workflow into fitting initialization

### DIFF
--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -9450,6 +9450,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             clear_model_state=False,
             clear_consensus=bool(fit_strategy is not None),
         )
+        _constraints_were_set_before_fit = bool(self.__CONTRAINTS_SET)
 
         verbose = kwargs.get("verbose", False)
 
@@ -9839,7 +9840,8 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         if not self.__CONTRAINTS_SET:
             self.set_default_constraints()
 
-        self._apply_parameter_workflow_estimates()
+        if not _constraints_were_set_before_fit:
+            self._apply_parameter_workflow_estimates()
 
         if cuda:
             self.cuda()

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -9029,14 +9029,15 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 global_diagnostics=LightcurveDiagnostics(),
             )
 
+        p025, p50, p975 = np.percentile(flux_values, [2.5, 50.0, 97.5])
         return ParameterEstimationContext(
             is_multiband=self.ndim > 1,
             global_diagnostics=LightcurveDiagnostics(
-                median_flux=float(np.median(flux_values)),
+                median_flux=float(p50),
                 flux_percentiles={
-                    2.5: float(np.percentile(flux_values, 2.5)),
-                    50.0: float(np.percentile(flux_values, 50.0)),
-                    97.5: float(np.percentile(flux_values, 97.5)),
+                    2.5: float(p025),
+                    50.0: float(p50),
+                    97.5: float(p975),
                 },
                 n_points=int(flux_values.size),
             ),

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -58,6 +58,14 @@ import dataclasses
 import json
 import math
 from types import MappingProxyType
+from pgmuvi.parameter_context import (
+    LightcurveDiagnostics,
+    ParameterEstimationContext,
+)
+from pgmuvi.parameter_workflow import (
+    build_and_apply_parameter_estimates,
+    model_supports_parameter_workflow,
+)
 
 try:
     from scipy.signal import find_peaks as _scipy_find_peaks
@@ -9007,6 +9015,30 @@ class Lightcurve(InputHelpers, gpytorch.Module):
 
         return model_str, diagnostics
 
+    def _build_parameter_estimation_context(self):
+        """Construct a parameter-estimation context from this light curve."""
+        flux_values = np.asarray(self._ydata_raw, dtype=float)
+        flux_values = flux_values[np.isfinite(flux_values)]
+
+        if flux_values.size == 0:
+            return ParameterEstimationContext(
+                is_multiband=self.ndim > 1,
+                global_diagnostics=LightcurveDiagnostics(),
+            )
+
+        return ParameterEstimationContext(
+            is_multiband=self.ndim > 1,
+            global_diagnostics=LightcurveDiagnostics(
+                median_flux=float(np.median(flux_values)),
+                flux_percentiles={
+                    2.5: float(np.percentile(flux_values, 2.5)),
+                    50.0: float(np.percentile(flux_values, 50.0)),
+                    97.5: float(np.percentile(flux_values, 97.5)),
+                },
+                n_points=int(flux_values.size),
+            ),
+        )
+
     def fit(self, *args, **kwargs):
         """Fit wrapper that records lightweight in-memory fit history."""
         # Nested fit() calls (e.g. from _consensus_standard_fit) delegate
@@ -9790,6 +9822,13 @@ class Lightcurve(InputHelpers, gpytorch.Module):
 
         if not self.__CONTRAINTS_SET:
             self.set_default_constraints()
+
+        if model_supports_parameter_workflow(self.model):
+            context = self._build_parameter_estimation_context()
+            build_and_apply_parameter_estimates(
+                model=self.model,
+                context=context,
+            )
 
         if cuda:
             self.cuda()
@@ -16707,6 +16746,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         raise NotImplementedError(
             "fit_strategy='consensus_relaxed' is not implemented yet."
         )
+
 
     def mcmc(
         self,

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -9039,6 +9039,18 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             ),
         )
 
+    def _apply_parameter_workflow_estimates(self):
+        """Apply parameter workflow estimates when the model supports them."""
+        if not model_supports_parameter_workflow(self.model):
+            return None
+
+        context = self._build_parameter_estimation_context()
+
+        return build_and_apply_parameter_estimates(
+            model=self.model,
+            context=context,
+        )
+
     def fit(self, *args, **kwargs):
         """Fit wrapper that records lightweight in-memory fit history."""
         # Nested fit() calls (e.g. from _consensus_standard_fit) delegate
@@ -9823,12 +9835,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         if not self.__CONTRAINTS_SET:
             self.set_default_constraints()
 
-        if model_supports_parameter_workflow(self.model):
-            context = self._build_parameter_estimation_context()
-            build_and_apply_parameter_estimates(
-                model=self.model,
-                context=context,
-            )
+        self._apply_parameter_workflow_estimates()
 
         if cuda:
             self.cuda()

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -9017,7 +9017,10 @@ class Lightcurve(InputHelpers, gpytorch.Module):
 
     def _build_parameter_estimation_context(self):
         """Construct a parameter-estimation context from this light curve."""
-        flux_values = np.asarray(self._ydata_raw, dtype=float)
+        flux_values = self._ydata_raw
+        if isinstance(flux_values, torch.Tensor):
+            flux_values = flux_values.detach().cpu().numpy()
+        flux_values = np.asarray(flux_values, dtype=float)
         flux_values = flux_values[np.isfinite(flux_values)]
 
         if flux_values.size == 0:

--- a/tests/test_lightcurve_parameter_context.py
+++ b/tests/test_lightcurve_parameter_context.py
@@ -1,0 +1,70 @@
+import unittest
+
+import torch
+
+from pgmuvi.lightcurve import Lightcurve
+from pgmuvi.parameter_context import (
+    LightcurveDiagnostics,
+    ParameterEstimationContext,
+)
+
+
+class TestLightcurveParameterEstimationContext(unittest.TestCase):
+
+    def test_build_parameter_estimation_context_for_1d_lightcurve(self):
+        lc = Lightcurve(
+            torch.tensor([0.0, 1.0, 2.0, 3.0, 4.0]),
+            torch.tensor([10.0, 20.0, 30.0, 40.0, 50.0]),
+        )
+
+        context = lc._build_parameter_estimation_context()
+
+        self.assertIsInstance(context, ParameterEstimationContext)
+        self.assertIsInstance(context.global_diagnostics, LightcurveDiagnostics)
+
+        self.assertFalse(context.is_multiband)
+        self.assertEqual(context.global_diagnostics.n_points, 5)
+        self.assertAlmostEqual(context.global_diagnostics.median_flux, 30.0)
+
+        self.assertAlmostEqual(
+            context.global_diagnostics.flux_percentiles[50.0],
+            30.0,
+        )
+        self.assertAlmostEqual(
+            context.global_diagnostics.flux_percentiles[2.5],
+            11.0,
+        )
+        self.assertAlmostEqual(
+            context.global_diagnostics.flux_percentiles[97.5],
+            49.0,
+        )
+
+    def test_build_parameter_estimation_context_for_2d_lightcurve(self):
+        xdata = torch.tensor(
+            [
+                [0.0, 1.0],
+                [1.0, 1.0],
+                [0.0, 2.0],
+                [1.0, 2.0],
+            ]
+        )
+        ydata = torch.tensor([10.0, 20.0, 100.0, 200.0])
+
+        lc = Lightcurve(xdata, ydata)
+
+        context = lc._build_parameter_estimation_context()
+
+        self.assertIsInstance(context, ParameterEstimationContext)
+        self.assertTrue(context.is_multiband)
+        self.assertEqual(context.global_diagnostics.n_points, 4)
+        self.assertAlmostEqual(context.global_diagnostics.median_flux, 60.0)
+
+    def test_build_parameter_estimation_context_ignores_nonfinite_flux_values(self):
+        lc = Lightcurve(
+            torch.tensor([0.0, 1.0, 2.0]),
+            torch.tensor([10.0, float("nan"), 30.0]),
+        )
+
+        # Lightcurve currently rejects NaNs on construction, so this test is
+        # only useful if non-finite values can exist internally later.
+        # Do not add this test if constructor validation rejects the input.

--- a/tests/test_lightcurve_parameter_context.py
+++ b/tests/test_lightcurve_parameter_context.py
@@ -3,10 +3,51 @@ import unittest
 import torch
 
 from pgmuvi.lightcurve import Lightcurve
+from pgmuvi.parameter_specs import (
+    ConstraintStrategy,
+    GuessStrategy,
+    ParameterDomain,
+    ParameterRole,
+    ParameterScale,
+    ParameterSpec,
+    ParameterSpecCollection,
+)
 from pgmuvi.parameter_context import (
     LightcurveDiagnostics,
     ParameterEstimationContext,
 )
+
+
+class DummyWorkflowMeanModule:
+    def __init__(self):
+        self.offset = torch.nn.Parameter(torch.zeros(1))
+        self.calls = []
+
+    def register_constraint(self, parameter_name, constraint):
+        self.calls.append((parameter_name, constraint))
+
+
+class DummyWorkflowModel:
+    def __init__(self):
+        self.mean_module = DummyWorkflowMeanModule()
+
+    def parameter_schema(self):
+        return ParameterSpecCollection(
+            [
+                ParameterSpec(
+                    name="mean_module.offset",
+                    role=ParameterRole.OFFSET,
+                    domain=ParameterDomain.FLUX,
+                    scale=ParameterScale.LINEAR,
+                    guess_strategy=GuessStrategy.MEDIAN_FLUX,
+                    constraint_strategy=ConstraintStrategy.ROBUST_FLUX_RANGE,
+                ),
+            ]
+        )
+
+
+class DummyNoWorkflowModel:
+    pass
 
 
 class TestLightcurveParameterEstimationContext(unittest.TestCase):
@@ -68,3 +109,43 @@ class TestLightcurveParameterEstimationContext(unittest.TestCase):
         # Lightcurve currently rejects NaNs on construction, so this test is
         # only useful if non-finite values can exist internally later.
         # Do not add this test if constructor validation rejects the input.
+
+    def test_apply_parameter_workflow_estimates_returns_none_without_schema(self):
+        lc = Lightcurve(
+            torch.tensor([0.0, 1.0, 2.0]),
+            torch.tensor([10.0, 20.0, 30.0]),
+        )
+        lc.model = DummyNoWorkflowModel()
+
+        result = lc._apply_parameter_workflow_estimates()
+
+        self.assertIsNone(result)
+
+    def test_apply_parameter_workflow_estimates_applies_supported_schema(self):
+        lc = Lightcurve(
+            torch.tensor([0.0, 1.0, 2.0]),
+            torch.tensor([10.0, 20.0, 30.0]),
+        )
+        lc.model = DummyWorkflowModel()
+
+        result = lc._apply_parameter_workflow_estimates()
+
+        self.assertEqual(
+            result,
+            {
+                "mean_module.offset": {
+                    "value": True,
+                    "constraint": True,
+                },
+            },
+        )
+
+        self.assertAlmostEqual(
+            float(lc.model.mean_module.offset.item()),
+            20.0,
+        )
+
+        self.assertEqual(
+            lc.model.mean_module.calls[0][0],
+            "offset",
+        )

--- a/tests/test_lightcurve_parameter_context.py
+++ b/tests/test_lightcurve_parameter_context.py
@@ -106,9 +106,10 @@ class TestLightcurveParameterEstimationContext(unittest.TestCase):
             torch.tensor([10.0, float("nan"), 30.0]),
         )
 
-        # Lightcurve currently rejects NaNs on construction, so this test is
-        # only useful if non-finite values can exist internally later.
-        # Do not add this test if constructor validation rejects the input.
+        context = lc._build_parameter_estimation_context()
+        self.assertEqual(context.global_diagnostics.n_points, 2)
+        self.assertAlmostEqual(context.global_diagnostics.median_flux, 20.0)
+
 
     def test_apply_parameter_workflow_estimates_returns_none_without_schema(self):
         lc = Lightcurve(


### PR DESCRIPTION
## Summary

Integrate the parameter-estimation workflow into the Lightcurve fitting
initialization path.

This PR adds Lightcurve support for constructing parameter-estimation
contexts from the current light-curve data and applies parameter workflow
estimates during fit initialization when the model exposes a valid
parameter schema.

## Changes

- Add `Lightcurve._build_parameter_estimation_context()`
- Add `Lightcurve._apply_parameter_workflow_estimates()`
- Invoke the workflow hook in `fit()` after default constraints are set
- Preserve explicit user override precedence by running the workflow
  before existing guess/hyperparameter application logic
- Add tests for 1D and 2D context construction
- Add tests for workflow-supported and unsupported models

## Scope

This PR does not add new parameter-estimation rules.

It does not change consensus logic, optimizer behavior, or explicit user
guess handling.

## Testing

```bash
python3 -m unittest discover -s tests -p "test_lightcurve_parameter_context.py"
python3 -m unittest discover -s tests -p "test_parameter_workflow.py"
python3 -m unittest discover -s tests -p "test_parameter_application.py"
python3 -m unittest discover -s tests -p "test_parameter_builders.py"