### PR TITLE
Make spectral-mixture schemas ARD-dimension aware

### DIFF
--- a/pgmuvi/gps.py
+++ b/pgmuvi/gps.py
@@ -159,14 +159,30 @@ def scale_kernel_parameter_schema(prefix="covar_module"):
     )
 
 
-def spectral_mixture_parameter_schema(prefix="covar_module", num_mixtures=None):
+def spectral_mixture_parameter_schema(
+    prefix="covar_module",
+    num_mixtures=None,
+    ard_num_dims=1,
+):
     """Return model-independent parameter specifications for a spectral-mixture kernel."""
 
     def name(local_name):
         return f"{prefix}.{local_name}" if prefix else local_name
 
-    shape = None if num_mixtures is None else (num_mixtures,)
-    default_components = None if num_mixtures is None else [1.0] * num_mixtures
+    if num_mixtures is None:
+        shape = None
+        default_components = None
+
+    elif ard_num_dims > 1:
+        shape = (num_mixtures, 1, ard_num_dims)
+        default_components = [
+            [[1.0] * ard_num_dims]
+            for _ in range(num_mixtures)
+        ]
+
+    else:
+        shape = (num_mixtures,)
+        default_components = [1.0] * num_mixtures
 
     return ParameterSpecCollection(
         [
@@ -205,8 +221,8 @@ def spectral_mixture_parameter_schema(prefix="covar_module", num_mixtures=None):
                 role=ParameterRole.WEIGHT,
                 domain=ParameterDomain.VARIANCE,
                 scale=ParameterScale.LOG,
-                shape=shape,
-                initial_value=default_components,
+                shape=None if num_mixtures is None else (num_mixtures,),
+                initial_value=None if num_mixtures is None else [1.0] * num_mixtures,
                 constraint=(1.0e-12, 1.0e12),
                 guess_strategy=GuessStrategy.DEFAULT,
                 constraint_strategy=ConstraintStrategy.DEFAULT,
@@ -258,6 +274,7 @@ def _kernel_parameter_schema(
         return spectral_mixture_parameter_schema(
             prefix=prefix,
             num_mixtures=kernel.num_mixtures,
+            ard_num_dims=kernel.ard_num_dims,
         )
 
     if isinstance(kernel, GIK):
@@ -595,6 +612,7 @@ class SpectralMixtureGPModel(ExactGP):
         return spectral_mixture_parameter_schema(
             prefix="covar_module",
             num_mixtures=self.covar_module.num_mixtures,
+            ard_num_dims=self.covar_module.ard_num_dims,
         )
 
     def forward(self, x):
@@ -649,6 +667,7 @@ class SpectralMixtureLinearMeanGPModel(ExactGP):
         return spectral_mixture_parameter_schema(
             prefix="covar_module",
             num_mixtures=self.covar_module.num_mixtures,
+            ard_num_dims=self.covar_module.ard_num_dims,
         )
 
     def forward(self, x):
@@ -707,6 +726,7 @@ class TwoDSpectralMixtureGPModel(ExactGP):
         return spectral_mixture_parameter_schema(
             prefix="covar_module",
             num_mixtures=self.covar_module.num_mixtures,
+            ard_num_dims=self.covar_module.ard_num_dims,
         )
 
     def forward(self, x):
@@ -767,6 +787,7 @@ class TwoDSpectralMixtureLinearMeanGPModel(ExactGP):
         return spectral_mixture_parameter_schema(
             prefix="covar_module",
             num_mixtures=self.covar_module.num_mixtures,
+            ard_num_dims=self.covar_module.ard_num_dims,
         )
 
     def forward(self, x):
@@ -836,6 +857,7 @@ class SpectralMixtureKISSGPModel(ExactGP):
         return spectral_mixture_parameter_schema(
             prefix="covar_module.base_kernel",
             num_mixtures=self.covar_module.base_kernel.num_mixtures,
+            ard_num_dims=self.covar_module.base_kernel.ard_num_dims,
         )
 
     def forward(self, x):
@@ -908,6 +930,7 @@ class SpectralMixtureLinearMeanKISSGPModel(ExactGP):
         return spectral_mixture_parameter_schema(
             prefix="covar_module.base_kernel",
             num_mixtures=self.covar_module.base_kernel.num_mixtures,
+            ard_num_dims=self.covar_module.base_kernel.ard_num_dims,
         )
 
     def forward(self, x):
@@ -978,6 +1001,7 @@ class TwoDSpectralMixtureKISSGPModel(ExactGP):
         return spectral_mixture_parameter_schema(
             prefix="covar_module.base_kernel",
             num_mixtures=self.covar_module.base_kernel.num_mixtures,
+            ard_num_dims=self.covar_module.base_kernel.ard_num_dims,
         )
 
     def forward(self, x):
@@ -1050,6 +1074,7 @@ class TwoDSpectralMixtureLinearMeanKISSGPModel(ExactGP):
         return spectral_mixture_parameter_schema(
             prefix="covar_module.base_kernel",
             num_mixtures=self.covar_module.base_kernel.num_mixtures,
+            ard_num_dims=self.covar_module.base_kernel.ard_num_dims,
         )
 
     def forward(self, x):
@@ -1109,6 +1134,7 @@ class TwoDSpectralMixturePowerLawMeanGPModel(ExactGP):
             spectral_mixture_parameter_schema(
                 prefix="covar_module",
                 num_mixtures=self.covar_module.num_mixtures,
+                ard_num_dims=self.covar_module.ard_num_dims,
             ),
         )
 
@@ -1182,6 +1208,7 @@ class TwoDSpectralMixturePowerLawMeanKISSGPModel(ExactGP):
             spectral_mixture_parameter_schema(
                 prefix="covar_module.base_kernel",
                 num_mixtures=self.covar_module.base_kernel.num_mixtures,
+                ard_num_dims=self.covar_module.base_kernel.ard_num_dims,
             ),
         )
 
@@ -1245,6 +1272,7 @@ class TwoDSpectralMixtureDustMeanGPModel(ExactGP):
             spectral_mixture_parameter_schema(
                 prefix="covar_module",
                 num_mixtures=self.covar_module.num_mixtures,
+                ard_num_dims=self.covar_module.ard_num_dims,
             ),
         )
 
@@ -1319,6 +1347,7 @@ class TwoDSpectralMixtureDustMeanKISSGPModel(ExactGP):
             spectral_mixture_parameter_schema(
                 prefix="covar_module.base_kernel",
                 num_mixtures=self.covar_module.base_kernel.num_mixtures,
+                ard_num_dims=self.covar_module.base_kernel.ard_num_dims,
             ),
         )
 
@@ -1384,6 +1413,7 @@ class SparseSpectralMixtureGPModel(ApproximateGP):
         return spectral_mixture_parameter_schema(
             prefix="covar_module",
             num_mixtures=self.covar_module.num_mixtures,
+            ard_num_dims=self.covar_module.ard_num_dims,
         )
 
     def forward(self, x):

--- a/tests/test_parameter_workflow.py
+++ b/tests/test_parameter_workflow.py
@@ -403,7 +403,7 @@ class TestParameterWorkflow(unittest.TestCase):
 
         self.assertEqual(
             schema["covar_module.mixture_means"].shape,
-            (3,),
+            (3, 1, 2),
         )
 
     def test_two_d_spectral_mixture_linear_mean_gp_model_exposes_parameter_schema(self):
@@ -437,7 +437,7 @@ class TestParameterWorkflow(unittest.TestCase):
 
         self.assertEqual(
             schema["covar_module.mixture_means"].shape,
-            (3,),
+            (3, 1, 2),
         )
 
     def test_spectral_mixture_kiss_gp_model_exposes_parameter_schema(self):
@@ -531,7 +531,7 @@ class TestParameterWorkflow(unittest.TestCase):
 
         self.assertEqual(
             schema["covar_module.base_kernel.mixture_means"].shape,
-            (3,),
+            (3, 1, 2),
         )
 
     def test_two_d_spectral_mixture_linear_mean_kiss_gp_model_exposes_parameter_schema(self):
@@ -566,7 +566,7 @@ class TestParameterWorkflow(unittest.TestCase):
 
         self.assertEqual(
             schema["covar_module.base_kernel.mixture_means"].shape,
-            (3,),
+            (3, 1, 2),
         )
 
     def test_two_d_spectral_mixture_power_law_mean_gp_model_exposes_parameter_schema(self):
@@ -604,7 +604,7 @@ class TestParameterWorkflow(unittest.TestCase):
 
         self.assertEqual(
             schema["covar_module.mixture_means"].shape,
-            (3,),
+            (3, 1, 2),
         )
 
     def test_two_d_spectral_mixture_power_law_mean_kiss_gp_model_exposes_parameter_schema(self):
@@ -643,7 +643,7 @@ class TestParameterWorkflow(unittest.TestCase):
 
         self.assertEqual(
             schema["covar_module.base_kernel.mixture_means"].shape,
-            (3,),
+            (3, 1, 2),
         )
 
     def test_two_d_spectral_mixture_dust_mean_gp_model_exposes_parameter_schema(self):
@@ -682,7 +682,7 @@ class TestParameterWorkflow(unittest.TestCase):
 
         self.assertEqual(
             schema["covar_module.mixture_means"].shape,
-            (3,),
+            (3, 1, 2),
         )
 
     def test_two_d_spectral_mixture_dust_mean_kiss_gp_model_exposes_parameter_schema(self):
@@ -722,7 +722,7 @@ class TestParameterWorkflow(unittest.TestCase):
 
         self.assertEqual(
             schema["covar_module.base_kernel.mixture_means"].shape,
-            (3,),
+            (3, 1, 2),
         )
 
     def test_sparse_spectral_mixture_gp_model_exposes_parameter_schema(self):


### PR DESCRIPTION
## Summary

Update spectral-mixture parameter schemas to correctly represent the parameter shapes used by ARD spectral-mixture kernels.

## Problem

The parameter workflow schema for spectral-mixture models assumed that mixture means, scales, and weights always had shape:

```python
(num_mixtures,)
```

This is correct for 1D spectral-mixture kernels but incorrect for ARD kernels used by the 2D spectral-mixture models.

For ARD spectral-mixture kernels, GPyTorch stores:

```python
mixture_means.shape  == (num_mixtures, 1, ard_num_dims)
mixture_scales.shape == (num_mixtures, 1, ard_num_dims)
```

while:

```python
mixture_weights.shape == (num_mixtures,)
```

As a result, the schema metadata did not accurately describe the underlying model parameters.

## Changes

* Add `ard_num_dims` support to `spectral_mixture_parameter_schema()`
* Generate shape:

```python
(num_mixtures, 1, ard_num_dims)
```

for:

* `mixture_means`

* `mixture_scales`

* Preserve shape:

```python
(num_mixtures,)
```

for:

* `mixture_weights`

* Update default initialization payloads to match the declared schema shapes

* Propagate `ard_num_dims` from all spectral-mixture model schema definitions

## Testing

Updated workflow tests to reflect the corrected schema metadata.

Executed:

```bash
python3 -m unittest discover -s tests -p "test_parameter_workflow.py"
python3 -m unittest discover -s tests -p "test_parameter_application.py"
python3 -m unittest discover -s tests -p "test_model_parameter_schemas.py"
```

All tests pass.

## Impact

This PR does not change fitting behaviour directly.

Instead, it ensures that schema metadata accurately reflects the true parameter tensor shapes used by ARD spectral-mixture kernels.

This provides the foundation for subsequent work on shape-aware parameter estimate generation and application for 2D spectral-mixture models.
