### PR TITLE
Add sampling-based time lengthscale estimation

### DIFF
--- a/pgmuvi/gps.py
+++ b/pgmuvi/gps.py
@@ -119,7 +119,11 @@ def lengthscale_kernel_parameter_schema(
                 scale=ParameterScale.LOG,
                 initial_value=1.0,
                 constraint=(1.0e-3, 1.0e3),
-                guess_strategy=GuessStrategy.DEFAULT,
+                guess_strategy=(
+                    GuessStrategy.GEOMETRIC_SAMPLING_TIMESCALE
+                    if domain is ParameterDomain.TIME
+                    else GuessStrategy.DEFAULT
+                ),
                 constraint_strategy=ConstraintStrategy.DEFAULT,
                 description=(
                     "Positive correlation lengthscale of the kernel in "

--- a/pgmuvi/parameter_builders.py
+++ b/pgmuvi/parameter_builders.py
@@ -5,6 +5,7 @@ diagnostic contexts into parameter estimates.
 """
 
 from __future__ import annotations
+import math
 
 from pgmuvi.parameter_context import ParameterEstimationContext
 from pgmuvi.parameter_estimates import (
@@ -68,6 +69,9 @@ class ParameterEstimateBuilder:
 
         if spec.guess_strategy is GuessStrategy.ROBUST_FLUX_SPAN:
             return self._estimate_robust_flux_span(context)
+
+        if spec.guess_strategy is GuessStrategy.GEOMETRIC_SAMPLING_TIMESCALE:
+            return self._estimate_geometric_sampling_timescale(context)
 
         return None
 
@@ -160,3 +164,24 @@ class ParameterEstimateBuilder:
 
         lower, upper = interval
         return upper - lower
+
+    @staticmethod
+    def _estimate_geometric_sampling_timescale(
+        context: ParameterEstimationContext,
+    ):
+        """Estimate a timescale from sampling diagnostics."""
+        diagnostics = context.global_diagnostics
+
+        if diagnostics is None:
+            return None
+
+        baseline = diagnostics.baseline_duration
+        cadence = diagnostics.median_cadence
+
+        if baseline is None or cadence is None:
+            return None
+
+        if baseline <= 0 or cadence <= 0:
+            return None
+
+        return math.sqrt(baseline * cadence)

--- a/pgmuvi/parameter_specs.py
+++ b/pgmuvi/parameter_specs.py
@@ -52,6 +52,7 @@ class GuessStrategy(str, Enum):
     MEDIAN_FLUX = "median_flux"
     ROBUST_FLUX_RANGE = "robust_flux_range"
     ROBUST_FLUX_SPAN = "robust_flux_span"
+    GEOMETRIC_SAMPLING_TIMESCALE = "geometric_sampling_timescale"
     FLUX_STD = "flux_std"
     MAD = "mad"
 

--- a/tests/test_lengthscale_kernel_parameter_schema.py
+++ b/tests/test_lengthscale_kernel_parameter_schema.py
@@ -27,7 +27,10 @@ class TestLengthscaleKernelParameterSchema(unittest.TestCase):
         self.assertIs(lengthscale.scale, ParameterScale.LOG)
         self.assertEqual(lengthscale.initial_value, 1.0)
         self.assertEqual(lengthscale.constraint, (1.0e-3, 1.0e3))
-        self.assertEqual(lengthscale.guess_strategy, GuessStrategy.DEFAULT)
+        self.assertEqual(
+                lengthscale.guess_strategy,
+                GuessStrategy.GEOMETRIC_SAMPLING_TIMESCALE
+                )
         self.assertEqual(
             lengthscale.constraint_strategy,
             ConstraintStrategy.DEFAULT,

--- a/tests/test_parameter_builders.py
+++ b/tests/test_parameter_builders.py
@@ -360,6 +360,52 @@ class TestParameterEstimateBuilder(unittest.TestCase):
         self.assertEqual(estimate.constraint, (1.0e-3, 1.0e3))
         self.assertEqual(estimate.constraint_source, "default")
 
+    def test_geometric_sampling_timescale_guess(self):
+        spec = ParameterSpec(
+            name="covar_module.lengthscale",
+            role=ParameterRole.LENGTHSCALE,
+            domain=ParameterDomain.TIME,
+            scale=ParameterScale.LOG,
+            guess_strategy=GuessStrategy.GEOMETRIC_SAMPLING_TIMESCALE,
+        )
+
+        context = ParameterEstimationContext(
+            is_multiband=False,
+            global_diagnostics=LightcurveDiagnostics(
+                baseline_duration=1000.0,
+                median_cadence=10.0,
+            ),
+        )
+
+        estimate = ParameterEstimateBuilder().build_one(
+            spec=spec,
+            context=context,
+        )
+
+        self.assertAlmostEqual(
+            estimate.value,
+            100.0,
+        )
+
+    def test_geometric_sampling_timescale_requires_sampling_diagnostics(self):
+        spec = ParameterSpec(
+            name="covar_module.lengthscale",
+            role=ParameterRole.LENGTHSCALE,
+            domain=ParameterDomain.TIME,
+            scale=ParameterScale.LOG,
+            guess_strategy=GuessStrategy.GEOMETRIC_SAMPLING_TIMESCALE,
+        )
+
+        context = ParameterEstimationContext(
+                is_multiband=False,
+                )
+
+        estimate = ParameterEstimateBuilder().build_one(
+            spec=spec,
+            context=context,
+        )
+
+        self.assertIsNone(estimate.value)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Add a diagnostic-derived timescale estimator and apply it to time-domain
kernel lengthscales.

## Changes

- Add `GuessStrategy.GEOMETRIC_SAMPLING_TIMESCALE`
- Estimate characteristic timescale as:

  `sqrt(baseline_duration * median_cadence)`

- Use this strategy for `ParameterDomain.TIME` lengthscales
- Keep wavelength-domain lengthscales on schema defaults
- Add tests for builder behavior and domain-specific schema behavior

## Scope

This PR only affects time-domain lengthscale initialization rules.

It does not modify wavelength lengthscale rules, spectral-mixture
frequency initialization, consensus logic, or fitting workflow
integration.

## Testing

```bash
python3 -m unittest discover -s tests -p "test_lengthscale_kernel_parameter_schema.py"
python3 -m unittest discover -s tests -p "test_parameter_builders.py"
python3 -m unittest discover -s tests -p "test_parameter_specs.py"