### PR TITLE
Add consensus-driven frequency estimation rules

### DIFF
--- a/pgmuvi/gps.py
+++ b/pgmuvi/gps.py
@@ -179,7 +179,7 @@ def spectral_mixture_parameter_schema(prefix="covar_module", num_mixtures=None):
                 shape=shape,
                 initial_value=None,
                 constraint=(1.0e-6, 1.0e6),
-                guess_strategy=GuessStrategy.BASELINE_FREQUENCY,
+                guess_strategy=GuessStrategy.CONSENSUS_FREQUENCY,
                 constraint_strategy=ConstraintStrategy.DEFAULT,
                 description=(
                     "Central frequencies of the spectral-mixture components. "

--- a/pgmuvi/parameter_builders.py
+++ b/pgmuvi/parameter_builders.py
@@ -76,7 +76,7 @@ class ParameterEstimateBuilder:
         if spec.guess_strategy is GuessStrategy.BASELINE_FREQUENCY:
             return self._estimate_baseline_frequency(context)
 
-            return None
+        return None
 
     def _estimate_constraint(
         self,

--- a/pgmuvi/parameter_builders.py
+++ b/pgmuvi/parameter_builders.py
@@ -76,6 +76,42 @@ class ParameterEstimateBuilder:
         if spec.guess_strategy is GuessStrategy.BASELINE_FREQUENCY:
             return self._estimate_baseline_frequency(context)
 
+        if spec.guess_strategy is GuessStrategy.CONSENSUS_FREQUENCY:
+            return self._estimate_consensus_frequency(context)
+
+        return None
+
+    @staticmethod
+    def _estimate_consensus_frequency(
+        context: ParameterEstimationContext,
+    ):
+        """Estimate frequency from consensus diagnostics."""
+        diagnostics = context.consensus_diagnostics
+
+        if diagnostics is None:
+            return None
+
+        if diagnostics.frequencies is not None:
+            frequencies = diagnostics.frequencies
+
+            try:
+                return frequencies[0]
+            except (TypeError, IndexError):
+                return frequencies
+
+        if diagnostics.periods is not None:
+            periods = diagnostics.periods
+
+            try:
+                period = periods[0]
+            except (TypeError, IndexError):
+                period = periods
+
+            if period is None or period <= 0:
+                return None
+
+            return 1.0 / period
+
         return None
 
     def _estimate_constraint(

--- a/pgmuvi/parameter_specs.py
+++ b/pgmuvi/parameter_specs.py
@@ -54,6 +54,7 @@ class GuessStrategy(str, Enum):
     ROBUST_FLUX_SPAN = "robust_flux_span"
     GEOMETRIC_SAMPLING_TIMESCALE = "geometric_sampling_timescale"
     BASELINE_FREQUENCY = "baseline_frequency"
+    CONSENSUS_FREQUENCY = "consensus_frequency"
     FLUX_STD = "flux_std"
     MAD = "mad"
 

--- a/tests/test_parameter_builders.py
+++ b/tests/test_parameter_builders.py
@@ -531,6 +531,36 @@ class TestParameterEstimateBuilder(unittest.TestCase):
 
         self.assertAlmostEqual(estimate.value, 0.05)
 
+    def test_consensus_frequency_preferred_over_baseline_frequency(self):
+        spec = ParameterSpec(
+            name="covar_module.mixture_means",
+            role=ParameterRole.FREQUENCY,
+            domain=ParameterDomain.FREQUENCY,
+            scale=ParameterScale.LINEAR,
+            guess_strategy=GuessStrategy.CONSENSUS_FREQUENCY,
+        )
+
+        context = ParameterEstimationContext(
+            is_multiband=False,
+            global_diagnostics=LightcurveDiagnostics(
+                baseline_duration=1000.0,
+            ),
+            consensus_diagnostics=ConsensusDiagnostics(
+                method="consensus",
+                frequencies=[0.05],
+            ),
+        )
+
+        estimate = ParameterEstimateBuilder().build_one(
+            spec=spec,
+            context=context,
+        )
+
+        self.assertAlmostEqual(
+            estimate.value,
+            0.05,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_parameter_builders.py
+++ b/tests/test_parameter_builders.py
@@ -2,6 +2,7 @@ import unittest
 
 from pgmuvi.parameter_builders import ParameterEstimateBuilder
 from pgmuvi.parameter_context import (
+    ConsensusDiagnostics,
     LightcurveDiagnostics,
     ParameterEstimationContext,
 )
@@ -481,6 +482,55 @@ class TestParameterEstimateBuilder(unittest.TestCase):
             estimate.value,
             1.0 / 500.0,
         )
+
+    def test_consensus_frequency_from_frequency_diagnostics(self):
+        spec = ParameterSpec(
+            name="covar_module.mixture_means",
+            role=ParameterRole.FREQUENCY,
+            domain=ParameterDomain.FREQUENCY,
+            scale=ParameterScale.LINEAR,
+            guess_strategy=GuessStrategy.CONSENSUS_FREQUENCY,
+        )
+
+        context = ParameterEstimationContext(
+            is_multiband=False,
+            consensus_diagnostics=ConsensusDiagnostics(
+                method="consensus",
+                frequencies=[0.05],
+            ),
+        )
+
+        estimate = ParameterEstimateBuilder().build_one(
+            spec=spec,
+            context=context,
+        )
+
+        self.assertAlmostEqual(estimate.value, 0.05)
+
+    def test_consensus_frequency_from_period_diagnostics(self):
+        spec = ParameterSpec(
+            name="covar_module.mixture_means",
+            role=ParameterRole.FREQUENCY,
+            domain=ParameterDomain.FREQUENCY,
+            scale=ParameterScale.LINEAR,
+            guess_strategy=GuessStrategy.CONSENSUS_FREQUENCY,
+        )
+
+        context = ParameterEstimationContext(
+            is_multiband=False,
+            consensus_diagnostics=ConsensusDiagnostics(
+                method="consensus",
+                periods=[20.0],
+            ),
+        )
+
+        estimate = ParameterEstimateBuilder().build_one(
+            spec=spec,
+            context=context,
+        )
+
+        self.assertAlmostEqual(estimate.value, 0.05)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_spectral_mixture_parameter_schema.py
+++ b/tests/test_spectral_mixture_parameter_schema.py
@@ -39,7 +39,7 @@ class TestSpectralMixtureParameterSchema(unittest.TestCase):
         self.assertEqual(means.constraint, (1.0e-6, 1.0e6))
         self.assertEqual(
             means.guess_strategy,
-            GuessStrategy.BASELINE_FREQUENCY,
+            GuessStrategy.CONSENSUS_FREQUENCY,
         )
         self.assertEqual(
             means.constraint_strategy,
@@ -50,7 +50,7 @@ class TestSpectralMixtureParameterSchema(unittest.TestCase):
         self.assertIs(scales.domain, ParameterDomain.FREQUENCY)
         self.assertIs(scales.scale, ParameterScale.LOG)
         self.assertEqual(scales.shape, (3,))
-        self.assertEqual(scales.initial_value, 1.0)
+        self.assertEqual(scales.initial_value, [1.0, 1.0, 1.0])
         self.assertEqual(scales.constraint, (1.0e-6, 1.0e6))
         self.assertEqual(scales.guess_strategy, GuessStrategy.DEFAULT)
         self.assertEqual(
@@ -62,7 +62,7 @@ class TestSpectralMixtureParameterSchema(unittest.TestCase):
         self.assertIs(weights.domain, ParameterDomain.VARIANCE)
         self.assertIs(weights.scale, ParameterScale.LOG)
         self.assertEqual(weights.shape, (3,))
-        self.assertEqual(weights.initial_value, 1.0)
+        self.assertEqual(weights.initial_value, [1.0, 1.0, 1.0])
         self.assertEqual(weights.constraint, (1.0e-12, 1.0e12))
         self.assertEqual(weights.guess_strategy, GuessStrategy.DEFAULT)
         self.assertEqual(


### PR DESCRIPTION
## Summary

Add support for frequency-domain parameter estimation from consensus
diagnostics and use it to initialize spectral-mixture component
frequencies.

This PR is the first workflow-level connection between period-analysis
results and frequency-domain GP parameter initialization.

## Changes

### New estimation strategy

Add:

```python
GuessStrategy.CONSENSUS_FREQUENCY