### PR TITLE
Add PowerLawMean parameter estimation rules

### DIFF
--- a/pgmuvi/gps.py
+++ b/pgmuvi/gps.py
@@ -273,6 +273,8 @@ class PowerLawMean(gpt.means.Mean):
                     role=ParameterRole.AMPLITUDE,
                     domain=ParameterDomain.FLUX,
                     scale=ParameterScale.LINEAR,
+                    guess_strategy=GuessStrategy.ROBUST_FLUX_SPAN,
+                    constraint_strategy=ConstraintStrategy.ROBUST_FLUX_RANGE,
                     description=(
                         "Linear flux-domain amplitude multiplying the wavelength "
                         "power-law term. The sign controls whether the mean flux "

--- a/pgmuvi/gps.py
+++ b/pgmuvi/gps.py
@@ -261,6 +261,8 @@ class PowerLawMean(gpt.means.Mean):
                     role=ParameterRole.OFFSET,
                     domain=ParameterDomain.FLUX,
                     scale=ParameterScale.LINEAR,
+                    guess_strategy=GuessStrategy.MEDIAN_FLUX,
+                    constraint_strategy=ConstraintStrategy.ROBUST_FLUX_RANGE,
                     description=(
                         "Constant additive flux offset of the wavelength "
                         "power-law mean function."

--- a/pgmuvi/gps.py
+++ b/pgmuvi/gps.py
@@ -286,6 +286,10 @@ class PowerLawMean(gpt.means.Mean):
                     role=ParameterRole.SHAPE,
                     domain=ParameterDomain.DIMENSIONLESS,
                     scale=ParameterScale.LINEAR,
+                    initial_value=-2.0,
+                    constraint=(-10.0, 10.0),
+                    guess_strategy=GuessStrategy.DEFAULT,
+                    constraint_strategy=ConstraintStrategy.DEFAULT,
                     description=(
                         "Dimensionless power-law index controlling the wavelength "
                         "dependence of the mean flux."

--- a/tests/test_power_law_mean_parameter_schema.py
+++ b/tests/test_power_law_mean_parameter_schema.py
@@ -81,3 +81,19 @@ class TestPowerLawMeanParameterSchema(unittest.TestCase):
             weight.constraint_strategy,
             ConstraintStrategy.ROBUST_FLUX_RANGE,
         )
+
+    def test_power_law_mean_exponent_default_estimation_strategies(self):
+        schema = PowerLawMean().parameter_schema()
+
+        exponent = schema["mean_module.exponent"]
+
+        self.assertEqual(exponent.initial_value, -2.0)
+        self.assertEqual(exponent.constraint, (-10.0, 10.0))
+        self.assertEqual(
+            exponent.guess_strategy,
+            GuessStrategy.DEFAULT,
+        )
+        self.assertEqual(
+            exponent.constraint_strategy,
+            ConstraintStrategy.DEFAULT,
+        )

--- a/tests/test_power_law_mean_parameter_schema.py
+++ b/tests/test_power_law_mean_parameter_schema.py
@@ -67,3 +67,17 @@ class TestPowerLawMeanParameterSchema(unittest.TestCase):
             offset.constraint_strategy,
             ConstraintStrategy.ROBUST_FLUX_RANGE,
         )
+
+    def test_power_law_mean_weight_estimation_strategies(self):
+        schema = PowerLawMean().parameter_schema()
+
+        weight = schema["mean_module.weight"]
+
+        self.assertEqual(
+            weight.guess_strategy,
+            GuessStrategy.ROBUST_FLUX_SPAN,
+        )
+        self.assertEqual(
+            weight.constraint_strategy,
+            ConstraintStrategy.ROBUST_FLUX_RANGE,
+        )

--- a/tests/test_power_law_mean_parameter_schema.py
+++ b/tests/test_power_law_mean_parameter_schema.py
@@ -1,7 +1,13 @@
 import unittest
 
 from pgmuvi.gps import PowerLawMean
-from pgmuvi.parameter_specs import ParameterDomain, ParameterRole, ParameterScale
+from pgmuvi.parameter_specs import (
+    ConstraintStrategy,
+    GuessStrategy,
+    ParameterDomain,
+    ParameterRole,
+    ParameterScale,
+)
 
 
 class TestPowerLawMeanParameterSchema(unittest.TestCase):
@@ -46,4 +52,18 @@ class TestPowerLawMeanParameterSchema(unittest.TestCase):
                 "weight",
                 "exponent",
             ],
+        )
+
+    def test_power_law_mean_offset_estimation_strategies(self):
+        schema = PowerLawMean().parameter_schema()
+
+        offset = schema["mean_module.offset"]
+
+        self.assertEqual(
+            offset.guess_strategy,
+            GuessStrategy.MEDIAN_FLUX,
+        )
+        self.assertEqual(
+            offset.constraint_strategy,
+            ConstraintStrategy.ROBUST_FLUX_RANGE,
         )


### PR DESCRIPTION
## Summary

Add parameter-estimation rules for `PowerLawMean`.

## Changes

- `offset` now uses:
  - `GuessStrategy.MEDIAN_FLUX`
  - `ConstraintStrategy.ROBUST_FLUX_RANGE`

- `weight` now uses:
  - `GuessStrategy.ROBUST_FLUX_SPAN`
  - `ConstraintStrategy.ROBUST_FLUX_RANGE`

- `exponent` now uses schema-provided defaults:
  - initial value: `-2.0`
  - constraint: `(-10.0, 10.0)`
  - `GuessStrategy.DEFAULT`
  - `ConstraintStrategy.DEFAULT`

## Scope

This PR only adds rules for `PowerLawMean`.

It does not change kernels, fitting workflow integration, or consensus logic.

## Testing

```bash
python3 -m unittest discover -s tests -p "test_power_law_mean_parameter_schema.py"
python3 -m unittest discover -s tests -p "test_parameter_builders.py"
python3 -m unittest discover -s tests -p "test_parameter_specs.py"