### PR TITLE
Document parameter workflow initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,3 +127,33 @@ print(f"{results['summary']['n_variable']} variable bands")
 lc_var = lc2d.filter_variable_bands()
 lc_var.fit(...)
 ```
+
+### Parameter workflow initialization
+
+Schema-enabled models can automatically initialize supported model
+parameters from available light-curve diagnostics during `fit()`.
+
+By default, the parameter workflow is enabled:
+```python
+    lc.fit(
+        model="1DMatern",
+    )
+```
+To disable schema-driven initialization:
+```python
+    lc.fit(
+        model="1DMatern",
+        use_parameter_workflow=False,
+    )
+```
+After fitting, the workflow results can be inspected directly:
+```python
+    lc.parameter_workflow_result
+```
+or summarized using:
+```python
+    lc.get_parameter_workflow_summary()
+```
+The summary reports whether parameter-workflow results are available,
+which parameters were successfully initialized, which were skipped,
+and the corresponding parameter names.

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -9424,6 +9424,15 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             variability.  This can improve convergence for sources with a
             large dynamic range in the number of observations across bands.
             Has no effect for 1D lightcurves or when ``use_mls_init=False``.
+        use_parameter_workflow : bool, optional
+            Whether to apply schema-driven parameter initialization before
+            training. When enabled, models that expose a parameter_schema()
+            may automatically receive parameter estimates and constraints
+            derived from available light-curve diagnostics. Defaults to True.
+
+            Set to False to disable automatic parameter-workflow application
+            and rely only on existing defaults, explicit user guesses,
+            consensus/MLS initialization, and manually supplied constraints.
         constraint_set : str or None, optional
             Name of a pre-defined source-type constraint set to apply via
             :meth:`set_default_constraints`.  When provided, the period bounds


### PR DESCRIPTION
## Summary

Document schema-driven parameter workflow initialization and reporting.

## Changes

- Document `use_parameter_workflow` in the fit documentation
- Add README examples for default workflow behavior
- Add README example for disabling schema-driven initialization
- Document `parameter_workflow_result`
- Document `get_parameter_workflow_summary()`

## Scope

Documentation-only change.

## Testing

```bash
python3 -m unittest discover -s tests -p "test_lightcurve_parameter_context.py"