### PR TITLE
Reset parameter workflow state between fits

### DIFF
--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -9205,6 +9205,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 self._fit_nesting_depth -= 1
 
         self._fit_nesting_depth = 1
+        self.parameter_workflow_result = None
         _fit_start = time.perf_counter()
         _model_arg = kwargs.get("model")
         _fit_strategy = kwargs.get("fit_strategy")

--- a/tests/test_lightcurve_parameter_context.py
+++ b/tests/test_lightcurve_parameter_context.py
@@ -534,6 +534,53 @@ class TestLightcurveParameterEstimationContext(unittest.TestCase):
             },
         )
 
+    def test_fit_clears_previous_parameter_workflow_result_when_disabled(self):
+        import gpytorch
+
+        lc = Lightcurve(
+            torch.tensor([0.0, 1.0, 2.0, 3.0]),
+            torch.tensor([1.0, 2.0, 3.0, 4.0]),
+        )
+
+        with patch("pgmuvi.lightcurve.train", return_value={"mock": "result"}):
+            lc.fit(
+                model="1DMatern",
+                likelihood=gpytorch.likelihoods.GaussianLikelihood,
+                training_iter=0,
+                miniter=0,
+                use_parameter_workflow=True,
+            )
+
+        self.assertIsNotNone(lc.parameter_workflow_result)
+
+        with patch("pgmuvi.lightcurve.train", return_value={"mock": "result"}):
+            result = lc.fit(
+                model="1DMatern",
+                likelihood=gpytorch.likelihoods.GaussianLikelihood,
+                training_iter=0,
+                miniter=0,
+                use_parameter_workflow=False,
+            )
+
+        self.assertEqual(
+            result,
+            {"mock": "result"},
+        )
+
+        self.assertIsNone(lc.parameter_workflow_result)
+
+        self.assertEqual(
+            lc.get_parameter_workflow_summary(),
+            {
+                "available": False,
+                "applied": 0,
+                "skipped": 0,
+                "applied_parameters": [],
+                "skipped_parameters": [],
+                "skipped_reasons": {},
+            },
+        )
+
     def test_parameter_workflow_propagates_global_diagnostics_reason(self):
         import gpytorch
 


### PR DESCRIPTION
## Summary

Clear stale parameter workflow results between successive fits.

## Problem

`parameter_workflow_result` persisted on the `Lightcurve` instance after a fit completed.

When a subsequent fit was run with:

```
use_parameter_workflow=False
```

the old workflow results remained attached to the object, causing:

* `parameter_workflow_result`
* `get_parameter_workflow_summary()`
* `get_parameter_workflow_report()`

to report stale information from a previous fit.

## Changes

* Reset `parameter_workflow_result` at the start of each fit
* Add a regression test covering:

  * workflow-enabled fit populates results
  * subsequent workflow-disabled fit clears results
  * summary reporting returns the expected unavailable state

## Scope

This PR fixes workflow diagnostics state management only.

It does not modify parameter estimation, parameter application, model schemas, initialization logic, or optimizer behavior.

## Testing

```
python3 -m unittest discover -s tests -p "test_lightcurve_parameter_context.py"
```
