### PR TITLE
Report skipped parameter workflow execution

### DIFF
--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -9992,6 +9992,15 @@ class Lightcurve(InputHelpers, gpytorch.Module):
 
         if use_parameter_workflow and not _constraints_were_set_before_fit:
             self._apply_parameter_workflow_estimates()
+        elif use_parameter_workflow and _constraints_were_set_before_fit:
+            self.parameter_workflow_result = {
+                "__workflow__": {
+                    "value": False,
+                    "constraint": False,
+                    "value_reason": "skipped_existing_constraints",
+                    "constraint_reason": "skipped_existing_constraints",
+                },
+            }
 
         if cuda:
             self.cuda()

--- a/tests/test_lightcurve_parameter_context.py
+++ b/tests/test_lightcurve_parameter_context.py
@@ -534,6 +534,81 @@ class TestLightcurveParameterEstimationContext(unittest.TestCase):
             },
         )
 
+    def test_fit_reports_parameter_workflow_skipped_by_existing_constraints(self):
+        import gpytorch
+
+        lc = Lightcurve(
+            torch.tensor([0.0, 1.0, 2.0, 3.0]),
+            torch.tensor([1.0, 2.0, 3.0, 4.0]),
+        )
+
+        with patch(
+            "pgmuvi.lightcurve.train",
+            return_value={"mock": "result"},
+        ), patch.object(
+            lc,
+            "_Lightcurve__CONTRAINTS_SET",
+            True,
+        ):
+            result = lc.fit(
+                model="1DMatern",
+                likelihood=gpytorch.likelihoods.GaussianLikelihood,
+                training_iter=0,
+                miniter=0,
+                use_parameter_workflow=True,
+            )
+
+        self.assertEqual(
+            result,
+            {"mock": "result"},
+        )
+
+        self.assertEqual(
+            lc.parameter_workflow_result,
+            {
+                "__workflow__": {
+                    "value": False,
+                    "constraint": False,
+                    "value_reason": "skipped_existing_constraints",
+                    "constraint_reason": "skipped_existing_constraints",
+                },
+            },
+        )
+
+        self.assertEqual(
+            lc.get_parameter_workflow_summary(),
+            {
+                "available": True,
+                "applied": 0,
+                "skipped": 1,
+                "applied_parameters": [],
+                "skipped_parameters": ["__workflow__"],
+                "skipped_reasons": {
+                    "__workflow__": {
+                        "value_reason": "skipped_existing_constraints",
+                        "constraint_reason": "skipped_existing_constraints",
+                    },
+                },
+            },
+        )
+
+        self.assertEqual(
+            lc.get_parameter_workflow_report(),
+            {
+                "available": True,
+                "applied": [],
+                "skipped": [
+                    {
+                        "parameter": "__workflow__",
+                        "value_applied": False,
+                        "constraint_applied": False,
+                        "value_reason": "skipped_existing_constraints",
+                        "constraint_reason": "skipped_existing_constraints",
+                    },
+                ],
+            },
+        )
+
     def test_fit_clears_previous_parameter_workflow_result_when_disabled(self):
         import gpytorch
 


### PR DESCRIPTION
## Summary

Expose workflow-level diagnostics when parameter workflow execution is skipped.

## Problem

A fit may be executed with:

```
use_parameter_workflow=True
```

yet the parameter workflow may still be bypassed because constraints or
other initialization steps have already been applied earlier in the fit
path.

Previously these cases appeared indistinguishable from a workflow that
was never available, because:

* `parameter_workflow_result` remained unavailable
* workflow summaries reported no workflow activity
* workflow reports provided no explanation

This made it difficult to understand why schema-driven initialization
did not run.

## Changes

* Record an explicit workflow-level skip entry when parameter workflow
  execution is bypassed due to existing constraints or initialization
* Surface the skip reason through:

  * `parameter_workflow_result`
  * `get_parameter_workflow_summary()`
  * `get_parameter_workflow_report()`
* Add regression tests validating workflow-level skip reporting

## Scope

This PR improves workflow diagnostics only.

It does not change:

* parameter estimation
* parameter application
* model schemas
* initialization logic
* optimizer behaviour

## Testing

```
python3 -m unittest discover -s tests -p "test_lightcurve_parameter_context.py"
```
