### PR TITLE
Pr20 parameter workflow skip reasons

### DIFF
--- a/pgmuvi/parameter_application.py
+++ b/pgmuvi/parameter_application.py
@@ -46,7 +46,15 @@ class ParameterEstimateApplicator:
             results[estimate.name] = {
                 "value": value_applied,
                 "constraint": constraint_applied,
-                "value_reason": None if value_applied else "value_unavailable",
+                "value_reason": (
+                    None
+                    if value_applied
+                    else estimate.metadata.get(
+                        "value_reason",
+                        "value_unavailable",
+                    )
+                    or "value_unavailable"
+                ),
                 "constraint_reason": (
                     None if constraint_applied else "constraint_unavailable"
                 ),

--- a/pgmuvi/parameter_application.py
+++ b/pgmuvi/parameter_application.py
@@ -36,13 +36,20 @@ class ParameterEstimateApplicator:
                 else self._resolve_parameter(model, module_path)
             )
 
+            value_applied = self._apply_value(
+                target_module,
+                parameter_name,
+                estimate,
+            )
+            constraint_applied = self._apply_constraint(model, estimate)
+
             results[estimate.name] = {
-                "value": self._apply_value(
-                    target_module,
-                    parameter_name,
-                    estimate,
+                "value": value_applied,
+                "constraint": constraint_applied,
+                "value_reason": None if value_applied else "value_unavailable",
+                "constraint_reason": (
+                    None if constraint_applied else "constraint_unavailable"
                 ),
-                "constraint": self._apply_constraint(model, estimate),
             }
 
         return results

--- a/pgmuvi/parameter_builders.py
+++ b/pgmuvi/parameter_builders.py
@@ -45,6 +45,14 @@ class ParameterEstimateBuilder:
         value = self._estimate_value(spec, context)
         constraint = self._estimate_constraint(spec, context)
 
+        value = self._estimate_value(spec, context)
+        constraint = self._estimate_constraint(spec, context)
+        value_reason = self._estimate_value_reason(
+            spec,
+            context,
+            value,
+        )
+
         return ParameterEstimate(
             spec=spec,
             value=value,
@@ -53,7 +61,25 @@ class ParameterEstimateBuilder:
             constraint_source=(
                 spec.constraint_strategy.value if spec.constraint_strategy else None
             ),
+            metadata={
+                "value_reason": value_reason,
+            },
         )
+
+    def _estimate_value_reason(
+        self,
+        spec: ParameterSpec,
+        context: ParameterEstimationContext,
+        value,
+    ):
+        """Return a reason string when value estimation did not produce a value."""
+        if value is not None:
+            return None
+
+        if spec.guess_strategy is GuessStrategy.CONSENSUS_FREQUENCY:
+            return "consensus_frequency_unavailable"
+
+        return None
 
     def _estimate_value(
         self,

--- a/tests/test_lightcurve_parameter_context.py
+++ b/tests/test_lightcurve_parameter_context.py
@@ -314,7 +314,7 @@ class TestLightcurveParameterEstimationContext(unittest.TestCase):
                 "covar_module.mixture_means": {
                     "value": False,
                     "constraint": True,
-                    "value_reason": "value_unavailable",
+                    "value_reason": "consensus_frequency_unavailable",
                     "constraint_reason": None,
                 },
                 "covar_module.mixture_scales": {

--- a/tests/test_lightcurve_parameter_context.py
+++ b/tests/test_lightcurve_parameter_context.py
@@ -146,6 +146,8 @@ class TestLightcurveParameterEstimationContext(unittest.TestCase):
                 "mean_module.offset": {
                     "value": True,
                     "constraint": True,
+                    "value_reason": None,
+                    "constraint_reason": None,
                 },
             },
         )
@@ -256,10 +258,14 @@ class TestLightcurveParameterEstimationContext(unittest.TestCase):
                 "covar_module.outputscale": {
                     "value": True,
                     "constraint": True,
+                    "value_reason": None,
+                    "constraint_reason": None,
                 },
                 "covar_module.base_kernel.lengthscale": {
                     "value": True,
                     "constraint": True,
+                    "value_reason": None,
+                    "constraint_reason": None,
                 },
             },
         )
@@ -308,14 +314,20 @@ class TestLightcurveParameterEstimationContext(unittest.TestCase):
                 "covar_module.mixture_means": {
                     "value": False,
                     "constraint": True,
+                    "value_reason": "value_unavailable",
+                    "constraint_reason": None,
                 },
                 "covar_module.mixture_scales": {
                     "value": True,
                     "constraint": True,
+                    "value_reason": None,
+                    "constraint_reason": None,
                 },
                 "covar_module.mixture_weights": {
                     "value": True,
                     "constraint": True,
+                    "value_reason": None,
+                    "constraint_reason": None,
                 },
             },
         )
@@ -352,10 +364,14 @@ class TestLightcurveParameterEstimationContext(unittest.TestCase):
                 "covar_module.outputscale": {
                     "value": True,
                     "constraint": True,
+                    "value_reason": None,
+                    "constraint_reason": None,
                 },
                 "covar_module.base_kernel.lengthscale": {
                     "value": True,
                     "constraint": True,
+                    "value_reason": None,
+                    "constraint_reason": None,
                 },
             },
         )

--- a/tests/test_parameter_application.py
+++ b/tests/test_parameter_application.py
@@ -292,10 +292,14 @@ class TestParameterEstimateApplicator(unittest.TestCase):
                 "mean_module.offset": {
                     "value": True,
                     "constraint": False,
+                    "value_reason": None,
+                    "constraint_reason": "constraint_unavailable",
                 },
                 "mean_module.log_amplitude": {
                     "value": True,
                     "constraint": False,
+                    "value_reason": None,
+                    "constraint_reason": "constraint_unavailable",
                 },
             },
         )
@@ -610,6 +614,8 @@ class TestParameterEstimateApplicator(unittest.TestCase):
                 "covar_module.lengthscale": {
                     "value": True,
                     "constraint": False,
+                    "value_reason": None,
+                    "constraint_reason": "constraint_unavailable",
                 },
             },
         )

--- a/tests/test_parameter_builders.py
+++ b/tests/test_parameter_builders.py
@@ -698,3 +698,27 @@ class TestParameterEstimateBuilder(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+    def test_consensus_frequency_unavailable_records_value_reason(self):
+        spec = ParameterSpec(
+            name="covar_module.mixture_means",
+            role=ParameterRole.FREQUENCY,
+            domain=ParameterDomain.FREQUENCY,
+            scale=ParameterScale.LINEAR,
+            guess_strategy=GuessStrategy.CONSENSUS_FREQUENCY,
+        )
+
+        context = ParameterEstimationContext(
+            is_multiband=False,
+        )
+
+        estimate = ParameterEstimateBuilder().build_one(
+            spec=spec,
+            context=context,
+        )
+
+        self.assertIsNone(estimate.value)
+        self.assertEqual(
+            estimate.metadata["value_reason"],
+            "consensus_frequency_unavailable",
+        )

--- a/tests/test_parameter_workflow.py
+++ b/tests/test_parameter_workflow.py
@@ -163,6 +163,8 @@ class TestParameterWorkflow(unittest.TestCase):
                 "mean_module.offset": {
                     "value": True,
                     "constraint": True,
+                    "value_reason": None,
+                    "constraint_reason": None,
                 },
             },
         )
@@ -201,6 +203,8 @@ class TestParameterWorkflow(unittest.TestCase):
                 "mean_module.offset": {
                     "value": True,
                     "constraint": True,
+                    "value_reason": None,
+                    "constraint_reason": None,
                 },
             },
         )


### PR DESCRIPTION
## Summary

Add reason fields to parameter workflow application results and propagate
specific skip reasons for unavailable consensus-frequency estimates.

## Changes

- Add `value_reason` and `constraint_reason` to workflow application results
- Preserve existing `value` and `constraint` boolean flags
- Record generic unavailable reasons for skipped values/constraints
- Add builder metadata for unavailable `CONSENSUS_FREQUENCY` estimates
- Propagate `consensus_frequency_unavailable` into workflow results
- Update tests for the expanded result schema

## Scope

This PR improves workflow diagnostics only.

It does not change parameter estimation behavior, application behavior,
model schemas, or fitting behavior.

## Testing

```bash
python3 -m unittest discover -s tests -p "test_parameter_builders.py"
python3 -m unittest discover -s tests -p "test_parameter_application.py"
python3 -m unittest discover -s tests -p "test_lightcurve_parameter_context.py"
python3 -m unittest discover -s tests -p "test_parameter_workflow.py"