### PR TITLE
Add specific parameter workflow skip reasons

### DIFF
--- a/pgmuvi/parameter_builders.py
+++ b/pgmuvi/parameter_builders.py
@@ -79,6 +79,20 @@ class ParameterEstimateBuilder:
         if spec.guess_strategy is GuessStrategy.CONSENSUS_FREQUENCY:
             return "consensus_frequency_unavailable"
 
+        diagnostics = context.global_diagnostics
+
+        if spec.guess_strategy is GuessStrategy.MEDIAN_FLUX:
+            if diagnostics is None:
+                return "global_diagnostics_unavailable"
+
+            return "median_flux_unavailable"
+
+        if spec.guess_strategy is GuessStrategy.ROBUST_FLUX_SPAN:
+            if diagnostics is None:
+                return "global_diagnostics_unavailable"
+
+            return "robust_flux_span_unavailable"
+
         return None
 
     def _estimate_value(

--- a/tests/test_lightcurve_parameter_context.py
+++ b/tests/test_lightcurve_parameter_context.py
@@ -472,3 +472,42 @@ class TestLightcurveParameterEstimationContext(unittest.TestCase):
                 "skipped_reasons": {},
             },
         )
+
+    def test_parameter_workflow_propagates_global_diagnostics_reason(self):
+        import gpytorch
+
+        from pgmuvi.gps import DustMeanGPModel
+
+        lc = Lightcurve(
+            torch.tensor(
+                [
+                    [0.0, 1.0],
+                    [1.0, 1.0],
+                    [2.0, 2.0],
+                    [3.0, 2.0],
+                ]
+            ),
+            torch.tensor([1.0, 2.0, 3.0, 4.0]),
+        )
+
+        lc.model = DustMeanGPModel(
+            lc.xdata,
+            lc.ydata,
+            gpytorch.likelihoods.GaussianLikelihood(),
+        )
+
+        context = ParameterEstimationContext(
+            is_multiband=True,
+        )
+
+        with patch.object(
+            lc,
+            "_build_parameter_estimation_context",
+            return_value=context,
+        ):
+            result = lc._apply_parameter_workflow_estimates()
+
+        self.assertEqual(
+            result["mean_module.offset"]["value_reason"],
+            "global_diagnostics_unavailable",
+        )

--- a/tests/test_parameter_builders.py
+++ b/tests/test_parameter_builders.py
@@ -722,3 +722,51 @@ if __name__ == "__main__":
             estimate.metadata["value_reason"],
             "consensus_frequency_unavailable",
         )
+
+    def test_median_flux_unavailable_records_reason(self):
+        spec = ParameterSpec(
+            name="mean_module.offset",
+            role=ParameterRole.MEAN,
+            domain=ParameterDomain.FLUX,
+            scale=ParameterScale.LINEAR,
+            guess_strategy=GuessStrategy.MEDIAN_FLUX,
+        )
+
+        context = ParameterEstimationContext(
+            is_multiband=False,
+        )
+
+        estimate = ParameterEstimateBuilder().build_one(
+            spec=spec,
+            context=context,
+        )
+
+        self.assertIsNone(estimate.value)
+        self.assertEqual(
+            estimate.metadata["value_reason"],
+            "global_diagnostics_unavailable",
+        )
+
+    def test_robust_flux_span_unavailable_records_reason(self):
+        spec = ParameterSpec(
+            name="mean_module.log_amplitude",
+            role=ParameterRole.AMPLITUDE,
+            domain=ParameterDomain.FLUX,
+            scale=ParameterScale.LOG,
+            guess_strategy=GuessStrategy.ROBUST_FLUX_SPAN,
+        )
+
+        context = ParameterEstimationContext(
+            is_multiband=False,
+        )
+
+        estimate = ParameterEstimateBuilder().build_one(
+            spec=spec,
+            context=context,
+        )
+
+        self.assertIsNone(estimate.value)
+        self.assertEqual(
+            estimate.metadata["value_reason"],
+            "global_diagnostics_unavailable",
+        )


### PR DESCRIPTION
## Summary

Add more specific skip reasons for unavailable parameter estimates.

## Changes

- Record `global_diagnostics_unavailable` for diagnostic-derived estimates when no global diagnostics are available
- Record unavailable reasons for median-flux and robust-flux-span estimate paths
- Preserve existing `consensus_frequency_unavailable` behavior
- Add builder-level tests for specific reason metadata
- Add integration-style validation that diagnostic skip reasons propagate into workflow results

## Scope

This PR improves workflow diagnostics only.

It does not change fitting behavior, model schemas, parameter application semantics, or optimizer behavior.

## Testing

```bash
python3 -m unittest discover -s tests -p "test_parameter_builders.py"
python3 -m unittest discover -s tests -p "test_lightcurve_parameter_context.py"
python3 -m unittest discover -s tests -p "test_parameter_application.py"
python3 -m unittest discover -s tests -p "test_parameter_workflow.py"