### PR TITLE
Isolate Torch default dtype in GP-prior tests

### DIFF
--- a/tests/test_docs_gp_prior_sampling.py
+++ b/tests/test_docs_gp_prior_sampling.py
@@ -123,6 +123,9 @@ class TestGPriorSamplingDocumentation(unittest.TestCase):
         "gpytorch is required for the GP-prior notebook smoke test",
     )
     def test_all_code_cells_execute_without_fitting_or_files(self):
+        # Executed notebook cells set Torch's process-wide default dtype.
+        # Restore the incoming value after this test so later tests are isolated.
+        self.addCleanup(torch.set_default_dtype, torch.get_default_dtype())
         from pgmuvi.lightcurve import Lightcurve
 
         namespace = {"__name__": "__main__"}

--- a/tests/test_gp_prior_sampling_example_script.py
+++ b/tests/test_gp_prior_sampling_example_script.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import tempfile
 import unittest
 from unittest.mock import patch
+import torch
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -28,6 +29,11 @@ def load_module():
 
 
 class TestGPriorSamplingExample(unittest.TestCase):
+    def setUp(self):
+        # Tests in this class execute code that may change Torch's global dtype.
+        # Restore the incoming value after every test method.
+        self.addCleanup(torch.set_default_dtype, torch.get_default_dtype())
+
     def test_script_compiles_and_uses_current_parameter_layer(self):
         text = load_script_text()
         compile(text, str(SCRIPT), "exec")


### PR DESCRIPTION
## Summary

- restore the incoming process-wide Torch default dtype after executing the GP-prior documentation notebook
- isolate every test in `TestGPriorSamplingExample` from global dtype changes
- preserve the intentional float64 behavior of the documented GP-prior workflows
- remove unittest discovery-order dependence from downstream model and transform tests

## Problem

The GP-prior notebook and example workflows intentionally configure PGMUVI to use `torch.float64`. Their execution tests allowed that process-wide setting to persist after the test completed.

Consequently, the complete unittest discovery suite became order-dependent. Later tests received float64 model state while constructing explicit float32 tensors, causing 13 downstream failures and errors even though those tests passed independently.

## Resolution

The affected tests now register cleanup that restores the Torch default dtype inherited at test entry.

The example-script test class uses class-wide setup so every method is isolated, including future methods that execute the same workflow.

No production behavior or documented workflow behavior is changed.

## Validation

- repository-wide per-file dtype-leak scan reports no transition
- GP-prior documentation tests pass
- GP-prior example-script tests pass
- complete unittest suite passes:
  - 2,124 tests
  - OK
