### PR TITLE
Add model-level parameter schemas

### DIFF
--- a/pgmuvi/gps.py
+++ b/pgmuvi/gps.py
@@ -1312,6 +1312,13 @@ class SparseSpectralMixtureGPModel(ApproximateGP):
         # structure. Will turn this into an @property at some point.
         self.sci_kernel = self.covar_module
 
+    def parameter_schema(self):
+        """Return parameter specifications for this model."""
+        return spectral_mixture_parameter_schema(
+            prefix="covar_module",
+            num_mixtures=self.covar_module.num_mixtures,
+        )
+
     def forward(self, x):
         mean_x = self.mean_module(x)
         covar_x = self.covar_module(x)

--- a/pgmuvi/gps.py
+++ b/pgmuvi/gps.py
@@ -906,6 +906,13 @@ class TwoDSpectralMixtureKISSGPModel(ExactGP):
         # structure. Will turn this into an @property at some point.
         self.sci_kernel = self.covar_module
 
+    def parameter_schema(self):
+        """Return parameter specifications for this model."""
+        return spectral_mixture_parameter_schema(
+            prefix="covar_module.base_kernel",
+            num_mixtures=self.covar_module.base_kernel.num_mixtures,
+        )
+
     def forward(self, x):
         mean_x = self.mean_module(x)
         covar_x = self.covar_module(x)

--- a/pgmuvi/gps.py
+++ b/pgmuvi/gps.py
@@ -523,6 +523,13 @@ class SpectralMixtureGPModel(ExactGP):
         # Will turn this into an @property at some point.
         self.sci_kernel = self.covar_module
 
+    def parameter_schema(self):
+        """Return parameter specifications for this model."""
+        return spectral_mixture_parameter_schema(
+            prefix="covar_module",
+            num_mixtures=self.covar_module.num_mixtures,
+        )
+
     def forward(self, x):
         mean_x = self.mean_module(x)
         covar_x = self.covar_module(x)

--- a/pgmuvi/gps.py
+++ b/pgmuvi/gps.py
@@ -978,6 +978,13 @@ class TwoDSpectralMixtureLinearMeanKISSGPModel(ExactGP):
         # structure. Will turn this into an @property at some point.
         self.sci_kernel = self.covar_module
 
+    def parameter_schema(self):
+        """Return parameter specifications for this model."""
+        return spectral_mixture_parameter_schema(
+            prefix="covar_module.base_kernel",
+            num_mixtures=self.covar_module.base_kernel.num_mixtures,
+        )
+
     def forward(self, x):
         mean_x = self.mean_module(x)
         covar_x = self.covar_module(x)

--- a/pgmuvi/gps.py
+++ b/pgmuvi/gps.py
@@ -635,6 +635,13 @@ class TwoDSpectralMixtureGPModel(ExactGP):
         # structure. Will turn this into an @property at some point.
         self.sci_kernel = self.covar_module
 
+    def parameter_schema(self):
+        """Return parameter specifications for this model."""
+        return spectral_mixture_parameter_schema(
+            prefix="covar_module",
+            num_mixtures=self.covar_module.num_mixtures,
+        )
+
     def forward(self, x):
         mean_x = self.mean_module(x)
         covar_x = self.covar_module(x)

--- a/pgmuvi/gps.py
+++ b/pgmuvi/gps.py
@@ -764,6 +764,13 @@ class SpectralMixtureKISSGPModel(ExactGP):
         self.sci_kernel = self.covar_module.base_kernel
         # self.covar_module.base_kernel.initialize_from_data(train_x, train_y)
 
+    def parameter_schema(self):
+        """Return parameter specifications for this model."""
+        return spectral_mixture_parameter_schema(
+            prefix="covar_module.base_kernel",
+            num_mixtures=self.covar_module.base_kernel.num_mixtures,
+        )
+
     def forward(self, x):
         mean_x = self.mean_module(x)
         covar_x = self.covar_module(x)

--- a/pgmuvi/gps.py
+++ b/pgmuvi/gps.py
@@ -695,6 +695,13 @@ class TwoDSpectralMixtureLinearMeanGPModel(ExactGP):
         # structure. Will turn this into an @property at some point.
         self.sci_kernel = self.covar_module
 
+    def parameter_schema(self):
+        """Return parameter specifications for this model."""
+        return spectral_mixture_parameter_schema(
+            prefix="covar_module",
+            num_mixtures=self.covar_module.num_mixtures,
+        )
+
     def forward(self, x):
         mean_x = self.mean_module(x)
         covar_x = self.covar_module(x)

--- a/pgmuvi/gps.py
+++ b/pgmuvi/gps.py
@@ -61,33 +61,32 @@ def rq_kernel_parameter_schema(
     if description_context is None:
         description_context = domain.value
 
-    return ParameterSpecCollection(
-        [
-            ParameterSpec(
-                name=name("lengthscale"),
-                role=ParameterRole.LENGTHSCALE,
-                domain=domain,
-                scale=ParameterScale.LOG,
-                description=(
-                    "Positive correlation lengthscale of the Rational Quadratic "
-                    f"kernel in {description_context} space."
-                ),
+    return ParameterSpecCollection.combine(
+        lengthscale_kernel_parameter_schema(
+            prefix=prefix,
+            domain=domain,
+            description_context=(
+                f"Rational Quadratic {description_context}"
             ),
-            ParameterSpec(
-                name=name("alpha"),
-                role=ParameterRole.SHAPE,
-                domain=ParameterDomain.DIMENSIONLESS,
-                scale=ParameterScale.LOG,
-                initial_value=1.0,
-                constraint=(1.0e-3, 1.0e3),
-                guess_strategy=GuessStrategy.DEFAULT,
-                constraint_strategy=ConstraintStrategy.DEFAULT,
-                description=(
-                    "Positive Rational Quadratic shape parameter controlling "
-                    "the mixture of correlation scales."
+        ),
+        ParameterSpecCollection(
+            [
+                ParameterSpec(
+                    name=name("alpha"),
+                    role=ParameterRole.SHAPE,
+                    domain=ParameterDomain.DIMENSIONLESS,
+                    scale=ParameterScale.LOG,
+                    initial_value=1.0,
+                    constraint=(1.0e-3, 1.0e3),
+                    guess_strategy=GuessStrategy.DEFAULT,
+                    constraint_strategy=ConstraintStrategy.DEFAULT,
+                    description=(
+                        "Positive Rational Quadratic shape parameter controlling "
+                        "the mixture of correlation scales."
+                    ),
                 ),
-            ),
-        ]
+            ]
+        ),
     )
 
 

--- a/pgmuvi/gps.py
+++ b/pgmuvi/gps.py
@@ -1431,6 +1431,37 @@ class QuasiPeriodicGPModel(ExactGP):
         self.covar_module = _make_qp_kernel(period)
         self.sci_kernel = self.covar_module
 
+    def parameter_schema(self):
+        """Return parameter specifications for this model."""
+        return ParameterSpecCollection.combine(
+            scale_kernel_parameter_schema(
+                prefix="covar_module",
+            ),
+            ParameterSpecCollection(
+                [
+                    ParameterSpec(
+                        name="covar_module.base_kernel.kernels.0.period_length",
+                        role=ParameterRole.PERIOD,
+                        domain=ParameterDomain.TIME,
+                        scale=ParameterScale.LOG,
+                        initial_value=1.0,
+                        constraint=(1.0e-3, 1.0e6),
+                        guess_strategy=GuessStrategy.CONSENSUS_PERIOD,
+                        constraint_strategy=ConstraintStrategy.DEFAULT,
+                        description=(
+                            "Positive period length of the periodic component "
+                            "in the quasi-periodic kernel."
+                        ),
+                    ),
+                ]
+            ),
+            lengthscale_kernel_parameter_schema(
+                prefix="covar_module.base_kernel.kernels.1",
+                domain=ParameterDomain.TIME,
+                description_context="quasi-periodic decay time",
+            ),
+        )
+
     def forward(self, x):
         mean_x = self.mean_module(x)
         covar_x = self.covar_module(x)

--- a/pgmuvi/gps.py
+++ b/pgmuvi/gps.py
@@ -1035,6 +1035,16 @@ class TwoDSpectralMixturePowerLawMeanGPModel(ExactGP):
 
         self.sci_kernel = self.covar_module
 
+    def parameter_schema(self):
+        """Return parameter specifications for this model."""
+        return ParameterSpecCollection.combine(
+            self.mean_module.parameter_schema(prefix="mean_module"),
+            spectral_mixture_parameter_schema(
+                prefix="covar_module",
+                num_mixtures=self.covar_module.num_mixtures,
+            ),
+        )
+
     def forward(self, x):
         mean_x = self.mean_module(x)
         covar_x = self.covar_module(x)

--- a/pgmuvi/gps.py
+++ b/pgmuvi/gps.py
@@ -1245,6 +1245,16 @@ class TwoDSpectralMixtureDustMeanKISSGPModel(ExactGP):
 
         self.sci_kernel = self.covar_module
 
+    def parameter_schema(self):
+        """Return parameter specifications for this model."""
+        return ParameterSpecCollection.combine(
+            self.mean_module.parameter_schema(prefix="mean_module"),
+            spectral_mixture_parameter_schema(
+                prefix="covar_module.base_kernel",
+                num_mixtures=self.covar_module.base_kernel.num_mixtures,
+            ),
+        )
+
     def forward(self, x):
         mean_x = self.mean_module(x)
         covar_x = self.covar_module(x)

--- a/pgmuvi/gps.py
+++ b/pgmuvi/gps.py
@@ -1107,6 +1107,17 @@ class TwoDSpectralMixturePowerLawMeanKISSGPModel(ExactGP):
 
         self.sci_kernel = self.covar_module
 
+
+    def parameter_schema(self):
+        """Return parameter specifications for this model."""
+        return ParameterSpecCollection.combine(
+            self.mean_module.parameter_schema(prefix="mean_module"),
+            spectral_mixture_parameter_schema(
+                prefix="covar_module.base_kernel",
+                num_mixtures=self.covar_module.base_kernel.num_mixtures,
+            ),
+        )
+
     def forward(self, x):
         mean_x = self.mean_module(x)
         covar_x = self.covar_module(x)
@@ -1159,6 +1170,16 @@ class TwoDSpectralMixtureDustMeanGPModel(ExactGP):
         self.covar_module = SMK(ard_num_dims=2, num_mixtures=num_mixtures)
 
         self.sci_kernel = self.covar_module
+
+    def parameter_schema(self):
+        """Return parameter specifications for this model."""
+        return ParameterSpecCollection.combine(
+            self.mean_module.parameter_schema(prefix="mean_module"),
+            spectral_mixture_parameter_schema(
+                prefix="covar_module",
+                num_mixtures=self.covar_module.num_mixtures,
+            ),
+        )
 
     def forward(self, x):
         mean_x = self.mean_module(x)

--- a/pgmuvi/gps.py
+++ b/pgmuvi/gps.py
@@ -220,6 +220,61 @@ def spectral_mixture_parameter_schema(prefix="covar_module", num_mixtures=None):
     )
 
 
+def _kernel_parameter_schema(
+    kernel,
+    *,
+    prefix,
+    domain,
+    description_context=None,
+):
+    """Return parameter specifications for supported kernel instances."""
+    if isinstance(kernel, ScaleKernel):
+        return ParameterSpecCollection.combine(
+            scale_kernel_parameter_schema(
+                prefix=prefix,
+            ),
+            _kernel_parameter_schema(
+                kernel.base_kernel,
+                prefix=f"{prefix}.base_kernel",
+                domain=domain,
+                description_context=description_context,
+            ),
+        )
+
+    if isinstance(kernel, (MaternKernel, RBFKernel)):
+        return lengthscale_kernel_parameter_schema(
+            prefix=prefix,
+            domain=domain,
+            description_context=description_context,
+        )
+
+    if isinstance(kernel, RQKernel):
+        return rq_kernel_parameter_schema(
+            prefix=prefix,
+            domain=domain,
+            description_context=description_context,
+        )
+
+    if isinstance(kernel, SMK):
+        return spectral_mixture_parameter_schema(
+            prefix=prefix,
+            num_mixtures=kernel.num_mixtures,
+        )
+
+    if isinstance(kernel, GIK):
+        return _kernel_parameter_schema(
+            kernel.base_kernel,
+            prefix=f"{prefix}.base_kernel",
+            domain=domain,
+            description_context=description_context,
+        )
+
+    if isinstance(kernel, ConstantKernel):
+        return ParameterSpecCollection()
+
+    return ParameterSpecCollection()
+
+
 # ---------------------------------------------------------------------
 # Mean functions
 # ---------------------------------------------------------------------
@@ -1874,6 +1929,23 @@ class SeparableGPModel(ExactGP):
         # without any custom forward() code.
         self.covar_module = time_kernel * wavelength_kernel
         self.sci_kernel = self.covar_module
+
+    def parameter_schema(self):
+        """Return parameter specifications for this model."""
+        return ParameterSpecCollection.combine(
+            _kernel_parameter_schema(
+                self.covar_module.kernels[0],
+                prefix="covar_module.kernels.0",
+                domain=ParameterDomain.TIME,
+                description_context="time",
+            ),
+            _kernel_parameter_schema(
+                self.covar_module.kernels[1],
+                prefix="covar_module.kernels.1",
+                domain=ParameterDomain.WAVELENGTH,
+                description_context="wavelength",
+            ),
+        )
 
     def forward(self, x):
         mean_x = self.mean_module(x)

--- a/pgmuvi/gps.py
+++ b/pgmuvi/gps.py
@@ -577,6 +577,13 @@ class SpectralMixtureLinearMeanGPModel(ExactGP):
         # Will turn this into an @property at some point.
         self.sci_kernel = self.covar_module
 
+    def parameter_schema(self):
+        """Return parameter specifications for this model."""
+        return spectral_mixture_parameter_schema(
+            prefix="covar_module",
+            num_mixtures=self.covar_module.num_mixtures,
+        )
+
     def forward(self, x):
         mean_x = self.mean_module(x)
         covar_x = self.covar_module(x)

--- a/pgmuvi/gps.py
+++ b/pgmuvi/gps.py
@@ -268,6 +268,19 @@ def _kernel_parameter_schema(
             description_context=description_context,
         )
 
+    if isinstance(kernel, (ProductKernel, AdditiveKernel)):
+        return ParameterSpecCollection.combine(
+            *[
+                _kernel_parameter_schema(
+                    component,
+                    prefix=f"{prefix}.kernels.{index}",
+                    domain=domain,
+                    description_context=description_context,
+                )
+                for index, component in enumerate(kernel.kernels)
+            ]
+        )
+
     if isinstance(kernel, ConstantKernel):
         return ParameterSpecCollection()
 

--- a/pgmuvi/gps.py
+++ b/pgmuvi/gps.py
@@ -1773,6 +1773,37 @@ class LinearMeanQuasiPeriodicGPModel(ExactGP):
         self.covar_module = _make_qp_kernel(period)
         self.sci_kernel = self.covar_module
 
+    def parameter_schema(self):
+        """Return parameter specifications for this model."""
+        return ParameterSpecCollection.combine(
+            scale_kernel_parameter_schema(
+                prefix="covar_module",
+            ),
+            ParameterSpecCollection(
+                [
+                    ParameterSpec(
+                        name="covar_module.base_kernel.kernels.0.period_length",
+                        role=ParameterRole.PERIOD,
+                        domain=ParameterDomain.TIME,
+                        scale=ParameterScale.LOG,
+                        initial_value=1.0,
+                        constraint=(1.0e-3, 1.0e6),
+                        guess_strategy=GuessStrategy.CONSENSUS_PERIOD,
+                        constraint_strategy=ConstraintStrategy.DEFAULT,
+                        description=(
+                            "Positive period length of the periodic component "
+                            "in the quasi-periodic kernel."
+                        ),
+                    ),
+                ]
+            ),
+            lengthscale_kernel_parameter_schema(
+                prefix="covar_module.base_kernel.kernels.1",
+                domain=ParameterDomain.TIME,
+                description_context="quasi-periodic decay time",
+            ),
+        )
+
     def forward(self, x):
         mean_x = self.mean_module(x)
         covar_x = self.covar_module(x)

--- a/pgmuvi/gps.py
+++ b/pgmuvi/gps.py
@@ -815,14 +815,33 @@ class SpectralMixtureLinearMeanKISSGPModel(ExactGP):
 
     def __init__(self, train_x, train_y, likelihood, num_mixtures=4, grid_size=2000):
         super().__init__(train_x, train_y, likelihood)
+
+        if not grid_size:
+            grid_size = gpt.utils.grid.choose_grid_size(train_x, 1.0)
+            print(f"Using a grid of size {grid_size} for SKI")
+
+        grid_bounds = [[t.min(train_x), t.max(train_x)]]
+
         self.mean_module = LinearMean(input_size=1)
-        self.covar_module = GIK(SMK(num_mixtures=num_mixtures), grid_size=grid_size)
+        self.covar_module = GIK(
+            SMK(num_mixtures=num_mixtures),
+            grid_size=grid_size,
+            num_dims=1,
+            grid_bounds=grid_bounds,
+        )
         self.covar_module.base_kernel.initialize_from_data(train_x, train_y)
 
         # Now we alias the covariance kernel so that we can exploit the
         # same object properties in different classes with different kernel
         # structure. Will turn this into an @property at some point.
         self.sci_kernel = self.covar_module
+
+    def parameter_schema(self):
+        """Return parameter specifications for this model."""
+        return spectral_mixture_parameter_schema(
+            prefix="covar_module.base_kernel",
+            num_mixtures=self.covar_module.base_kernel.num_mixtures,
+        )
 
     def forward(self, x):
         mean_x = self.mean_module(x)

--- a/pgmuvi/gps.py
+++ b/pgmuvi/gps.py
@@ -2300,6 +2300,20 @@ class WavelengthDependentGPModel(SeparableGPModel):
             **kwargs
         )
 
+    def parameter_schema(self):
+        """Return parameter specifications for this model."""
+        mean_schema = None
+
+        if hasattr(self.mean_module, "parameter_schema"):
+            mean_schema = self.mean_module.parameter_schema(
+                prefix="mean_module",
+            )
+
+        return ParameterSpecCollection.combine(
+            mean_schema,
+            super().parameter_schema(),
+        )
+
 
 class DustMeanGPModel(WavelengthDependentGPModel):
     """2D GP model combining a dust-extinction mean with separable simple kernels.

--- a/pgmuvi/gps.py
+++ b/pgmuvi/gps.py
@@ -1487,6 +1487,19 @@ class MaternGPModel(ExactGP):
         self.covar_module = ScaleKernel(matern_k)
         self.sci_kernel = self.covar_module
 
+    def parameter_schema(self):
+        """Return parameter specifications for this model."""
+        return ParameterSpecCollection.combine(
+            scale_kernel_parameter_schema(
+                prefix="covar_module",
+            ),
+            lengthscale_kernel_parameter_schema(
+                prefix="covar_module.base_kernel",
+                domain=ParameterDomain.TIME,
+                description_context="time",
+            ),
+        )
+
     def forward(self, x):
         mean_x = self.mean_module(x)
         covar_x = self.covar_module(x)

--- a/pgmuvi/gps.py
+++ b/pgmuvi/gps.py
@@ -1699,6 +1699,45 @@ class PeriodicPlusStochasticGPModel(ExactGP):
         self.covar_module = AdditiveKernel(qp_part, rbf_stochastic)
         self.sci_kernel = self.covar_module
 
+    def parameter_schema(self):
+        """Return parameter specifications for this model."""
+        return ParameterSpecCollection.combine(
+            scale_kernel_parameter_schema(
+                prefix="covar_module.kernels.0",
+            ),
+            ParameterSpecCollection(
+                [
+                    ParameterSpec(
+                        name="covar_module.kernels.0.base_kernel.kernels.0.period_length",
+                        role=ParameterRole.PERIOD,
+                        domain=ParameterDomain.TIME,
+                        scale=ParameterScale.LOG,
+                        initial_value=1.0,
+                        constraint=(1.0e-3, 1.0e6),
+                        guess_strategy=GuessStrategy.CONSENSUS_PERIOD,
+                        constraint_strategy=ConstraintStrategy.DEFAULT,
+                        description=(
+                            "Positive period length of the periodic component "
+                            "in the quasi-periodic kernel."
+                        ),
+                    ),
+                ]
+            ),
+            lengthscale_kernel_parameter_schema(
+                prefix="covar_module.kernels.0.base_kernel.kernels.1",
+                domain=ParameterDomain.TIME,
+                description_context="quasi-periodic decay time",
+            ),
+            scale_kernel_parameter_schema(
+                prefix="covar_module.kernels.1",
+            ),
+            lengthscale_kernel_parameter_schema(
+                prefix="covar_module.kernels.1.base_kernel",
+                domain=ParameterDomain.TIME,
+                description_context="stochastic RBF time",
+            ),
+        )
+
     def forward(self, x):
         mean_x = self.mean_module(x)
         covar_x = self.covar_module(x)

--- a/pgmuvi/parameter_specs.py
+++ b/pgmuvi/parameter_specs.py
@@ -205,3 +205,20 @@ class ParameterSpecCollection:
 
     def as_dict(self) -> dict[str, ParameterSpec]:
         return {spec.name: spec for spec in self.specs}
+
+    @classmethod
+    def combine(
+        cls,
+        *collections: "ParameterSpecCollection | None",
+    ) -> "ParameterSpecCollection":
+        """Combine multiple parameter specification collections."""
+        combined = cls()
+
+        for collection in collections:
+            if collection is None:
+                continue
+
+            for spec in collection:
+                combined.add(spec)
+
+        return combined

--- a/tests/test_parameter_specs.py
+++ b/tests/test_parameter_specs.py
@@ -139,3 +139,37 @@ class TestParameterSpecs(unittest.TestCase):
 
         self.assertIs(spec.required, True)
         self.assertIs(spec.trainable, False)
+
+    def test_parameter_spec_collection_combine(self):
+        first = ParameterSpecCollection(
+            [
+                ParameterSpec(
+                    name="mean_module.offset",
+                    role=ParameterRole.OFFSET,
+                    domain=ParameterDomain.FLUX,
+                )
+            ]
+        )
+        second = ParameterSpecCollection(
+            [
+                ParameterSpec(
+                    name="covar_module.outputscale",
+                    role=ParameterRole.WEIGHT,
+                    domain=ParameterDomain.VARIANCE,
+                )
+            ]
+        )
+
+        combined = ParameterSpecCollection.combine(
+            first,
+            None,
+            second,
+        )
+
+        self.assertEqual(
+            combined.names(),
+            [
+                "mean_module.offset",
+                "covar_module.outputscale",
+            ],
+        )

--- a/tests/test_parameter_workflow.py
+++ b/tests/test_parameter_workflow.py
@@ -340,6 +340,34 @@ class TestParameterWorkflow(unittest.TestCase):
             (3,),
         )
 
+    def test_spectral_mixture_linear_mean_gp_model_exposes_parameter_schema(self):
+        import gpytorch
+        import torch
+
+        from pgmuvi.gps import SpectralMixtureLinearMeanGPModel
+
+        train_x = torch.tensor([0.0, 1.0, 2.0])
+        train_y = torch.tensor([1.0, 2.0, 3.0])
+
+        model = SpectralMixtureLinearMeanGPModel(
+            train_x,
+            train_y,
+            gpytorch.likelihoods.GaussianLikelihood(),
+            num_mixtures=3,
+        )
+
+        schema = model.parameter_schema()
+        names = schema.names()
+
+        self.assertIn("covar_module.mixture_means", names)
+        self.assertIn("covar_module.mixture_scales", names)
+        self.assertIn("covar_module.mixture_weights", names)
+
+        self.assertEqual(
+            schema["covar_module.mixture_means"].shape,
+            (3,),
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_parameter_workflow.py
+++ b/tests/test_parameter_workflow.py
@@ -891,7 +891,44 @@ class TestParameterWorkflow(unittest.TestCase):
             ParameterDomain.TIME,
         )
 
+    def test_wavelength_dependent_gp_model_exposes_mean_and_kernel_schema(self):
+        import gpytorch
+        import torch
 
+        from pgmuvi.gps import WavelengthDependentGPModel
+
+        train_x = torch.tensor(
+            [
+                [0.0, 1.0],
+                [1.0, 1.0],
+                [2.0, 2.0],
+                [3.0, 2.0],
+            ]
+        )
+        train_y = torch.tensor([1.0, 2.0, 3.0, 4.0])
+
+        model = WavelengthDependentGPModel(
+            train_x,
+            train_y,
+            gpytorch.likelihoods.GaussianLikelihood(),
+        )
+
+        schema = model.parameter_schema()
+        names = schema.names()
+
+        self.assertIn("mean_module.weights", names)
+        self.assertIn("mean_module.bias", names)
+
+        self.assertIn("covar_module.kernels.0.outputscale", names)
+        self.assertIn(
+            "covar_module.kernels.0.base_kernel.lengthscale",
+            names,
+        )
+        self.assertIn("covar_module.kernels.1.outputscale", names)
+        self.assertIn(
+            "covar_module.kernels.1.base_kernel.lengthscale",
+            names,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_parameter_workflow.py
+++ b/tests/test_parameter_workflow.py
@@ -849,6 +849,50 @@ class TestParameterWorkflow(unittest.TestCase):
             ParameterDomain.WAVELENGTH,
         )
 
+    def test_achromatic_gp_model_inherits_separable_parameter_schema(self):
+        import gpytorch
+        import torch
+
+        from pgmuvi.gps import AchromaticGPModel
+
+        train_x = torch.tensor(
+            [
+                [0.0, 1.0],
+                [1.0, 1.0],
+                [2.0, 2.0],
+                [3.0, 2.0],
+            ]
+        )
+        train_y = torch.tensor([1.0, 2.0, 3.0, 4.0])
+
+        model = AchromaticGPModel(
+            train_x,
+            train_y,
+            gpytorch.likelihoods.GaussianLikelihood(),
+        )
+
+        schema = model.parameter_schema()
+        names = schema.names()
+
+        self.assertIn("covar_module.kernels.0.outputscale", names)
+        self.assertIn(
+            "covar_module.kernels.0.base_kernel.lengthscale",
+            names,
+        )
+
+        self.assertNotIn("covar_module.kernels.1.outputscale", names)
+        self.assertNotIn(
+            "covar_module.kernels.1.base_kernel.lengthscale",
+            names,
+        )
+
+        self.assertEqual(
+            schema["covar_module.kernels.0.base_kernel.lengthscale"].domain,
+            ParameterDomain.TIME,
+        )
+
+
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_parameter_workflow.py
+++ b/tests/test_parameter_workflow.py
@@ -280,6 +280,38 @@ class TestParameterWorkflow(unittest.TestCase):
             names,
         )
 
+    def test_quasi_periodic_gp_model_exposes_parameter_schema(self):
+        import gpytorch
+        import torch
+
+        from pgmuvi.gps import QuasiPeriodicGPModel
+
+        train_x = torch.tensor([0.0, 1.0, 2.0])
+        train_y = torch.tensor([1.0, 2.0, 3.0])
+
+        model = QuasiPeriodicGPModel(
+            train_x,
+            train_y,
+            gpytorch.likelihoods.GaussianLikelihood(),
+            period=2.0,
+        )
+
+        schema = model.parameter_schema()
+        names = schema.names()
+
+        self.assertIn(
+            "covar_module.outputscale",
+            names,
+        )
+        self.assertIn(
+            "covar_module.base_kernel.kernels.0.period_length",
+            names,
+        )
+        self.assertIn(
+            "covar_module.base_kernel.kernels.1.lengthscale",
+            names,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_parameter_workflow.py
+++ b/tests/test_parameter_workflow.py
@@ -930,6 +930,47 @@ class TestParameterWorkflow(unittest.TestCase):
             names,
         )
 
+    def test_dust_mean_gp_model_inherits_wavelength_dependent_schema(self):
+        import gpytorch
+        import torch
+
+        from pgmuvi.gps import DustMeanGPModel
+
+        train_x = torch.tensor(
+            [
+                [0.0, 1.0],
+                [1.0, 1.0],
+                [2.0, 2.0],
+                [3.0, 2.0],
+            ]
+        )
+        train_y = torch.tensor([1.0, 2.0, 3.0, 4.0])
+
+        model = DustMeanGPModel(
+            train_x,
+            train_y,
+            gpytorch.likelihoods.GaussianLikelihood(),
+        )
+
+        schema = model.parameter_schema()
+        names = schema.names()
+
+        self.assertIn("mean_module.offset", names)
+        self.assertIn("mean_module.log_amplitude", names)
+        self.assertIn("mean_module.log_tau", names)
+        self.assertIn("mean_module.log_alpha", names)
+
+        self.assertIn("covar_module.kernels.0.outputscale", names)
+        self.assertIn(
+            "covar_module.kernels.0.base_kernel.lengthscale",
+            names,
+        )
+        self.assertIn("covar_module.kernels.1.outputscale", names)
+        self.assertIn(
+            "covar_module.kernels.1.base_kernel.lengthscale",
+            names,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_parameter_workflow.py
+++ b/tests/test_parameter_workflow.py
@@ -681,6 +681,46 @@ class TestParameterWorkflow(unittest.TestCase):
             (3,),
         )
 
+    def test_two_d_spectral_mixture_dust_mean_kiss_gp_model_exposes_parameter_schema(self):
+        import gpytorch
+        import torch
+
+        from pgmuvi.gps import TwoDSpectralMixtureDustMeanKISSGPModel
+
+        train_x = torch.tensor(
+            [
+                [0.0, 1.0],
+                [1.0, 1.0],
+                [2.0, 1.0],
+            ]
+        )
+        train_y = torch.tensor([1.0, 2.0, 3.0])
+
+        model = TwoDSpectralMixtureDustMeanKISSGPModel(
+            train_x,
+            train_y,
+            gpytorch.likelihoods.GaussianLikelihood(),
+            num_mixtures=3,
+            grid_size=[8, 4],
+        )
+
+        schema = model.parameter_schema()
+        names = schema.names()
+
+        self.assertIn("mean_module.offset", names)
+        self.assertIn("mean_module.log_amplitude", names)
+        self.assertIn("mean_module.log_tau", names)
+        self.assertIn("mean_module.log_alpha", names)
+
+        self.assertIn("covar_module.base_kernel.mixture_means", names)
+        self.assertIn("covar_module.base_kernel.mixture_scales", names)
+        self.assertIn("covar_module.base_kernel.mixture_weights", names)
+
+        self.assertEqual(
+            schema["covar_module.base_kernel.mixture_means"].shape,
+            (3,),
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_parameter_workflow.py
+++ b/tests/test_parameter_workflow.py
@@ -436,6 +436,35 @@ class TestParameterWorkflow(unittest.TestCase):
             (3,),
         )
 
+    def test_spectral_mixture_kiss_gp_model_exposes_parameter_schema(self):
+        import gpytorch
+        import torch
+
+        from pgmuvi.gps import SpectralMixtureKISSGPModel
+
+        train_x = torch.tensor([0.0, 1.0, 2.0, 3.0])
+        train_y = torch.tensor([1.0, 2.0, 3.0, 4.0])
+
+        model = SpectralMixtureKISSGPModel(
+            train_x,
+            train_y,
+            gpytorch.likelihoods.GaussianLikelihood(),
+            num_mixtures=3,
+            grid_size=8,
+        )
+
+        schema = model.parameter_schema()
+        names = schema.names()
+
+        self.assertIn("covar_module.base_kernel.mixture_means", names)
+        self.assertIn("covar_module.base_kernel.mixture_scales", names)
+        self.assertIn("covar_module.base_kernel.mixture_weights", names)
+
+        self.assertEqual(
+            schema["covar_module.base_kernel.mixture_means"].shape,
+            (3,),
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_parameter_workflow.py
+++ b/tests/test_parameter_workflow.py
@@ -368,6 +368,40 @@ class TestParameterWorkflow(unittest.TestCase):
             (3,),
         )
 
+    def test_two_d_spectral_mixture_gp_model_exposes_parameter_schema(self):
+        import gpytorch
+        import torch
+
+        from pgmuvi.gps import TwoDSpectralMixtureGPModel
+
+        train_x = torch.tensor(
+            [
+                [0.0, 1.0],
+                [1.0, 1.0],
+                [2.0, 1.0],
+            ]
+        )
+        train_y = torch.tensor([1.0, 2.0, 3.0])
+
+        model = TwoDSpectralMixtureGPModel(
+            train_x,
+            train_y,
+            gpytorch.likelihoods.GaussianLikelihood(),
+            num_mixtures=3,
+        )
+
+        schema = model.parameter_schema()
+        names = schema.names()
+
+        self.assertIn("covar_module.mixture_means", names)
+        self.assertIn("covar_module.mixture_scales", names)
+        self.assertIn("covar_module.mixture_weights", names)
+
+        self.assertEqual(
+            schema["covar_module.mixture_means"].shape,
+            (3,),
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_parameter_workflow.py
+++ b/tests/test_parameter_workflow.py
@@ -565,6 +565,44 @@ class TestParameterWorkflow(unittest.TestCase):
             (3,),
         )
 
+    def test_two_d_spectral_mixture_power_law_mean_gp_model_exposes_parameter_schema(self):
+        import gpytorch
+        import torch
+
+        from pgmuvi.gps import TwoDSpectralMixturePowerLawMeanGPModel
+
+        train_x = torch.tensor(
+            [
+                [0.0, 1.0],
+                [1.0, 1.0],
+                [2.0, 1.0],
+            ]
+        )
+        train_y = torch.tensor([1.0, 2.0, 3.0])
+
+        model = TwoDSpectralMixturePowerLawMeanGPModel(
+            train_x,
+            train_y,
+            gpytorch.likelihoods.GaussianLikelihood(),
+            num_mixtures=3,
+        )
+
+        schema = model.parameter_schema()
+        names = schema.names()
+
+        self.assertIn("mean_module.offset", names)
+        self.assertIn("mean_module.weight", names)
+        self.assertIn("mean_module.exponent", names)
+
+        self.assertIn("covar_module.mixture_means", names)
+        self.assertIn("covar_module.mixture_scales", names)
+        self.assertIn("covar_module.mixture_weights", names)
+
+        self.assertEqual(
+            schema["covar_module.mixture_means"].shape,
+            (3,),
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_parameter_workflow.py
+++ b/tests/test_parameter_workflow.py
@@ -465,6 +465,35 @@ class TestParameterWorkflow(unittest.TestCase):
             (3,),
         )
 
+    def test_spectral_mixture_linear_mean_kiss_gp_model_exposes_parameter_schema(self):
+        import gpytorch
+        import torch
+
+        from pgmuvi.gps import SpectralMixtureLinearMeanKISSGPModel
+
+        train_x = torch.tensor([0.0, 1.0, 2.0, 3.0])
+        train_y = torch.tensor([1.0, 2.0, 3.0, 4.0])
+
+        model = SpectralMixtureLinearMeanKISSGPModel(
+            train_x,
+            train_y,
+            gpytorch.likelihoods.GaussianLikelihood(),
+            num_mixtures=3,
+            grid_size=8,
+        )
+
+        schema = model.parameter_schema()
+        names = schema.names()
+
+        self.assertIn("covar_module.base_kernel.mixture_means", names)
+        self.assertIn("covar_module.base_kernel.mixture_scales", names)
+        self.assertIn("covar_module.base_kernel.mixture_weights", names)
+
+        self.assertEqual(
+            schema["covar_module.base_kernel.mixture_means"].shape,
+            (3,),
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_parameter_workflow.py
+++ b/tests/test_parameter_workflow.py
@@ -751,6 +751,37 @@ class TestParameterWorkflow(unittest.TestCase):
             (3,),
         )
 
+    def test_periodic_plus_stochastic_gp_model_exposes_parameter_schema(self):
+        import gpytorch
+        import torch
+
+        from pgmuvi.gps import PeriodicPlusStochasticGPModel
+
+        train_x = torch.tensor([0.0, 1.0, 2.0, 3.0])
+        train_y = torch.tensor([1.0, 2.0, 3.0, 4.0])
+
+        model = PeriodicPlusStochasticGPModel(
+            train_x,
+            train_y,
+            gpytorch.likelihoods.GaussianLikelihood(),
+            period=2.0,
+        )
+
+        schema = model.parameter_schema()
+        names = schema.names()
+
+        self.assertIn("covar_module.kernels.0.outputscale", names)
+        self.assertIn(
+            "covar_module.kernels.0.base_kernel.kernels.0.period_length",
+            names,
+        )
+        self.assertIn(
+            "covar_module.kernels.0.base_kernel.kernels.1.lengthscale",
+            names,
+        )
+        self.assertIn("covar_module.kernels.1.outputscale", names)
+        self.assertIn("covar_module.kernels.1.base_kernel.lengthscale", names)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_parameter_workflow.py
+++ b/tests/test_parameter_workflow.py
@@ -495,5 +495,41 @@ class TestParameterWorkflow(unittest.TestCase):
         )
 
 
+    def test_two_d_spectral_mixture_kiss_gp_model_exposes_parameter_schema(self):
+        import gpytorch
+        import torch
+
+        from pgmuvi.gps import TwoDSpectralMixtureKISSGPModel
+
+        train_x = torch.tensor(
+            [
+                [0.0, 1.0],
+                [1.0, 1.0],
+                [2.0, 1.0],
+            ]
+        )
+        train_y = torch.tensor([1.0, 2.0, 3.0])
+
+        model = TwoDSpectralMixtureKISSGPModel(
+            train_x,
+            train_y,
+            gpytorch.likelihoods.GaussianLikelihood(),
+            num_mixtures=3,
+            grid_size=[8, 4],
+        )
+
+        schema = model.parameter_schema()
+        names = schema.names()
+
+        self.assertIn("covar_module.base_kernel.mixture_means", names)
+        self.assertIn("covar_module.base_kernel.mixture_scales", names)
+        self.assertIn("covar_module.base_kernel.mixture_weights", names)
+
+        self.assertEqual(
+            schema["covar_module.base_kernel.mixture_means"].shape,
+            (3,),
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_parameter_workflow.py
+++ b/tests/test_parameter_workflow.py
@@ -971,6 +971,46 @@ class TestParameterWorkflow(unittest.TestCase):
             names,
         )
 
+    def test_power_law_mean_gp_model_inherits_wavelength_dependent_schema(self):
+        import gpytorch
+        import torch
+
+        from pgmuvi.gps import PowerLawMeanGPModel
+
+        train_x = torch.tensor(
+            [
+                [0.0, 1.0],
+                [1.0, 1.0],
+                [2.0, 2.0],
+                [3.0, 2.0],
+            ]
+        )
+        train_y = torch.tensor([1.0, 2.0, 3.0, 4.0])
+
+        model = PowerLawMeanGPModel(
+            train_x,
+            train_y,
+            gpytorch.likelihoods.GaussianLikelihood(),
+        )
+
+        schema = model.parameter_schema()
+        names = schema.names()
+
+        self.assertIn("mean_module.offset", names)
+        self.assertIn("mean_module.weight", names)
+        self.assertIn("mean_module.exponent", names)
+
+        self.assertIn("covar_module.kernels.0.outputscale", names)
+        self.assertIn(
+            "covar_module.kernels.0.base_kernel.lengthscale",
+            names,
+        )
+        self.assertIn("covar_module.kernels.1.outputscale", names)
+        self.assertIn(
+            "covar_module.kernels.1.base_kernel.lengthscale",
+            names,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_parameter_workflow.py
+++ b/tests/test_parameter_workflow.py
@@ -811,6 +811,44 @@ class TestParameterWorkflow(unittest.TestCase):
             names,
         )
 
+    def test_separable_gp_model_exposes_default_parameter_schema(self):
+        import gpytorch
+        import torch
+
+        from pgmuvi.gps import SeparableGPModel
+
+        train_x = torch.tensor(
+            [
+                [0.0, 1.0],
+                [1.0, 1.0],
+                [2.0, 1.0],
+            ]
+        )
+        train_y = torch.tensor([1.0, 2.0, 3.0])
+
+        model = SeparableGPModel(
+            train_x,
+            train_y,
+            gpytorch.likelihoods.GaussianLikelihood(),
+        )
+
+        schema = model.parameter_schema()
+        names = schema.names()
+
+        self.assertIn("covar_module.kernels.0.outputscale", names)
+        self.assertIn("covar_module.kernels.0.base_kernel.lengthscale", names)
+        self.assertIn("covar_module.kernels.1.outputscale", names)
+        self.assertIn("covar_module.kernels.1.base_kernel.lengthscale", names)
+
+        self.assertEqual(
+            schema["covar_module.kernels.0.base_kernel.lengthscale"].domain,
+            ParameterDomain.TIME,
+        )
+        self.assertEqual(
+            schema["covar_module.kernels.1.base_kernel.lengthscale"].domain,
+            ParameterDomain.WAVELENGTH,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_parameter_workflow.py
+++ b/tests/test_parameter_workflow.py
@@ -603,6 +603,84 @@ class TestParameterWorkflow(unittest.TestCase):
             (3,),
         )
 
+    def test_two_d_spectral_mixture_power_law_mean_kiss_gp_model_exposes_parameter_schema(self):
+        import gpytorch
+        import torch
+
+        from pgmuvi.gps import TwoDSpectralMixturePowerLawMeanKISSGPModel
+
+        train_x = torch.tensor(
+            [
+                [0.0, 1.0],
+                [1.0, 1.0],
+                [2.0, 1.0],
+            ]
+        )
+        train_y = torch.tensor([1.0, 2.0, 3.0])
+
+        model = TwoDSpectralMixturePowerLawMeanKISSGPModel(
+            train_x,
+            train_y,
+            gpytorch.likelihoods.GaussianLikelihood(),
+            num_mixtures=3,
+            grid_size=[8, 4],
+        )
+
+        schema = model.parameter_schema()
+        names = schema.names()
+
+        self.assertIn("mean_module.offset", names)
+        self.assertIn("mean_module.weight", names)
+        self.assertIn("mean_module.exponent", names)
+
+        self.assertIn("covar_module.base_kernel.mixture_means", names)
+        self.assertIn("covar_module.base_kernel.mixture_scales", names)
+        self.assertIn("covar_module.base_kernel.mixture_weights", names)
+
+        self.assertEqual(
+            schema["covar_module.base_kernel.mixture_means"].shape,
+            (3,),
+        )
+
+    def test_two_d_spectral_mixture_dust_mean_gp_model_exposes_parameter_schema(self):
+        import gpytorch
+        import torch
+
+        from pgmuvi.gps import TwoDSpectralMixtureDustMeanGPModel
+
+        train_x = torch.tensor(
+            [
+                [0.0, 1.0],
+                [1.0, 1.0],
+                [2.0, 1.0],
+            ]
+        )
+        train_y = torch.tensor([1.0, 2.0, 3.0])
+
+        model = TwoDSpectralMixtureDustMeanGPModel(
+            train_x,
+            train_y,
+            gpytorch.likelihoods.GaussianLikelihood(),
+            num_mixtures=3,
+        )
+
+        schema = model.parameter_schema()
+        names = schema.names()
+
+        self.assertIn("mean_module.offset", names)
+        self.assertIn("mean_module.log_amplitude", names)
+        self.assertIn("mean_module.log_tau", names)
+        self.assertIn("mean_module.log_alpha", names)
+
+        self.assertIn("covar_module.mixture_means", names)
+        self.assertIn("covar_module.mixture_scales", names)
+        self.assertIn("covar_module.mixture_weights", names)
+
+        self.assertEqual(
+            schema["covar_module.mixture_means"].shape,
+            (3,),
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_parameter_workflow.py
+++ b/tests/test_parameter_workflow.py
@@ -249,6 +249,37 @@ class TestParameterWorkflow(unittest.TestCase):
             )
         )
 
+    def test_matern_gp_model_exposes_parameter_schema(self):
+        import gpytorch
+        import torch
+
+        from pgmuvi.gps import MaternGPModel
+
+        train_x = torch.tensor([0.0, 1.0, 2.0])
+        train_y = torch.tensor([1.0, 2.0, 3.0])
+
+        model = MaternGPModel(
+            train_x,
+            train_y,
+            gpytorch.likelihoods.GaussianLikelihood(),
+        )
+
+        schema = model.parameter_schema()
+
+        self.assertIsNotNone(schema)
+
+        names = schema.names()
+
+        self.assertIn(
+            "covar_module.outputscale",
+            names,
+        )
+
+        self.assertIn(
+            "covar_module.base_kernel.lengthscale",
+            names,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_parameter_workflow.py
+++ b/tests/test_parameter_workflow.py
@@ -782,6 +782,35 @@ class TestParameterWorkflow(unittest.TestCase):
         self.assertIn("covar_module.kernels.1.outputscale", names)
         self.assertIn("covar_module.kernels.1.base_kernel.lengthscale", names)
 
+    def test_linear_mean_quasi_periodic_gp_model_exposes_parameter_schema(self):
+        import gpytorch
+        import torch
+
+        from pgmuvi.gps import LinearMeanQuasiPeriodicGPModel
+
+        train_x = torch.tensor([0.0, 1.0, 2.0, 3.0])
+        train_y = torch.tensor([1.0, 2.0, 3.0, 4.0])
+
+        model = LinearMeanQuasiPeriodicGPModel(
+            train_x,
+            train_y,
+            gpytorch.likelihoods.GaussianLikelihood(),
+            period=2.0,
+        )
+
+        schema = model.parameter_schema()
+        names = schema.names()
+
+        self.assertIn("covar_module.outputscale", names)
+        self.assertIn(
+            "covar_module.base_kernel.kernels.0.period_length",
+            names,
+        )
+        self.assertIn(
+            "covar_module.base_kernel.kernels.1.lengthscale",
+            names,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_parameter_workflow.py
+++ b/tests/test_parameter_workflow.py
@@ -402,6 +402,40 @@ class TestParameterWorkflow(unittest.TestCase):
             (3,),
         )
 
+    def test_two_d_spectral_mixture_linear_mean_gp_model_exposes_parameter_schema(self):
+        import gpytorch
+        import torch
+
+        from pgmuvi.gps import TwoDSpectralMixtureLinearMeanGPModel
+
+        train_x = torch.tensor(
+            [
+                [0.0, 1.0],
+                [1.0, 1.0],
+                [2.0, 1.0],
+            ]
+        )
+        train_y = torch.tensor([1.0, 2.0, 3.0])
+
+        model = TwoDSpectralMixtureLinearMeanGPModel(
+            train_x,
+            train_y,
+            gpytorch.likelihoods.GaussianLikelihood(),
+            num_mixtures=3,
+        )
+
+        schema = model.parameter_schema()
+        names = schema.names()
+
+        self.assertIn("covar_module.mixture_means", names)
+        self.assertIn("covar_module.mixture_scales", names)
+        self.assertIn("covar_module.mixture_weights", names)
+
+        self.assertEqual(
+            schema["covar_module.mixture_means"].shape,
+            (3,),
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_parameter_workflow.py
+++ b/tests/test_parameter_workflow.py
@@ -312,6 +312,34 @@ class TestParameterWorkflow(unittest.TestCase):
             names,
         )
 
+    def test_spectral_mixture_gp_model_exposes_parameter_schema(self):
+        import gpytorch
+        import torch
+
+        from pgmuvi.gps import SpectralMixtureGPModel
+
+        train_x = torch.tensor([0.0, 1.0, 2.0])
+        train_y = torch.tensor([1.0, 2.0, 3.0])
+
+        model = SpectralMixtureGPModel(
+            train_x,
+            train_y,
+            gpytorch.likelihoods.GaussianLikelihood(),
+            num_mixtures=3,
+        )
+
+        schema = model.parameter_schema()
+        names = schema.names()
+
+        self.assertIn("covar_module.mixture_means", names)
+        self.assertIn("covar_module.mixture_scales", names)
+        self.assertIn("covar_module.mixture_weights", names)
+
+        self.assertEqual(
+            schema["covar_module.mixture_means"].shape,
+            (3,),
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_parameter_workflow.py
+++ b/tests/test_parameter_workflow.py
@@ -721,6 +721,36 @@ class TestParameterWorkflow(unittest.TestCase):
             (3,),
         )
 
+    def test_sparse_spectral_mixture_gp_model_exposes_parameter_schema(self):
+        import gpytorch
+        import torch
+
+        from pgmuvi.gps import SparseSpectralMixtureGPModel
+
+        train_x = torch.tensor([0.0, 1.0, 2.0])
+        train_y = torch.tensor([1.0, 2.0, 3.0])
+        inducing_points = torch.tensor([0.0, 1.0])
+
+        model = SparseSpectralMixtureGPModel(
+            train_x,
+            train_y,
+            gpytorch.likelihoods.GaussianLikelihood(),
+            num_mixtures=3,
+            inducing_points=inducing_points,
+        )
+
+        schema = model.parameter_schema()
+        names = schema.names()
+
+        self.assertIn("covar_module.mixture_means", names)
+        self.assertIn("covar_module.mixture_scales", names)
+        self.assertIn("covar_module.mixture_weights", names)
+
+        self.assertEqual(
+            schema["covar_module.mixture_means"].shape,
+            (3,),
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_parameter_workflow.py
+++ b/tests/test_parameter_workflow.py
@@ -530,6 +530,41 @@ class TestParameterWorkflow(unittest.TestCase):
             (3,),
         )
 
+    def test_two_d_spectral_mixture_linear_mean_kiss_gp_model_exposes_parameter_schema(self):
+        import gpytorch
+        import torch
+
+        from pgmuvi.gps import TwoDSpectralMixtureLinearMeanKISSGPModel
+
+        train_x = torch.tensor(
+            [
+                [0.0, 1.0],
+                [1.0, 1.0],
+                [2.0, 1.0],
+            ]
+        )
+        train_y = torch.tensor([1.0, 2.0, 3.0])
+
+        model = TwoDSpectralMixtureLinearMeanKISSGPModel(
+            train_x,
+            train_y,
+            gpytorch.likelihoods.GaussianLikelihood(),
+            num_mixtures=3,
+            grid_size=[8, 4],
+        )
+
+        schema = model.parameter_schema()
+        names = schema.names()
+
+        self.assertIn("covar_module.base_kernel.mixture_means", names)
+        self.assertIn("covar_module.base_kernel.mixture_scales", names)
+        self.assertIn("covar_module.base_kernel.mixture_weights", names)
+
+        self.assertEqual(
+            schema["covar_module.base_kernel.mixture_means"].shape,
+            (3,),
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Expose parameter workflow schemas on GP model classes.

## Changes

- Add `ParameterSpecCollection.combine()`
- Add model-level `parameter_schema()` methods for supported GP models
- Add schema support for spectral-mixture, KISS-GP, separable, wavelength-dependent, dust-mean, and power-law mean model variants
- Add kernel-schema resolution for nested/composite kernels
- Reuse generic lengthscale rules for RQ lengthscales
- Add tests covering model-level schema exposure

## Testing

```bash
python3 -m unittest discover -s tests -p "test_parameter_workflow.py"
python3 -m unittest discover -s tests -p "test_parameter_specs.py"
python3 -m unittest discover -s tests -p "test_spectral_mixture_parameter_schema.py"
python3 -m unittest discover -s tests -p "test_power_law_mean_parameter_schema.py"
python3 -m unittest discover -s tests -p "test_dust_mean_parameter_schema.py"
python3 -m unittest discover -s tests -p "test_lengthscale_kernel_parameter_schema.py"
python3 -m unittest discover -s tests -p "test_scale_kernel_parameter_schema.py"
python3 -m unittest discover -s tests -p "test_rq_kernel_parameter_schema.py"