### PR TITLE
Repair wavelength advisory API and documentation contracts

### DIFF
--- a/docs/source/howto/legacy_wavelength_candidates.rst
+++ b/docs/source/howto/legacy_wavelength_candidates.rst
@@ -109,9 +109,11 @@ As a rule of thumb:
 * Decrease if the optimisation struggles to converge (fewer parameters = simpler
   optimisation landscape).
 
-The Bayesian Information Criterion (BIC) or Leave-One-Out cross-validation can be
-used for formal model comparison, but visual inspection of the PSD and residuals is
-often sufficient.
+The legacy workflow does not calculate the Bayesian Information Criterion (BIC)
+or Leave-One-Out cross-validation.  Either method would require a separate
+implementation or external analysis; the legacy training-point diagnostics and
+visual inspection of the PSD and residuals are not substitutes for held-out or
+penalized model comparison.
 
 Legacy Automatic Recommendation
 -------------------------------

--- a/docs/source/howto/wavelength_advisory.rst
+++ b/docs/source/howto/wavelength_advisory.rst
@@ -29,8 +29,8 @@ default.
 Current workflow map
 --------------------
 
-The current advisory workflow has four distinct outputs that should be read
-together:
+The current advisory pipeline has four distinct evidence layers that should be
+read together:
 
 .. list-table:: Advisory output layers
    :header-rows: 1
@@ -50,8 +50,12 @@ together:
      - A compact summary of why model/kernel fits failed when no advisory
        ranking can be trusted.
 
-The high-level helper returns all of these pieces in one dictionary.  Batch
-runs export the same information per source and per model/kernel config.
+The current high-level helper returns the model/kernel-config report, run
+report, training-quality report, and fallback report in one dictionary.  It
+does **not** preserve the complete period-independent diagnostic report or the
+parameter-plan report as first-class nested sections.  Run those lower-level
+helpers separately when their full provenance is required.  Batch runs export
+the retained high-level information per source and per model/kernel config.
 
 Purpose
 -------

--- a/docs/source/howto/wavelength_advisory_batch.rst
+++ b/docs/source/howto/wavelength_advisory_batch.rst
@@ -360,7 +360,10 @@ Important columns include:
    * - ``source_id``
      - Source identifier.
    * - ``model_kernel_config_id``
-     - Stable row identifier such as ``rank1_2DWavelengthDependent``.
+     - Current rank-dependent evaluation label such as
+       ``rank1_2DWavelengthDependent``.  It is useful within one report, but it
+       is not a stable configuration identity across candidate filtering,
+       reordering, or truncation.
    * - ``model_kernel_config_rank``
      - Original advisory/evaluation order.
    * - ``quality_rank``

--- a/docs/source/notebooks/tutorial_wavelength_advisory.ipynb
+++ b/docs/source/notebooks/tutorial_wavelength_advisory.ipynb
@@ -374,7 +374,7 @@
     "    print(f\"advisory only: {workflow['advisory_only']}\")\n",
     "    print(\n",
     "        \"fallback diagnostics available: \"\n",
-    "        f\"{workflow['fallback_report']['fallback_diagnostics_available']}\"\n",
+    "        f\"{workflow['fallback_report']['available']}\"\n",
     "    )\n"
    ]
   },

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -9320,6 +9320,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         sources,
         *,
         from_csv_kwargs=None,
+        positive_data_filter_kwargs=None,
         workflow_kwargs=None,
         output_dir=None,
         export=True,
@@ -9339,6 +9340,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         return run_period_independent_wavelength_advisory_workflow_batch(
             sources,
             from_csv_kwargs=from_csv_kwargs,
+            positive_data_filter_kwargs=positive_data_filter_kwargs,
             workflow_kwargs=workflow_kwargs,
             output_dir=output_dir,
             export=export,

--- a/pgmuvi/wavelength_diagnostics.py
+++ b/pgmuvi/wavelength_diagnostics.py
@@ -963,7 +963,7 @@ def _comparison_result_entry(
         "priority": candidate.get("priority"),
         "reason": candidate.get("reason"),
         "status": status,
-        "fit_success": bool(status == "passed"),
+        "fit_success": bool(status == "success"),
         "fit_failed": bool(status == "failed"),
         "success": bool(status == "success"),
         "failed": bool(status == "failed"),
@@ -5536,11 +5536,6 @@ def _piwd_batch_write_summary_csv(path, rows):
         for row in rows:
             writer.writerow({field: row.get(field) for field in fields})
 
-
-
-def _piwd_batch_nonempty(value):
-    """Return True for values that can safely identify a model/kernel config."""
-    return value is not None and value != ""
 
 
 def _piwd_batch_nonempty(value):

--- a/tests/test_docs_legacy_wavelength_candidates.py
+++ b/tests/test_docs_legacy_wavelength_candidates.py
@@ -28,6 +28,17 @@ class TestLegacyWavelengthCandidateDocumentation(unittest.TestCase):
         self.assertIn("wavelength_advisory", text)
         self.assertIn("selected_model=None", text)
 
+    def test_legacy_page_does_not_claim_bic_or_loo_are_implemented(self):
+        text = self.read("docs/source/howto/legacy_wavelength_candidates.rst")
+        self.assertIn("does not calculate", text)
+        self.assertIn("Bayesian Information Criterion (BIC)", text)
+        self.assertIn("Leave-One-Out cross-validation", text)
+        self.assertIn("implementation or external analysis", text)
+        self.assertNotIn(
+            "can be used for formal model comparison",
+            text,
+        )
+
     def test_howto_index_links_current_and_legacy_pages(self):
         text = self.read("docs/source/howto/index.rst")
         for page in [

--- a/tests/test_docs_wavelength_advisory.py
+++ b/tests/test_docs_wavelength_advisory.py
@@ -50,6 +50,27 @@ class TestWavelengthAdvisoryDocs(unittest.TestCase):
             with self.subTest(token=token):
                 self.assertIn(token, text)
 
+    def test_single_source_doc_describes_retained_high_level_reports_truthfully(self):
+        text = self._read("docs/source/howto/wavelength_advisory.rst")
+        self.assertIn(
+            "does **not** preserve the complete period-independent diagnostic report",
+            text,
+        )
+        self.assertIn("parameter-plan report", text)
+        self.assertNotIn(
+            "The high-level helper returns all of these pieces in one dictionary",
+            text,
+        )
+
+    def test_batch_doc_does_not_call_rank_labels_stable_configuration_ids(self):
+        text = self._read("docs/source/howto/wavelength_advisory_batch.rst")
+        self.assertIn("rank-dependent evaluation label", text)
+        self.assertIn("not a stable configuration identity", text)
+        self.assertNotIn(
+            "Stable row identifier such as ``rank1_2DWavelengthDependent``",
+            text,
+        )
+
     def test_howto_index_links_current_advisory_pages(self):
         text = self._read("docs/source/howto/index.rst")
         self.assertIn("wavelength_advisory", text)

--- a/tests/test_docs_wavelength_advisory_notebook.py
+++ b/tests/test_docs_wavelength_advisory_notebook.py
@@ -83,6 +83,11 @@ class TestWavelengthAdvisoryNotebook(unittest.TestCase):
             with self.subTest(token=token):
                 self.assertIn(token, text)
         self.assertNotIn("2DAchromatic", text)
+        self.assertIn("workflow['fallback_report']['available']", text)
+        self.assertNotIn(
+            "workflow['fallback_report']['fallback_diagnostics_available']",
+            text,
+        )
 
     def test_notebook_rejects_automatic_selection_framing(self):
         text = notebook_text()

--- a/tests/test_period_independent_wavelength_advisory_workflow_batch.py
+++ b/tests/test_period_independent_wavelength_advisory_workflow_batch.py
@@ -2,6 +2,7 @@ import json
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from pgmuvi.lightcurve import Lightcurve
 from pgmuvi.wavelength_diagnostics import (
@@ -389,12 +390,42 @@ class TestPeriodIndependentWavelengthAdvisoryWorkflowBatch(unittest.TestCase):
                 require_positive_flux_error=True,
             )
 
-    def test_lightcurve_static_method_delegates(self):
-        report = Lightcurve.run_period_independent_wavelength_advisory_workflow_batch(
-            [{"source_id": "src", "lightcurve": _FakeLightcurve()}],
-            export=False,
-        )
-        self.assertEqual(report["n_succeeded"], 1)
+    def test_lightcurve_static_method_delegates_batch_filter_kwargs(self):
+        sources = [{"source_id": "src", "lightcurve": _FakeLightcurve()}]
+        expected = {"kind": "period_independent_wavelength_advisory_workflow_batch"}
+        positive_filter = {
+            "require_positive_flux": True,
+            "require_positive_flux_error": True,
+        }
+
+        with mock.patch(
+            "pgmuvi.wavelength_diagnostics."
+            "run_period_independent_wavelength_advisory_workflow_batch",
+            return_value=expected,
+        ) as mocked:
+            report = Lightcurve.run_period_independent_wavelength_advisory_workflow_batch(
+                sources,
+                from_csv_kwargs={"check_sampling": True},
+                positive_data_filter_kwargs=positive_filter,
+                workflow_kwargs={"make_plots": False},
+                export=False,
+            )
+
+        self.assertIs(report, expected)
+        mocked.assert_called_once()
+        args, kwargs = mocked.call_args
+        self.assertEqual(args[0], sources)
+        self.assertEqual(kwargs["from_csv_kwargs"], {"check_sampling": True})
+        self.assertEqual(kwargs["positive_data_filter_kwargs"], positive_filter)
+        self.assertEqual(kwargs["workflow_kwargs"], {"make_plots": False})
+        self.assertFalse(kwargs["export"])
+
+    def test_batch_nonempty_helper_is_defined_once(self):
+        import inspect
+        import pgmuvi.wavelength_diagnostics as wavelength_diagnostics
+
+        source = inspect.getsource(wavelength_diagnostics)
+        self.assertEqual(source.count("def _piwd_batch_nonempty("), 1)
 
     def test_rejects_empty_sources(self):
         with self.assertRaisesRegex(ValueError, "non-empty"):

--- a/tests/test_wavelength_diagnostics.py
+++ b/tests/test_wavelength_diagnostics.py
@@ -471,6 +471,8 @@ class TestDiagnoseWavelengthDependencePrefit(unittest.TestCase):
 
         success = report["results"][0]
         self.assertTrue(success["success"])
+        self.assertTrue(success["fit_success"])
+        self.assertFalse(success["fit_failed"])
         self.assertEqual(success["resolved_model_class"], "_FakeFittedModel")
         self.assertTrue(success["likelihood_noise_summary"]["available"])
 


### PR DESCRIPTION
## Summary

- forward `positive_data_filter_kwargs` through the `Lightcurve` batch wrapper
- align the legacy `fit_success` alias with successful fit status
- remove the duplicate `_piwd_batch_nonempty()` helper
- correct the wavelength-advisory notebook fallback field
- correct documentation describing retained reports, rank-based configuration labels, and unavailable legacy comparison methods
- add focused regression tests for the corrected contracts

## Validation

- targeted wavelength-advisory and documentation tests passed
- Ruff CI-equivalent check passed
- strict Sphinx documentation build passed
- full suite passed:

  `Ran 2128 tests`
  
  `OK`
