### PR TITLE
Validate fit-path parameter workflow application

### DIFF
--- a/tests/test_lightcurve_parameter_context.py
+++ b/tests/test_lightcurve_parameter_context.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch
 
 import torch
 
@@ -322,4 +323,53 @@ class TestLightcurveParameterEstimationContext(unittest.TestCase):
         self.assertEqual(
             lc.parameter_workflow_result,
             result,
+        )
+
+    def test_fit_applies_parameter_workflow_for_schema_enabled_model(self):
+        import gpytorch
+
+        lc = Lightcurve(
+            torch.tensor([0.0, 1.0, 2.0, 3.0]),
+            torch.tensor([1.0, 2.0, 3.0, 4.0]),
+        )
+
+        with patch("pgmuvi.lightcurve.train", return_value={"mock": "result"}):
+            result = lc.fit(
+                model="1DMatern",
+                likelihood=gpytorch.likelihoods.GaussianLikelihood,
+                training_iter=0,
+                miniter=0,
+            )
+
+        self.assertEqual(
+            result,
+            {"mock": "result"},
+        )
+
+        self.assertEqual(
+            lc.parameter_workflow_result,
+            {
+                "covar_module.outputscale": {
+                    "value": True,
+                    "constraint": True,
+                },
+                "covar_module.base_kernel.lengthscale": {
+                    "value": True,
+                    "constraint": True,
+                },
+            },
+        )
+
+        self.assertEqual(
+            lc.get_parameter_workflow_summary(),
+            {
+                "available": True,
+                "applied": 2,
+                "skipped": 0,
+                "applied_parameters": [
+                    "covar_module.outputscale",
+                    "covar_module.base_kernel.lengthscale",
+                ],
+                "skipped_parameters": [],
+            },
         )


### PR DESCRIPTION
## Summary

Add validation that the parameter workflow is invoked through the actual
`Lightcurve.fit()` path.

## Changes

- Add a fit-level test using the schema-enabled `1DMatern` model
- Mock training to avoid running GP optimization
- Verify that parameter workflow estimates are applied during fit initialization
- Verify that `parameter_workflow_result` is populated
- Verify that workflow summary reporting reflects the applied parameters

## Scope

This PR adds validation only.

It does not change fitting behavior, model schemas, parameter estimation
rules, or optimizer behavior.

## Testing

```bash
python3 -m unittest discover -s tests -p "test_lightcurve_parameter_context.py"
python3 -m unittest discover -s tests -p "test_parameter_application.py"
python3 -m unittest discover -s tests -p "test_parameter_workflow.py"