### PR TITLE
Add structured parameter workflow reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,3 +157,5 @@ or summarized using:
 The summary reports whether parameter-workflow results are available,
 which parameters were successfully initialized, which were skipped,
 and the corresponding parameter names.
+Use `get_parameter_workflow_report()` when you need a structured list
+of applied and skipped parameters with value/constraint reason metadata.

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -9496,6 +9496,9 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             Set to False to disable automatic parameter-workflow application
             and rely only on existing defaults, explicit user guesses,
             consensus/MLS initialization, and manually supplied constraints.
+
+            After fitting, use get_parameter_workflow_summary() or
+            get_parameter_workflow_report() to inspect what was applied or skipped.
         constraint_set : str or None, optional
             Name of a pre-defined source-type constraint set to apply via
             :meth:`set_default_constraints`.  When provided, the period bounds

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -9139,6 +9139,58 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             "skipped_reasons": skipped_reasons,
         }
 
+    def get_parameter_workflow_report(self):
+        """Return a structured parameter workflow report."""
+        result = self.parameter_workflow_result
+
+        if result is None:
+            return {
+                "available": False,
+                "applied": [],
+                "skipped": [],
+            }
+
+        applied = []
+        skipped = []
+
+        for parameter, info in result.items():
+            if not isinstance(info, dict):
+                if info:
+                    applied.append(
+                        {
+                            "parameter": parameter,
+                        }
+                    )
+                else:
+                    skipped.append(
+                        {
+                            "parameter": parameter,
+                        }
+                    )
+                continue
+
+            value_applied = bool(info.get("value"))
+            constraint_applied = bool(info.get("constraint"))
+
+            entry = {
+                "parameter": parameter,
+                "value_applied": value_applied,
+                "constraint_applied": constraint_applied,
+                "value_reason": info.get("value_reason"),
+                "constraint_reason": info.get("constraint_reason"),
+            }
+
+            if value_applied or constraint_applied:
+                applied.append(entry)
+            else:
+                skipped.append(entry)
+
+        return {
+            "available": True,
+            "applied": applied,
+            "skipped": skipped,
+        }
+
     def fit(self, *args, **kwargs):
         """Fit wrapper that records lightweight in-memory fit history."""
         # Nested fit() calls (e.g. from _consensus_standard_fit) delegate

--- a/tests/test_lightcurve_parameter_context.py
+++ b/tests/test_lightcurve_parameter_context.py
@@ -277,6 +277,67 @@ class TestLightcurveParameterEstimationContext(unittest.TestCase):
             },
         )
 
+    def test_parameter_workflow_report_without_results(self):
+        lc = Lightcurve(
+            torch.tensor([0.0, 1.0, 2.0]),
+            torch.tensor([10.0, 20.0, 30.0]),
+        )
+
+        self.assertEqual(
+            lc.get_parameter_workflow_report(),
+            {
+                "available": False,
+                "applied": [],
+                "skipped": [],
+            },
+        )
+
+    def test_parameter_workflow_report_with_structured_results(self):
+        lc = Lightcurve(
+            torch.tensor([0.0, 1.0, 2.0]),
+            torch.tensor([10.0, 20.0, 30.0]),
+        )
+
+        lc.parameter_workflow_result = {
+            "covar_module.outputscale": {
+                "value": True,
+                "constraint": True,
+                "value_reason": None,
+                "constraint_reason": None,
+            },
+            "covar_module.mixture_means": {
+                "value": False,
+                "constraint": False,
+                "value_reason": "consensus_frequency_unavailable",
+                "constraint_reason": None,
+            },
+        }
+
+        self.assertEqual(
+            lc.get_parameter_workflow_report(),
+            {
+                "available": True,
+                "applied": [
+                    {
+                        "parameter": "covar_module.outputscale",
+                        "value_applied": True,
+                        "constraint_applied": True,
+                        "value_reason": None,
+                        "constraint_reason": None,
+                    }
+                ],
+                "skipped": [
+                    {
+                        "parameter": "covar_module.mixture_means",
+                        "value_applied": False,
+                        "constraint_applied": False,
+                        "value_reason": "consensus_frequency_unavailable",
+                        "constraint_reason": None,
+                    }
+                ],
+            },
+        )
+
     def test_parameter_workflow_applies_real_matern_model_schema(self):
         import gpytorch
 


### PR DESCRIPTION
## Summary

Add structured reporting for parameter workflow results.

## Changes

- Add `get_parameter_workflow_report()`
- Separate applied and skipped parameters
- Preserve value/constraint application status
- Preserve value/constraint reason metadata
- Add report-level tests
- Document workflow reports in the README and fit documentation

## Scope

This PR improves parameter workflow diagnostics and reporting only.

It does not change parameter estimation, parameter application, model
schemas, workflow behavior, or fitting behavior.

## Testing

```bash
python3 -m unittest discover -s tests -p "test_lightcurve_parameter_context.py"