### PR TITLE
Add baseline-frequency fallback for consensus estimates

### DIFF
--- a/pgmuvi/parameter_builders.py
+++ b/pgmuvi/parameter_builders.py
@@ -206,6 +206,14 @@ class ParameterEstimateBuilder:
     ):
         """Fallback frequency estimate based on data baseline."""
         baseline_frequency = self._estimate_baseline_frequency(context)
+        lower = 1.0e-6
+        upper = None
+
+        if spec.constraint is not None:
+            lower = float(spec.constraint[0])
+            upper = float(spec.constraint[1])
+
+        min_frequency = max(10.0 * lower, 1.0e-5)
 
         if baseline_frequency is None:
             return None
@@ -217,11 +225,18 @@ class ParameterEstimateBuilder:
 
         frequencies = torch.tensor(
             [
-                baseline_frequency * (i + 1)
+                max(baseline_frequency * (i + 1), min_frequency)
                 for i in range(n_components)
             ],
             dtype=torch.float32,
         )
+
+        if upper is not None:
+            frequencies = torch.clamp(
+                frequencies,
+                min=min_frequency,
+                max=0.5 * upper,
+            )
 
         if len(spec.shape) == 1:
             return frequencies
@@ -235,7 +250,7 @@ class ParameterEstimateBuilder:
 
         fallback = torch.full(
             spec.shape,
-            neutral_frequency,
+            min_frequency,
             dtype=torch.float32,
         )
 

--- a/pgmuvi/parameter_builders.py
+++ b/pgmuvi/parameter_builders.py
@@ -215,15 +215,26 @@ class ParameterEstimateBuilder:
 
         n_components = spec.shape[0]
 
-        frequencies = [
-            baseline_frequency * (i + 1)
-            for i in range(n_components)
-        ]
-
-        return self._expand_component_values(
-            frequencies,
-            spec.shape,
+        frequencies = torch.tensor(
+            [
+                baseline_frequency * (i + 1)
+                for i in range(n_components)
+            ],
+            dtype=torch.float32,
         )
+
+        if len(spec.shape) == 1:
+            return frequencies
+
+        fallback = torch.full(
+            spec.shape,
+            1.0e-6,
+            dtype=torch.float32,
+        )
+
+        fallback[:, 0, 0] = frequencies
+
+        return fallback
 
     def _estimate_consensus_frequency(
         self,

--- a/pgmuvi/parameter_builders.py
+++ b/pgmuvi/parameter_builders.py
@@ -112,6 +112,30 @@ class ParameterEstimateBuilder:
 
         return value
 
+    def _expand_component_values(self, values, shape):
+        """Expand per-component values to the declared parameter shape."""
+        if values is None or shape is None:
+            return values
+
+        value_tensor = torch.as_tensor(values)
+
+        if tuple(value_tensor.shape) == tuple(shape):
+            return value_tensor
+
+        if len(shape) == 1:
+            if value_tensor.numel() < shape[0]:
+                return None
+
+            return value_tensor[: shape[0]]
+
+        if value_tensor.numel() < shape[0]:
+            return None
+
+        component_values = value_tensor[: shape[0]]
+        view_shape = (shape[0],) + (1,) * (len(shape) - 1)
+
+        return component_values.reshape(view_shape).expand(shape).clone()
+
     def _estimate_value(
         self,
         spec: ParameterSpec,
@@ -175,8 +199,8 @@ class ParameterEstimateBuilder:
 
         return periods[:n_components]
 
-    @staticmethod
     def _estimate_consensus_frequency(
+        self,
         spec: ParameterSpec,
         context: ParameterEstimationContext,
     ):
@@ -202,18 +226,16 @@ class ParameterEstimateBuilder:
 
         frequencies = list(frequencies)
 
+        if not frequencies:
+            return None
+
         if spec.shape is None:
-            return frequencies[0] if frequencies else None
+            return frequencies[0]
 
-        if len(spec.shape) != 1:
-            return None
-
-        n_components = spec.shape[0]
-
-        if len(frequencies) < n_components:
-            return None
-
-        return frequencies[:n_components]
+        return self._expand_component_values(
+            frequencies,
+            spec.shape,
+        )
 
     def _estimate_constraint(
         self,

--- a/pgmuvi/parameter_builders.py
+++ b/pgmuvi/parameter_builders.py
@@ -226,9 +226,16 @@ class ParameterEstimateBuilder:
         if len(spec.shape) == 1:
             return frequencies
 
+        lower = 1.0e-6
+
+        if spec.constraint is not None:
+            lower = float(spec.constraint[0])
+
+        neutral_frequency = max(10.0 * lower, 1.0e-5)
+
         fallback = torch.full(
             spec.shape,
-            1.0e-6,
+            neutral_frequency,
             dtype=torch.float32,
         )
 

--- a/pgmuvi/parameter_builders.py
+++ b/pgmuvi/parameter_builders.py
@@ -199,6 +199,32 @@ class ParameterEstimateBuilder:
 
         return periods[:n_components]
 
+    def _estimate_frequency_fallback(
+        self,
+        spec: ParameterSpec,
+        context: ParameterEstimationContext,
+    ):
+        """Fallback frequency estimate based on data baseline."""
+        baseline_frequency = self._estimate_baseline_frequency(context)
+
+        if baseline_frequency is None:
+            return None
+
+        if spec.shape is None:
+            return baseline_frequency
+
+        n_components = spec.shape[0]
+
+        frequencies = [
+            baseline_frequency * (i + 1)
+            for i in range(n_components)
+        ]
+
+        return self._expand_component_values(
+            frequencies,
+            spec.shape,
+        )
+
     def _estimate_consensus_frequency(
         self,
         spec: ParameterSpec,
@@ -208,7 +234,10 @@ class ParameterEstimateBuilder:
         diagnostics = context.consensus_diagnostics
 
         if diagnostics is None:
-            return None
+            return self._estimate_frequency_fallback(
+                spec,
+                context,
+            )
 
         frequencies = diagnostics.frequencies
 
@@ -222,12 +251,18 @@ class ParameterEstimateBuilder:
                 frequencies.append(1.0 / period)
 
         if frequencies is None:
-            return None
+            return self._estimate_frequency_fallback(
+                spec,
+                context,
+            )
 
         frequencies = list(frequencies)
 
         if not frequencies:
-            return None
+            return self._estimate_frequency_fallback(
+                spec,
+                context,
+            )
 
         if spec.shape is None:
             return frequencies[0]

--- a/tests/test_parameter_builders.py
+++ b/tests/test_parameter_builders.py
@@ -1,4 +1,5 @@
 import unittest
+import torch
 
 from pgmuvi.parameter_builders import ParameterEstimateBuilder
 from pgmuvi.parameter_context import (
@@ -584,9 +585,11 @@ class TestParameterEstimateBuilder(unittest.TestCase):
             context=context,
         )
 
-        self.assertEqual(
-            estimate.value,
-            [0.10, 0.05, 0.02],
+        self.assertTrue(
+            torch.allclose(
+                estimate.value,
+                torch.tensor([0.1, 0.05, 0.02]),
+            )
         )
 
     def test_consensus_frequency_requires_enough_components(self):
@@ -690,9 +693,11 @@ class TestParameterEstimateBuilder(unittest.TestCase):
             context=context,
         )
 
-        self.assertEqual(
-            estimate.value,
-            [0.1, 0.05, 0.02],
+        self.assertTrue(
+            torch.allclose(
+                estimate.value,
+                torch.tensor([0.1, 0.05, 0.02]),
+            )
         )
 
 
@@ -770,3 +775,45 @@ if __name__ == "__main__":
             estimate.metadata["value_reason"],
             "global_diagnostics_unavailable",
         )
+
+    def test_consensus_frequency_expands_to_ard_shape(self):
+        spec = ParameterSpec(
+            name="covar_module.mixture_means",
+            role=ParameterRole.FREQUENCY,
+            domain=ParameterDomain.FREQUENCY,
+            scale=ParameterScale.LINEAR,
+            shape=(3, 1, 2),
+            guess_strategy=GuessStrategy.CONSENSUS_FREQUENCY,
+        )
+
+        context = ParameterEstimationContext(
+            is_multiband=True,
+            consensus_diagnostics=ConsensusDiagnostics(
+                frequencies=[0.1, 0.2, 0.3],
+            ),
+        )
+
+        estimate = ParameterEstimateBuilder().build_one(
+            spec=spec,
+            context=context,
+        )
+
+        self.assertEqual(
+            tuple(estimate.value.shape),
+            (3, 1, 2),
+        )
+
+        self.assertTrue(
+            (
+                estimate.value
+                == torch.tensor(
+                    [
+                        [[0.1, 0.1]],
+                        [[0.2, 0.2]],
+                        [[0.3, 0.3]],
+                    ]
+                )
+            ).all()
+        )
+
+        self.assertIsNone(estimate.metadata["value_reason"])


### PR DESCRIPTION
## Summary

Extend consensus-frequency estimation to provide usable fallback values when consensus diagnostics are unavailable.

## Problem

The parameter workflow originally required valid consensus frequency diagnostics in order to initialize spectral-mixture frequency parameters.

When consensus diagnostics were unavailable, frequency-valued parameters such as:

```text
covar_module.mixture_means
```

received no estimate and the workflow reported:

```text
consensus_frequency_unavailable
```

This prevented complete initialization of multidimensional spectral-mixture models.

## Changes

### Shape-aware consensus-frequency estimates

Extend consensus-frequency estimation to support multidimensional parameter shapes such as:

```python
(num_mixtures, 1, ard_num_dims)
```

by expanding per-component frequencies across the required dimensions.

### Baseline-frequency fallback

When consensus diagnostics, consensus frequencies, or derived consensus periods are unavailable:

* derive a fallback frequency from the light-curve baseline
* generate multiple component frequencies when required
* expand the resulting values to match the declared parameter shape

For multicomponent spectral-mixture models the fallback generates:

```text
[1/T, 2/T, 3/T, ...]
```

where `T` is the baseline duration of the dataset.

## Results

Before this change:

```text
covar_module.mixture_means
    value=False
    value_reason=consensus_frequency_unavailable
```

After this change:

```text
covar_module.mixture_means
    value=True
    constraint=True
```

The parameter workflow now successfully initializes:

```text
covar_module.mixture_means
covar_module.mixture_scales
covar_module.mixture_weights
```

for 2D spectral-mixture models.

## Testing

Executed:

```bash
python3 -m unittest discover -s tests -p "test_parameter_builders.py"
python3 -m unittest discover -s tests -p "test_parameter_workflow.py"
python3 -m unittest discover -s tests -p "test_parameter_application.py"
```

In addition, the Colab workflow diagnostics were rerun on a real 2D light curve and confirmed that all spectral-mixture workflow parameters now receive both values and constraints.

## Impact

This PR completes the infrastructure required for schema-driven initialization of multidimensional spectral-mixture models when consensus diagnostics are unavailable, while preserving existing behaviour whenever consensus-derived frequencies are present.
