### PR TITLE
Add frequency-domain parameter estimation rules

### DIFF
--- a/pgmuvi/gps.py
+++ b/pgmuvi/gps.py
@@ -179,6 +179,7 @@ def spectral_mixture_parameter_schema(prefix="covar_module", num_mixtures=None):
                 shape=shape,
                 initial_value=None,
                 constraint=(1.0e-6, 1.0e6),
+                guess_strategy=GuessStrategy.BASELINE_FREQUENCY,
                 constraint_strategy=ConstraintStrategy.DEFAULT,
                 description=(
                     "Central frequencies of the spectral-mixture components. "

--- a/pgmuvi/parameter_builders.py
+++ b/pgmuvi/parameter_builders.py
@@ -73,7 +73,10 @@ class ParameterEstimateBuilder:
         if spec.guess_strategy is GuessStrategy.GEOMETRIC_SAMPLING_TIMESCALE:
             return self._estimate_geometric_sampling_timescale(context)
 
-        return None
+        if spec.guess_strategy is GuessStrategy.BASELINE_FREQUENCY:
+            return self._estimate_baseline_frequency(context)
+
+            return None
 
     def _estimate_constraint(
         self,
@@ -185,3 +188,20 @@ class ParameterEstimateBuilder:
             return None
 
         return math.sqrt(baseline * cadence)
+
+    @staticmethod
+    def _estimate_baseline_frequency(
+        context: ParameterEstimationContext,
+    ):
+        """Estimate the lowest baseline-resolved frequency."""
+        diagnostics = context.global_diagnostics
+
+        if diagnostics is None:
+            return None
+
+        baseline = diagnostics.baseline_duration
+
+        if baseline is None or baseline <= 0:
+            return None
+
+        return 1.0 / baseline

--- a/pgmuvi/parameter_specs.py
+++ b/pgmuvi/parameter_specs.py
@@ -53,6 +53,7 @@ class GuessStrategy(str, Enum):
     ROBUST_FLUX_RANGE = "robust_flux_range"
     ROBUST_FLUX_SPAN = "robust_flux_span"
     GEOMETRIC_SAMPLING_TIMESCALE = "geometric_sampling_timescale"
+    BASELINE_FREQUENCY = "baseline_frequency"
     FLUX_STD = "flux_std"
     MAD = "mad"
 

--- a/tests/test_parameter_builders.py
+++ b/tests/test_parameter_builders.py
@@ -407,5 +407,54 @@ class TestParameterEstimateBuilder(unittest.TestCase):
 
         self.assertIsNone(estimate.value)
 
+    def test_baseline_frequency_guess(self):
+        spec = ParameterSpec(
+            name="covar_module.mixture_means",
+            role=ParameterRole.FREQUENCY,
+            domain=ParameterDomain.FREQUENCY,
+            scale=ParameterScale.LINEAR,
+            guess_strategy=GuessStrategy.BASELINE_FREQUENCY,
+        )
+
+        context = ParameterEstimationContext(
+            is_multiband=False,
+            global_diagnostics=LightcurveDiagnostics(
+                baseline_duration=1000.0,
+            ),
+        )
+
+        estimate = ParameterEstimateBuilder().build_one(
+            spec=spec,
+            context=context,
+        )
+
+        self.assertAlmostEqual(
+            estimate.value,
+            0.001,
+        )
+
+    def test_baseline_frequency_requires_positive_baseline(self):
+        spec = ParameterSpec(
+            name="covar_module.mixture_means",
+            role=ParameterRole.FREQUENCY,
+            domain=ParameterDomain.FREQUENCY,
+            scale=ParameterScale.LINEAR,
+            guess_strategy=GuessStrategy.BASELINE_FREQUENCY,
+        )
+
+        context = ParameterEstimationContext(
+            is_multiband=False,
+            global_diagnostics=LightcurveDiagnostics(
+                baseline_duration=0.0,
+            ),
+        )
+
+        estimate = ParameterEstimateBuilder().build_one(
+            spec=spec,
+            context=context,
+        )
+
+        self.assertIsNone(estimate.value)
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_parameter_builders.py
+++ b/tests/test_parameter_builders.py
@@ -456,5 +456,31 @@ class TestParameterEstimateBuilder(unittest.TestCase):
 
         self.assertIsNone(estimate.value)
 
+    def test_baseline_frequency_can_initialize_spectral_mixture_means(self):
+        spec = ParameterSpec(
+            name="covar_module.mixture_means",
+            role=ParameterRole.FREQUENCY,
+            domain=ParameterDomain.FREQUENCY,
+            scale=ParameterScale.LINEAR,
+            guess_strategy=GuessStrategy.BASELINE_FREQUENCY,
+        )
+
+        context = ParameterEstimationContext(
+            is_multiband=False,
+            global_diagnostics=LightcurveDiagnostics(
+                baseline_duration=500.0,
+            ),
+        )
+
+        estimate = ParameterEstimateBuilder().build_one(
+            spec=spec,
+            context=context,
+        )
+
+        self.assertAlmostEqual(
+            estimate.value,
+            1.0 / 500.0,
+        )
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_spectral_mixture_parameter_schema.py
+++ b/tests/test_spectral_mixture_parameter_schema.py
@@ -37,7 +37,10 @@ class TestSpectralMixtureParameterSchema(unittest.TestCase):
         self.assertEqual(means.shape, (3,))
         self.assertIsNone(means.initial_value)
         self.assertEqual(means.constraint, (1.0e-6, 1.0e6))
-        self.assertIsNone(means.guess_strategy)
+        self.assertEqual(
+            means.guess_strategy,
+            GuessStrategy.BASELINE_FREQUENCY,
+        )
         self.assertEqual(
             means.constraint_strategy,
             ConstraintStrategy.DEFAULT,


### PR DESCRIPTION
## Summary

Add diagnostic-derived frequency estimation support to the parameter
workflow and use it to initialize spectral-mixture component
frequencies.

This PR introduces the framework machinery needed for frequency-valued
parameter estimates, analogous to the sampling-based timescale
estimation added previously for time-domain lengthscales.

## Changes

### New estimation strategy

Add:

- `GuessStrategy.BASELINE_FREQUENCY`

which estimates the lowest baseline-resolved frequency:

```text
1 / baseline_duration