### PR TITLE
Support multicomponent consensus parameter estimates

### DIFF
--- a/pgmuvi/parameter_builders.py
+++ b/pgmuvi/parameter_builders.py
@@ -122,7 +122,6 @@ class ParameterEstimateBuilder:
     ):
         """Estimate frequency from consensus diagnostics."""
         diagnostics = context.consensus_diagnostics
-        diagnostics = context.consensus_diagnostics
 
         if diagnostics is None:
             return None

--- a/pgmuvi/parameter_builders.py
+++ b/pgmuvi/parameter_builders.py
@@ -77,42 +77,50 @@ class ParameterEstimateBuilder:
             return self._estimate_baseline_frequency(context)
 
         if spec.guess_strategy is GuessStrategy.CONSENSUS_FREQUENCY:
-            return self._estimate_consensus_frequency(context)
+            return self._estimate_consensus_frequency(spec, context)
 
         return None
 
     @staticmethod
     def _estimate_consensus_frequency(
+        spec: ParameterSpec,
         context: ParameterEstimationContext,
     ):
         """Estimate frequency from consensus diagnostics."""
+        diagnostics = context.consensus_diagnostics
         diagnostics = context.consensus_diagnostics
 
         if diagnostics is None:
             return None
 
-        if diagnostics.frequencies is not None:
-            frequencies = diagnostics.frequencies
+        frequencies = diagnostics.frequencies
 
-            try:
-                return frequencies[0]
-            except (TypeError, IndexError):
-                return frequencies
+        if frequencies is None and diagnostics.periods is not None:
+            frequencies = []
 
-        if diagnostics.periods is not None:
-            periods = diagnostics.periods
+            for period in diagnostics.periods:
+                if period is None or period <= 0:
+                    continue
 
-            try:
-                period = periods[0]
-            except (TypeError, IndexError):
-                period = periods
+                frequencies.append(1.0 / period)
 
-            if period is None or period <= 0:
-                return None
+        if frequencies is None:
+            return None
 
-            return 1.0 / period
+        frequencies = list(frequencies)
 
-        return None
+        if spec.shape is None:
+            return frequencies[0] if frequencies else None
+
+        if len(spec.shape) != 1:
+            return None
+
+        n_components = spec.shape[0]
+
+        if len(frequencies) < n_components:
+            return None
+
+        return frequencies[:n_components]
 
     def _estimate_constraint(
         self,

--- a/pgmuvi/parameter_builders.py
+++ b/pgmuvi/parameter_builders.py
@@ -79,7 +79,41 @@ class ParameterEstimateBuilder:
         if spec.guess_strategy is GuessStrategy.CONSENSUS_FREQUENCY:
             return self._estimate_consensus_frequency(spec, context)
 
+        if spec.guess_strategy is GuessStrategy.CONSENSUS_MULTICOMP_PERIOD:
+            return self._estimate_consensus_multicomp_period(spec, context)
+
         return None
+
+    @staticmethod
+    def _estimate_consensus_multicomp_period(
+        spec: ParameterSpec,
+        context: ParameterEstimationContext,
+    ):
+        """Estimate period(s) from multicomponent consensus diagnostics."""
+        diagnostics = context.consensus_diagnostics
+
+        if diagnostics is None:
+            return None
+
+        periods = diagnostics.periods
+
+        if periods is None:
+            return None
+
+        periods = list(periods)
+
+        if spec.shape is None:
+            return periods[0] if periods else None
+
+        if len(spec.shape) != 1:
+            return None
+
+        n_components = spec.shape[0]
+
+        if len(periods) < n_components:
+            return None
+
+        return periods[:n_components]
 
     @staticmethod
     def _estimate_consensus_frequency(

--- a/tests/test_parameter_builders.py
+++ b/tests/test_parameter_builders.py
@@ -561,6 +561,59 @@ class TestParameterEstimateBuilder(unittest.TestCase):
             0.05,
         )
 
+    def test_consensus_frequency_returns_multiple_components(self):
+        spec = ParameterSpec(
+            name="covar_module.mixture_means",
+            role=ParameterRole.FREQUENCY,
+            domain=ParameterDomain.FREQUENCY,
+            scale=ParameterScale.LINEAR,
+            shape=(3,),
+            guess_strategy=GuessStrategy.CONSENSUS_FREQUENCY,
+        )
+
+        context = ParameterEstimationContext(
+            is_multiband=False,
+            consensus_diagnostics=ConsensusDiagnostics(
+                method="consensus",
+                frequencies=[0.10, 0.05, 0.02],
+            ),
+        )
+
+        estimate = ParameterEstimateBuilder().build_one(
+            spec=spec,
+            context=context,
+        )
+
+        self.assertEqual(
+            estimate.value,
+            [0.10, 0.05, 0.02],
+        )
+
+    def test_consensus_frequency_requires_enough_components(self):
+        spec = ParameterSpec(
+            name="covar_module.mixture_means",
+            role=ParameterRole.FREQUENCY,
+            domain=ParameterDomain.FREQUENCY,
+            scale=ParameterScale.LINEAR,
+            shape=(3,),
+            guess_strategy=GuessStrategy.CONSENSUS_FREQUENCY,
+        )
+
+        context = ParameterEstimationContext(
+            is_multiband=False,
+            consensus_diagnostics=ConsensusDiagnostics(
+                method="consensus",
+                frequencies=[0.10, 0.05],
+            ),
+        )
+
+        estimate = ParameterEstimateBuilder().build_one(
+            spec=spec,
+            context=context,
+        )
+
+        self.assertIsNone(estimate.value)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_parameter_builders.py
+++ b/tests/test_parameter_builders.py
@@ -667,6 +667,34 @@ class TestParameterEstimateBuilder(unittest.TestCase):
 
         self.assertIsNone(estimate.value)
 
+    def test_consensus_frequency_initializes_multicomponent_mixture_means_from_periods(self):
+        spec = ParameterSpec(
+            name="covar_module.mixture_means",
+            role=ParameterRole.FREQUENCY,
+            domain=ParameterDomain.FREQUENCY,
+            scale=ParameterScale.LINEAR,
+            shape=(3,),
+            guess_strategy=GuessStrategy.CONSENSUS_FREQUENCY,
+        )
+
+        context = ParameterEstimationContext(
+            is_multiband=False,
+            consensus_diagnostics=ConsensusDiagnostics(
+                method="consensus_multicomp",
+                periods=[10.0, 20.0, 50.0],
+            ),
+        )
+
+        estimate = ParameterEstimateBuilder().build_one(
+            spec=spec,
+            context=context,
+        )
+
+        self.assertEqual(
+            estimate.value,
+            [0.1, 0.05, 0.02],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_parameter_builders.py
+++ b/tests/test_parameter_builders.py
@@ -614,6 +614,59 @@ class TestParameterEstimateBuilder(unittest.TestCase):
 
         self.assertIsNone(estimate.value)
 
+    def test_consensus_multicomp_period_returns_multiple_components(self):
+        spec = ParameterSpec(
+            name="periods",
+            role=ParameterRole.PERIOD,
+            domain=ParameterDomain.TIME,
+            scale=ParameterScale.LINEAR,
+            shape=(3,),
+            guess_strategy=GuessStrategy.CONSENSUS_MULTICOMP_PERIOD,
+        )
+
+        context = ParameterEstimationContext(
+            is_multiband=False,
+            consensus_diagnostics=ConsensusDiagnostics(
+                method="consensus_multicomp",
+                periods=[300.0, 600.0, 1200.0],
+            ),
+        )
+
+        estimate = ParameterEstimateBuilder().build_one(
+            spec=spec,
+            context=context,
+        )
+
+        self.assertEqual(
+            estimate.value,
+            [300.0, 600.0, 1200.0],
+        )
+
+    def test_consensus_multicomp_period_requires_enough_components(self):
+        spec = ParameterSpec(
+            name="periods",
+            role=ParameterRole.PERIOD,
+            domain=ParameterDomain.TIME,
+            scale=ParameterScale.LINEAR,
+            shape=(3,),
+            guess_strategy=GuessStrategy.CONSENSUS_MULTICOMP_PERIOD,
+        )
+
+        context = ParameterEstimationContext(
+            is_multiband=False,
+            consensus_diagnostics=ConsensusDiagnostics(
+                method="consensus_multicomp",
+                periods=[300.0, 600.0],
+            ),
+        )
+
+        estimate = ParameterEstimateBuilder().build_one(
+            spec=spec,
+            context=context,
+        )
+
+        self.assertIsNone(estimate.value)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Add support for multicomponent consensus-derived parameter estimates.

## Changes

- Implement `GuessStrategy.CONSENSUS_MULTICOMP_PERIOD` in the parameter builder
- Support scalar and vector-valued period estimates from consensus diagnostics
- Respect `ParameterSpec.shape` when constructing multicomponent estimates
- Return no estimate when too few consensus components are available
- Add coverage for vector-valued spectral-mixture frequency initialization from consensus periods
- Remove a duplicated consensus-diagnostics assignment in the builder

## Scope

This PR only expands builder support and test coverage for multicomponent consensus-derived estimates.

It does not modify consensus construction, fitting workflows, or optimizer behavior.

## Testing

```bash
python3 -m unittest discover -s tests -p "test_parameter_builders.py"
python3 -m unittest discover -s tests -p "test_spectral_mixture_parameter_schema.py"
python3 -m unittest discover -s tests -p "test_parameter_specs.py"