### PR TITLE
Add parameter workflow reporting helpers

### DIFF
--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -9089,6 +9089,32 @@ class Lightcurve(InputHelpers, gpytorch.Module):
 
         return self.parameter_workflow_result
 
+    def get_parameter_workflow_summary(self):
+        """Return a lightweight summary of parameter workflow results."""
+        result = self.parameter_workflow_result
+
+        if result is None:
+            return {
+                "available": False,
+                "applied": 0,
+                "skipped": 0,
+            }
+
+        applied = 0
+        skipped = 0
+
+        for value in result.values():
+            if value:
+                applied += 1
+            else:
+                skipped += 1
+
+        return {
+            "available": True,
+            "applied": applied,
+            "skipped": skipped,
+        }
+
     def fit(self, *args, **kwargs):
         """Fit wrapper that records lightweight in-memory fit history."""
         # Nested fit() calls (e.g. from _consensus_standard_fit) delegate

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -2839,6 +2839,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         self.failure_diagnostics = None
         self.failure_summary = None
         self.fit_history = []
+        self.parameter_workflow_result = None
 
         # ------------------------------------------------------------------
         # Sampling quality check

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -9098,6 +9098,8 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 "available": False,
                 "applied": 0,
                 "skipped": 0,
+                "applied_parameters": [],
+                "skipped_parameters": [],
             }
 
         applied = 0
@@ -9109,10 +9111,21 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             else:
                 skipped += 1
 
+        applied_parameters = []
+        skipped_parameters = []
+
+        for name, value in result.items():
+            if value:
+                applied_parameters.append(name)
+            else:
+                skipped_parameters.append(name)
+
         return {
             "available": True,
             "applied": applied,
             "skipped": skipped,
+            "applied_parameters": applied_parameters,
+            "skipped_parameters": skipped_parameters,
         }
 
     def fit(self, *args, **kwargs):

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -9074,15 +9074,19 @@ class Lightcurve(InputHelpers, gpytorch.Module):
 
     def _apply_parameter_workflow_estimates(self):
         """Apply parameter workflow estimates when the model supports them."""
+        self.parameter_workflow_result = None
+
         if not model_supports_parameter_workflow(self.model):
             return None
 
         context = self._build_parameter_estimation_context()
 
-        return build_and_apply_parameter_estimates(
+        self.parameter_workflow_result = build_and_apply_parameter_estimates(
             model=self.model,
             context=context,
         )
+
+        return self.parameter_workflow_result
 
     def fit(self, *args, **kwargs):
         """Fit wrapper that records lightweight in-memory fit history."""

--- a/tests/test_lightcurve_parameter_context.py
+++ b/tests/test_lightcurve_parameter_context.py
@@ -203,6 +203,8 @@ class TestLightcurveParameterEstimationContext(unittest.TestCase):
                 "available": False,
                 "applied": 0,
                 "skipped": 0,
+                "applied_parameters": [],
+                "skipped_parameters": [],
             },
         )
 
@@ -224,5 +226,7 @@ class TestLightcurveParameterEstimationContext(unittest.TestCase):
                 "available": True,
                 "applied": 2,
                 "skipped": 1,
+                "applied_parameters": ["a", "b"],
+                "skipped_parameters": ["c"],
             },
         )

--- a/tests/test_lightcurve_parameter_context.py
+++ b/tests/test_lightcurve_parameter_context.py
@@ -180,3 +180,13 @@ class TestLightcurveParameterEstimationContext(unittest.TestCase):
             context.global_diagnostics.median_cadence,
             10.0,
         )
+
+    def test_parameter_workflow_result_initialized_to_none(self):
+        lc = Lightcurve(
+            torch.tensor([0.0, 1.0, 2.0]),
+            torch.tensor([10.0, 20.0, 30.0]),
+        )
+
+        self.assertIsNone(
+            lc.parameter_workflow_result,
+        )

--- a/tests/test_lightcurve_parameter_context.py
+++ b/tests/test_lightcurve_parameter_context.py
@@ -190,3 +190,39 @@ class TestLightcurveParameterEstimationContext(unittest.TestCase):
         self.assertIsNone(
             lc.parameter_workflow_result,
         )
+
+    def test_parameter_workflow_summary_without_results(self):
+        lc = Lightcurve(
+            torch.tensor([0.0, 1.0, 2.0]),
+            torch.tensor([10.0, 20.0, 30.0]),
+        )
+
+        self.assertEqual(
+            lc.get_parameter_workflow_summary(),
+            {
+                "available": False,
+                "applied": 0,
+                "skipped": 0,
+            },
+        )
+
+    def test_parameter_workflow_summary_counts_results(self):
+        lc = Lightcurve(
+            torch.tensor([0.0, 1.0, 2.0]),
+            torch.tensor([10.0, 20.0, 30.0]),
+        )
+
+        lc.parameter_workflow_result = {
+            "a": True,
+            "b": True,
+            "c": False,
+        }
+
+        self.assertEqual(
+            lc.get_parameter_workflow_summary(),
+            {
+                "available": True,
+                "applied": 2,
+                "skipped": 1,
+            },
+        )

--- a/tests/test_lightcurve_parameter_context.py
+++ b/tests/test_lightcurve_parameter_context.py
@@ -118,7 +118,6 @@ class TestLightcurveParameterEstimationContext(unittest.TestCase):
         self.assertEqual(context.global_diagnostics.n_points, 2)
         self.assertAlmostEqual(context.global_diagnostics.median_flux, 20.0)
 
-
     def test_apply_parameter_workflow_estimates_returns_none_without_schema(self):
         lc = Lightcurve(
             torch.tensor([0.0, 1.0, 2.0]),
@@ -129,6 +128,7 @@ class TestLightcurveParameterEstimationContext(unittest.TestCase):
         result = lc._apply_parameter_workflow_estimates()
 
         self.assertIsNone(result)
+        self.assertIsNone(lc.parameter_workflow_result)
 
     def test_apply_parameter_workflow_estimates_applies_supported_schema(self):
         lc = Lightcurve(
@@ -147,6 +147,11 @@ class TestLightcurveParameterEstimationContext(unittest.TestCase):
                     "constraint": True,
                 },
             },
+        )
+
+        self.assertEqual(
+            lc.parameter_workflow_result,
+            result,
         )
 
         self.assertAlmostEqual(


### PR DESCRIPTION
## Summary

Add lightweight reporting support for parameter workflow execution.

This PR makes parameter workflow application results persistently
available on Lightcurve instances and exposes a small reporting API for
inspecting workflow outcomes.

## Changes

### Store workflow results

Parameter workflow application results are now stored on the
Lightcurve instance rather than being returned and discarded.

### Stable workflow state

All Lightcurve instances now initialize:

```python
parameter_workflow_result