### PR TITLE
Add fit control for parameter workflow initialization

### DIFF
--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -9308,6 +9308,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         periods=None,
         use_mls_init=True,
         use_best_band_init: bool = False,
+        use_parameter_workflow: bool = True,
         constraint_set=None,
         grid_size=2000,
         cuda=False,
@@ -9913,7 +9914,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         if not self.__CONTRAINTS_SET:
             self.set_default_constraints()
 
-        if not _constraints_were_set_before_fit:
+        if use_parameter_workflow and not _constraints_were_set_before_fit:
             self._apply_parameter_workflow_estimates()
 
         if cuda:

--- a/tests/test_lightcurve_parameter_context.py
+++ b/tests/test_lightcurve_parameter_context.py
@@ -373,3 +373,40 @@ class TestLightcurveParameterEstimationContext(unittest.TestCase):
                 "skipped_parameters": [],
             },
         )
+
+    def test_fit_can_disable_parameter_workflow_for_schema_enabled_model(self):
+        import gpytorch
+
+        lc = Lightcurve(
+            torch.tensor([0.0, 1.0, 2.0, 3.0]),
+            torch.tensor([1.0, 2.0, 3.0, 4.0]),
+        )
+
+        with patch("pgmuvi.lightcurve.train", return_value={"mock": "result"}):
+            result = lc.fit(
+                model="1DMatern",
+                likelihood=gpytorch.likelihoods.GaussianLikelihood,
+                training_iter=0,
+                miniter=0,
+                use_parameter_workflow=False,
+            )
+
+        self.assertEqual(
+            result,
+            {"mock": "result"},
+        )
+
+        self.assertIsNone(
+            lc.parameter_workflow_result,
+        )
+
+        self.assertEqual(
+            lc.get_parameter_workflow_summary(),
+            {
+                "available": False,
+                "applied": 0,
+                "skipped": 0,
+                "applied_parameters": [],
+                "skipped_parameters": [],
+            },
+        )


### PR DESCRIPTION
## Summary

Add a fit-level switch for automatic parameter workflow initialization.

## Changes

- Add `use_parameter_workflow` to `_fit_core()`
- Default behavior remains enabled
- Skip fit-time parameter workflow application when disabled
- Add test coverage for explicit opt-out behavior

## Scope

This PR only adds user control over the parameter workflow.

It does not change parameter schemas, estimation rules, application
semantics, or optimizer behavior.

## Testing

```bash
python3 -m unittest discover -s tests -p "test_lightcurve_parameter_context.py"
python3 -m unittest discover -s tests -p "test_parameter_application.py"
python3 -m unittest discover -s tests -p "test_parameter_workflow.py"