### PR TITLE
Report parameter workflow skip reasons in summaries

### DIFF
--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -9100,32 +9100,43 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 "skipped": 0,
                 "applied_parameters": [],
                 "skipped_parameters": [],
+                "skipped_reasons": {},
             }
-
-        applied = 0
-        skipped = 0
-
-        for value in result.values():
-            if value:
-                applied += 1
-            else:
-                skipped += 1
 
         applied_parameters = []
         skipped_parameters = []
+        skipped_reasons = {}
 
         for name, value in result.items():
-            if value:
+            if isinstance(value, dict):
+                value_applied = bool(value.get("value"))
+                constraint_applied = bool(value.get("constraint"))
+                applied = value_applied or constraint_applied
+            else:
+                applied = bool(value)
+
+            if applied:
                 applied_parameters.append(name)
             else:
                 skipped_parameters.append(name)
 
+            if isinstance(value, dict):
+                value_reason = value.get("value_reason")
+                constraint_reason = value.get("constraint_reason")
+
+                if value_reason is not None or constraint_reason is not None:
+                    skipped_reasons[name] = {
+                        "value_reason": value_reason,
+                        "constraint_reason": constraint_reason,
+                    }
+
         return {
             "available": True,
-            "applied": applied,
-            "skipped": skipped,
+            "applied": len(applied_parameters),
+            "skipped": len(skipped_parameters),
             "applied_parameters": applied_parameters,
             "skipped_parameters": skipped_parameters,
+            "skipped_reasons": skipped_reasons,
         }
 
     def fit(self, *args, **kwargs):

--- a/tests/test_lightcurve_parameter_context.py
+++ b/tests/test_lightcurve_parameter_context.py
@@ -208,6 +208,7 @@ class TestLightcurveParameterEstimationContext(unittest.TestCase):
                 "skipped": 0,
                 "applied_parameters": [],
                 "skipped_parameters": [],
+                "skipped_reasons": {},
             },
         )
 
@@ -231,6 +232,48 @@ class TestLightcurveParameterEstimationContext(unittest.TestCase):
                 "skipped": 1,
                 "applied_parameters": ["a", "b"],
                 "skipped_parameters": ["c"],
+                "skipped_reasons": {},
+            },
+        )
+
+    def test_parameter_workflow_summary_reports_skip_reasons(self):
+        lc = Lightcurve(
+            torch.tensor([0.0, 1.0, 2.0]),
+            torch.tensor([10.0, 20.0, 30.0]),
+        )
+
+        lc.parameter_workflow_result = {
+            "covar_module.mixture_means": {
+                "value": False,
+                "constraint": True,
+                "value_reason": "consensus_frequency_unavailable",
+                "constraint_reason": None,
+            },
+            "covar_module.mixture_scales": {
+                "value": True,
+                "constraint": True,
+                "value_reason": None,
+                "constraint_reason": None,
+            },
+        }
+
+        self.assertEqual(
+            lc.get_parameter_workflow_summary(),
+            {
+                "available": True,
+                "applied": 2,
+                "skipped": 0,
+                "applied_parameters": [
+                    "covar_module.mixture_means",
+                    "covar_module.mixture_scales",
+                ],
+                "skipped_parameters": [],
+                "skipped_reasons": {
+                    "covar_module.mixture_means": {
+                        "value_reason": "consensus_frequency_unavailable",
+                        "constraint_reason": None,
+                    },
+                },
             },
         )
 
@@ -286,6 +329,7 @@ class TestLightcurveParameterEstimationContext(unittest.TestCase):
                     "covar_module.base_kernel.lengthscale",
                 ],
                 "skipped_parameters": [],
+                "skipped_reasons": {},
             },
         )
 
@@ -387,6 +431,7 @@ class TestLightcurveParameterEstimationContext(unittest.TestCase):
                     "covar_module.base_kernel.lengthscale",
                 ],
                 "skipped_parameters": [],
+                "skipped_reasons": {},
             },
         )
 
@@ -424,5 +469,6 @@ class TestLightcurveParameterEstimationContext(unittest.TestCase):
                 "skipped": 0,
                 "applied_parameters": [],
                 "skipped_parameters": [],
+                "skipped_reasons": {},
             },
         )


### PR DESCRIPTION
## Summary

Expose parameter workflow skip reasons through summary reporting.

## Changes

- Extend `get_parameter_workflow_summary()` with `skipped_reasons`
- Preserve backward compatibility with legacy boolean-style workflow results
- Report value and constraint skip reasons from structured workflow results
- Add tests for:
  - missing workflow results
  - legacy boolean results
  - structured results with skip reasons

## Scope

This PR only changes workflow summary reporting.

It does not change parameter estimation, parameter application, model schemas,
or fitting behavior.

## Testing

```bash
python3 -m unittest discover -s tests -p "test_lightcurve_parameter_context.py"