### PR TITLE
Correct transformed uncertainties and training variance

### DIFF
--- a/docs/source/concepts.rst
+++ b/docs/source/concepts.rst
@@ -95,6 +95,14 @@ axis (``ytransform``). All predictions are automatically inverse-transformed bac
 the original units when plotting or reporting results. Pass ``center_time=False`` to
 turn off the default time-centering behaviour.
 
+When a ``ytransform`` is active, dependent-variable uncertainties are transformed as
+scales rather than as absolute values.  MinMax uncertainties are divided by the fitted
+range, z-score uncertainties by the fitted standard deviation, and robust-z-score
+uncertainties by the fitted MAD.  Location shifts such as the fitted minimum, mean,
+median, or explicit offset are never subtracted from ``yerr``.
+If ``set_likelihood(variance=True)`` is used because the stored values are already
+variances, PGMUVI applies the square of the fitted transform scale.
+
 1D vs 2D Models
 ----------------
 

--- a/docs/source/howto/consensus_fitting.rst
+++ b/docs/source/howto/consensus_fitting.rst
@@ -245,7 +245,9 @@ for all scatter:
 This adds one learned homoscedastic variance term on top of the supplied
 per-observation variances.  It does not replace the reported errors.  Do not set
 ``variance=True`` unless the stored uncertainty column already contains
-variances rather than standard deviations.
+variances rather than standard deviations.  With a ``ytransform``, standard
+deviations use the fitted scale once and variances use its square; location
+shifts are never applied to either quantity.
 
 Initialization, constraints, and numerical stability
 -----------------------------------------------------

--- a/docs/source/howto/interpreting_results.rst
+++ b/docs/source/howto/interpreting_results.rst
@@ -197,6 +197,12 @@ follow-up inspection.  It is not cross-validation, not held-out predictive
 performance, not AIC or BIC, and not marginal likelihood or model evidence.
 Small score differences do not establish a scientifically preferred model.
 
+Standardized residual metrics use the observed predictive standard deviation from
+``likelihood(model(x_train))``.  That predictive variance already includes the
+likelihood noise, so the reported measurement uncertainty is not added again.
+``standardization_sigma_source`` records whether observed predictive variance was
+available or whether transformed ``yerr`` had to be used as a fallback.
+
 A very low score should trigger inspection of the underlying metrics and fit
 state.  ``fit_quality_available=False`` means the candidate is unscored; it is
 not assigned a very poor sentinel score and cannot become top ranked.  A high

--- a/docs/source/howto/wavelength_advisory.rst
+++ b/docs/source/howto/wavelength_advisory.rst
@@ -363,6 +363,11 @@ Use training-residual diagnostics to rank completed fits:
 This is a diagnostic ranking, not a final evidence calculation.  Current metrics
 include training residual summaries such as normalized RMSE, median absolute
 standardized residual, reduced chi-square-like summaries, and outlier fraction.
+The standardized residuals use the observed predictive variance returned by
+``likelihood(model(x_train))``.  Because that variance already contains the
+likelihood noise, the stored measurement uncertainties are not added to it a second
+time.  Transformed ``yerr`` is used only as a fallback when predictive variance is
+unavailable.
 
 .. warning::
 

--- a/docs/source/howto/wavelength_advisory_batch.rst
+++ b/docs/source/howto/wavelength_advisory_batch.rst
@@ -405,6 +405,10 @@ Important columns include:
      - Fraction of large standardized residuals.
    * - ``training_reduced_chi2``
      - Reduced-chi-square-like training residual diagnostic.
+   * - ``training_standardization_sigma_source``
+     - Whether standardized residuals used observed predictive variance or the
+       transformed-uncertainty fallback. Observed predictive variance already
+       includes likelihood noise and is not combined with ``yerr`` again.
    * - ``exception_type`` / ``exception_message``
      - Per-config failure diagnostics.
    * - ``failure_stage`` / ``failure_stage_reason``

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -740,6 +740,24 @@ class Transformer(torch.nn.Module):
         """
         raise NotImplementedError
 
+    def transform_uncertainty(self, data, **kwargs):
+        """Transform uncertainty scales without applying a location shift.
+
+        Uncertainties describe differences in the transformed quantity, not
+        absolute locations.  Built-in affine transformers therefore reuse the
+        fitted scale while suppressing any mean, median, minimum, or offset
+        subtraction.  The transformer must already have been fitted on the
+        corresponding values before this method is called.
+        """
+        return self.transform(data, shift=False, **kwargs)
+
+    def transform_variance(self, data, **kwargs):
+        """Transform variance values using the square of the fitted scale."""
+        if torch.any(data < 0):
+            raise ValueError("Variance values must be non-negative.")
+        transformed_sigma = self.transform_uncertainty(torch.sqrt(data), **kwargs)
+        return transformed_sigma**2
+
     def inverse(self, data, shift=True, **kwargs):
         """Invert a transform based on saved parameters
 
@@ -796,6 +814,17 @@ class MinMax(Transformer):
         """
         return (data * self.range) + (shift * self.min)
 
+    def transform_uncertainty(self, data, apply_to=None, **kwargs):
+        """Divide uncertainty scales by the fitted data range."""
+        del kwargs
+        if not hasattr(self, "range"):
+            raise RuntimeError(
+                "MinMax uncertainty transformation requires a fitted range."
+            )
+        if apply_to is not None:
+            return data / self.range[apply_to]
+        return data / self.range
+
 
 class ZScore(Transformer):
     def transform(self, data, dim=0, apply_to=None, recalc=False, shift=True, **kwargs):
@@ -841,6 +870,18 @@ class ZScore(Transformer):
             The data to be reverse-transformed
         """
         return (data * self.sd) + (self.mean * shift)
+
+    def transform_uncertainty(self, data, apply_to=None, **kwargs):
+        """Divide uncertainty scales by the fitted standard deviation."""
+        del kwargs
+        if not hasattr(self, "sd"):
+            raise RuntimeError(
+                "ZScore uncertainty transformation requires a fitted standard "
+                "deviation."
+            )
+        if apply_to is not None:
+            return data / self.sd[apply_to]
+        return data / self.sd
 
 
 class Shift(Transformer):
@@ -967,6 +1008,11 @@ class Shift(Transformer):
             raise RuntimeError("Shift.inverse() called before the offset was fitted.")
         return data + self._offset_for_data(data)
 
+    def transform_uncertainty(self, data, **kwargs):
+        """Return uncertainty scales unchanged by a pure coordinate shift."""
+        del kwargs
+        return data
+
 
 class TimeCenter(Shift):
     """Center the time coordinate while preserving all other coordinates.
@@ -1024,6 +1070,17 @@ class RobustZScore(Transformer):
             The data to be reverse-transformed
         """
         return (data * self.mad) + (self.median * shift)
+
+    def transform_uncertainty(self, data, apply_to=None, **kwargs):
+        """Divide uncertainty scales by the fitted MAD."""
+        del kwargs
+        if not hasattr(self, "mad"):
+            raise RuntimeError(
+                "RobustZScore uncertainty transformation requires a fitted MAD."
+            )
+        if apply_to is not None:
+            return data / self.mad[apply_to]
+        return data / self.mad
 
 
 def minmax(data, dim=0):
@@ -3505,11 +3562,15 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             raise ValueError(errmsg)
         # then, store the raw data internally
         self.register_buffer("_yerr_raw", values)
-        # now apply the same transformation that was applied to the ydata
+        # Apply only the fitted scale from the y-data transformation. Errors
+        # represent differences, so location shifts must not be applied.
         if self.ytransform is None:
             self.register_buffer("_yerr_transformed", values)
         elif isinstance(self.ytransform, Transformer):
-            self.register_buffer("_yerr_transformed", self.ytransform.transform(values))
+            self.register_buffer(
+                "_yerr_transformed",
+                self.ytransform.transform_uncertainty(values),
+            )
 
     def _ensure_tensor(self, values):
         # Ensures that the input data has type torch.Tensor
@@ -6290,6 +6351,28 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             return self.ytransform.transform(values)
         raise TypeError("ytransform must be None or a Transformer instance.")
 
+    def transform_y_uncertainty(self, values):
+        """Transform dependent-variable uncertainty scales.
+
+        Unlike :meth:`transform_y`, this method never applies the location
+        shift fitted by the y-axis transformer.  For example, z-score errors
+        are divided by the fitted standard deviation, while MinMax errors are
+        divided by the fitted range.
+        """
+        if self.ytransform is None:
+            return values
+        elif isinstance(self.ytransform, Transformer):
+            return self.ytransform.transform_uncertainty(values)
+        raise TypeError("ytransform must be None or a Transformer instance.")
+
+    def transform_y_variance(self, values):
+        """Transform dependent-variable variances with the squared scale."""
+        if self.ytransform is None:
+            return values
+        elif isinstance(self.ytransform, Transformer):
+            return self.ytransform.transform_variance(values)
+        raise TypeError("ytransform must be None or a Transformer instance.")
+
     def _floating_data_dtype(self):
         """Return the floating dtype used by the stored training data."""
         for name in (
@@ -6370,7 +6453,10 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             to produce noise *variances* before being passed to the likelihood.
 
             If ``True``, the stored uncertainties are assumed to already be
-            variances and are passed through unchanged as the noise tensor.
+            variances.  When a ``ytransform`` is active, they are rescaled by
+            the square of the fitted y-axis scale before being passed to the
+            likelihood; without a y-transform they are passed through
+            unchanged.
         learn_additional_noise : bool, optional
             If ``True`` and per-point uncertainties are available, use
             :class:`gpytorch.likelihoods.FixedNoiseGaussianLikelihood` with
@@ -6396,12 +6482,13 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         learn_additional_noise = bool(learn_additional_noise)
 
         # Prepare the noise tensor: gpytorch likelihoods expect variances.
-        # By default (variance=False) we square the stored errors; if the
-        # caller has already supplied variances, we use them as-is.
+        # By default (variance=False) we square the transformed standard
+        # deviations. If the caller supplied variances, transform the raw
+        # values with the square of the fitted y-axis scale.
         _has_noise = hasattr(self, "_yerr_transformed")
         if _has_noise:
             noise = (
-                self._yerr_transformed
+                self.transform_y_variance(self._yerr_raw)
                 if variance
                 else self._yerr_transformed ** 2
             )

--- a/pgmuvi/wavelength_diagnostics.py
+++ b/pgmuvi/wavelength_diagnostics.py
@@ -3567,7 +3567,9 @@ def _piwd_compute_training_fit_quality(fitted_lightcurve: Any) -> dict[str, Any]
     the training coordinates in the transformed space used by the GP.  They are
     not cross-validation, AIC, BIC, or posterior predictive checks, but they are
     real fit-quality quantities and can distinguish model/kernel config fits that all pass
-    the consensus/viability checks.
+    the consensus/viability checks. Standardized residuals use the observed
+    likelihood-wrapped predictive variance once; stored measurement errors are
+    only a fallback when that variance is unavailable.
     """
     if fitted_lightcurve is None:
         return _piwd_training_fit_quality_unavailable("no fitted Lightcurve was provided")
@@ -3622,7 +3624,9 @@ def _piwd_compute_training_fit_quality(fitted_lightcurve: Any) -> dict[str, Any]
     resid_std = float(np.std(residual)) if n > 1 else 0.0
     nrmse = float(rmse / robust_scale) if robust_scale > 0 else None
 
-    yerr = _piwd_numpy_1d_or_none(getattr(fitted_lightcurve, "_yerr_transformed", None))
+    yerr = _piwd_numpy_1d_or_none(
+        getattr(fitted_lightcurve, "_yerr_transformed", None)
+    )
     if yerr is not None and yerr.size == finite.size:
         yerr = yerr[finite]
     else:
@@ -3635,15 +3639,29 @@ def _piwd_compute_training_fit_quality(fitted_lightcurve: Any) -> dict[str, Any]
         pred_std = np.sqrt(pred_var)
 
     sigma = None
+    sigma_source = None
+    predictive_variance_kind = None
     if yerr is not None:
         yerr = np.where(np.isfinite(yerr) & (yerr > 0), yerr, np.nan)
+    if pred_std is not None and np.any(np.isfinite(pred_std) & (pred_std > 0)):
+        sigma = pred_std.copy()
+        sigma_source = "observed_predictive_standard_deviation"
+        predictive_variance_kind = "observed"
+        if yerr is not None:
+            fill = (
+                (~np.isfinite(sigma) | (sigma <= 0))
+                & np.isfinite(yerr)
+                & (yerr > 0)
+            )
+            if np.any(fill):
+                sigma[fill] = yerr[fill]
+                sigma_source = (
+                    "observed_predictive_standard_deviation_with_"
+                    "transformed_yerr_fallback"
+                )
+    elif yerr is not None and np.any(np.isfinite(yerr) & (yerr > 0)):
         sigma = yerr.copy()
-    if pred_std is not None:
-        if sigma is None:
-            sigma = pred_std
-        else:
-            sigma = np.sqrt(np.nan_to_num(sigma, nan=0.0) ** 2 + np.nan_to_num(pred_std, nan=0.0) ** 2)
-            sigma = np.where(sigma > 0, sigma, np.nan)
+        sigma_source = "transformed_measurement_uncertainty_fallback"
 
     normalized_rmse = None
     median_abs_standardized_residual = None
@@ -3718,6 +3736,9 @@ def _piwd_compute_training_fit_quality(fitted_lightcurve: Any) -> dict[str, Any]
             "residual_std": resid_std,
             "target_robust_scale": robust_scale,
             "normalized_rmse_by_target_scale": nrmse,
+            "predictive_variance_kind": predictive_variance_kind,
+            "standardization_sigma_source": sigma_source,
+            "measurement_uncertainty_added_separately": False,
             "normalized_rmse": normalized_rmse,
             "median_abs_standardized_residual": median_abs_standardized_residual,
             "outlier_fraction_3sigma": outlier_fraction_3sigma,
@@ -4066,6 +4087,15 @@ def _piwd_extract_fit_outcome(
         "training_median_abs_standardized_residual": fit_quality.get("median_abs_standardized_residual"),
         "training_outlier_fraction_3sigma": fit_quality.get("outlier_fraction_3sigma"),
         "training_log_marginal_likelihood": fit_quality.get("log_marginal_likelihood"),
+        "training_predictive_variance_kind": fit_quality.get(
+            "predictive_variance_kind"
+        ),
+        "training_standardization_sigma_source": fit_quality.get(
+            "standardization_sigma_source"
+        ),
+        "training_measurement_uncertainty_added_separately": fit_quality.get(
+            "measurement_uncertainty_added_separately"
+        ),
         "sm_ard_scale_diagnostics": sm_ard_diagnostics,
         "constrained_sm_ard_components": sm_ard_diagnostics.get(
             "constrained_sm_ard_components"
@@ -4508,6 +4538,15 @@ def _piwd_score_one_wavelength_fit_quality(scored_or_outcome: dict[str, Any]) ->
             "training_outlier_fraction_3sigma": fit_quality.get("outlier_fraction_3sigma"),
             "training_reduced_chi2": fit_quality.get("reduced_chi2"),
             "training_log_marginal_likelihood": fit_quality.get("log_marginal_likelihood"),
+            "training_predictive_variance_kind": fit_quality.get(
+                "predictive_variance_kind"
+            ),
+            "training_standardization_sigma_source": fit_quality.get(
+                "standardization_sigma_source"
+            ),
+            "training_measurement_uncertainty_added_separately": fit_quality.get(
+                "measurement_uncertainty_added_separately"
+            ),
             "score_components": [reason],
             "source_outcome": outcome,
         }
@@ -5919,6 +5958,15 @@ def _piwd_batch_extract_model_kernel_config_rows(*, source_row, workflow):
             "training_log_marginal_likelihood": item.get(
                 "training_log_marginal_likelihood"
             ),
+            "training_predictive_variance_kind": item.get(
+                "training_predictive_variance_kind"
+            ),
+            "training_standardization_sigma_source": item.get(
+                "training_standardization_sigma_source"
+            ),
+            "training_measurement_uncertainty_added_separately": item.get(
+                "training_measurement_uncertainty_added_separately"
+            ),
             "n_constrained_sm_ard_components": item.get(
                 "n_constrained_sm_ard_components"
             ),
@@ -5983,6 +6031,9 @@ def _piwd_batch_model_kernel_config_csv_fields():
         "training_outlier_fraction_3sigma",
         "training_reduced_chi2",
         "training_log_marginal_likelihood",
+        "training_predictive_variance_kind",
+        "training_standardization_sigma_source",
+        "training_measurement_uncertainty_added_separately",
         "n_constrained_sm_ard_components",
         "n_constrained_sm_time_components",
         "n_constrained_sm_wavelength_components",

--- a/tests/test_docs_result_interpretation.py
+++ b/tests/test_docs_result_interpretation.py
@@ -66,6 +66,9 @@ class TestResultInterpretationDocs(unittest.TestCase):
             "only_valid_model",
             "``top_ranked_model`` remains ``None``",
             "selected_model=None",
+            "standardization_sigma_source",
+            "already includes the likelihood noise",
+            "not added again",
         ]
         for token in required:
             with self.subTest(token=token):

--- a/tests/test_docs_wavelength_advisory.py
+++ b/tests/test_docs_wavelength_advisory.py
@@ -77,6 +77,28 @@ class TestWavelengthAdvisoryDocs(unittest.TestCase):
             with self.subTest(document="batch", token=token):
                 self.assertIn(token, batch)
 
+    def test_docs_explain_training_residual_noise_semantics(self):
+        single = self._read("docs/source/howto/wavelength_advisory.rst")
+        batch = self._read("docs/source/howto/wavelength_advisory_batch.rst")
+        single = " ".join(single.split())
+        batch = " ".join(batch.split())
+
+        for token in [
+            "likelihood(model(x_train))",
+            "not added to it a second time",
+            "predictive variance is unavailable",
+        ]:
+            with self.subTest(document="single", token=token):
+                self.assertIn(token, single)
+
+        for token in [
+            "training_standardization_sigma_source",
+            "already includes likelihood noise",
+            "not combined with ``yerr`` again",
+        ]:
+            with self.subTest(document="batch", token=token):
+                self.assertIn(token, batch)
+
     def test_single_source_doc_describes_retained_high_level_reports_truthfully(self):
         text = self._read("docs/source/howto/wavelength_advisory.rst")
         self.assertIn(

--- a/tests/test_period_independent_wavelength_advisory_workflow_batch.py
+++ b/tests/test_period_independent_wavelength_advisory_workflow_batch.py
@@ -431,6 +431,11 @@ class TestPeriodIndependentWavelengthAdvisoryWorkflowBatch(unittest.TestCase):
                         "fit_quality_available": True,
                         "fit_quality_score": 42.0,
                         "training_reduced_chi2": 0.5,
+                        "training_predictive_variance_kind": "observed",
+                        "training_standardization_sigma_source": (
+                            "observed_predictive_standard_deviation"
+                        ),
+                        "training_measurement_uncertainty_added_separately": False,
                     },
                     {
                         "quality_rank": 2,
@@ -483,10 +488,24 @@ class TestPeriodIndependentWavelengthAdvisoryWorkflowBatch(unittest.TestCase):
         self.assertEqual(dust["quality_rank"], 1)
         self.assertEqual(dust["time_kernel_type"], "quasi_periodic")
         self.assertEqual(dust["fit_quality_score"], 42.0)
+        self.assertEqual(dust["training_predictive_variance_kind"], "observed")
+        self.assertEqual(
+            dust["training_standardization_sigma_source"],
+            "observed_predictive_standard_deviation",
+        )
+        self.assertFalse(
+            dust["training_measurement_uncertainty_added_separately"]
+        )
 
         csv_by_model = {row["model"]: row for row in csv_rows}
         self.assertEqual(csv_by_model["2DDustMean"]["model_kernel_config_id"], "rank2_2DDustMean")
         self.assertEqual(csv_by_model["2DDustMean"]["quality_rank"], "1")
+        self.assertEqual(
+            csv_by_model["2DDustMean"][
+                "training_standardization_sigma_source"
+            ],
+            "observed_predictive_standard_deviation",
+        )
         self.assertEqual(csv_by_model["2DWavelengthDependent"]["quality_rank"], "2")
 
 

--- a/tests/test_period_independent_wavelength_model_kernel_config_quality.py
+++ b/tests/test_period_independent_wavelength_model_kernel_config_quality.py
@@ -2,8 +2,11 @@
 
 import unittest
 
+import torch
+
 from pgmuvi.lightcurve import Lightcurve
 from pgmuvi.wavelength_diagnostics import (
+    _piwd_compute_training_fit_quality,
     score_period_independent_wavelength_model_kernel_config_quality,
 )
 
@@ -64,6 +67,92 @@ def _quality_run_report():
             },
         ],
     }
+
+
+class _Prediction:
+    def __init__(self, mean, variance=None):
+        self.mean = torch.as_tensor(mean, dtype=torch.float64)
+        if variance is not None:
+            self.variance = torch.as_tensor(variance, dtype=torch.float64)
+
+
+class _Model:
+    def __call__(self, _x):
+        return object()
+
+
+class _Likelihood:
+    def __init__(self, prediction):
+        self.prediction = prediction
+
+    def __call__(self, _output):
+        return self.prediction
+
+
+class _FittedLightcurve:
+    def __init__(self, *, prediction, y, yerr):
+        self.model = _Model()
+        self.likelihood = _Likelihood(prediction)
+        self._xdata_transformed = torch.arange(len(y), dtype=torch.float64)
+        self._ydata_transformed = torch.as_tensor(y, dtype=torch.float64)
+        self._yerr_transformed = torch.as_tensor(yerr, dtype=torch.float64)
+
+    def _eval(self):
+        return None
+
+
+class TestTrainingFitQualityVarianceSemantics(unittest.TestCase):
+    def test_observed_predictive_variance_is_not_combined_with_yerr_again(self):
+        fitted = _FittedLightcurve(
+            prediction=_Prediction(mean=[0.0, 0.0], variance=[4.0, 4.0]),
+            y=[1.0, 2.0],
+            yerr=[3.0, 3.0],
+        )
+
+        report = _piwd_compute_training_fit_quality(fitted)
+
+        self.assertTrue(report["available"])
+        self.assertEqual(report["predictive_variance_kind"], "observed")
+        self.assertEqual(
+            report["standardization_sigma_source"],
+            "observed_predictive_standard_deviation",
+        )
+        self.assertFalse(report["measurement_uncertainty_added_separately"])
+        self.assertAlmostEqual(report["normalized_rmse"], (0.625) ** 0.5)
+        self.assertAlmostEqual(report["reduced_chi2"], 1.25)
+
+    def test_yerr_is_used_only_when_predictive_variance_is_unavailable(self):
+        fitted = _FittedLightcurve(
+            prediction=_Prediction(mean=[0.0, 0.0]),
+            y=[1.0, 2.0],
+            yerr=[2.0, 2.0],
+        )
+
+        report = _piwd_compute_training_fit_quality(fitted)
+
+        self.assertEqual(
+            report["standardization_sigma_source"],
+            "transformed_measurement_uncertainty_fallback",
+        )
+        self.assertIsNone(report["predictive_variance_kind"])
+        self.assertAlmostEqual(report["normalized_rmse"], (0.625) ** 0.5)
+        self.assertAlmostEqual(report["reduced_chi2"], 1.25)
+
+    def test_invalid_predictive_variance_uses_pointwise_yerr_fallback(self):
+        fitted = _FittedLightcurve(
+            prediction=_Prediction(mean=[0.0, 0.0], variance=[4.0, float("nan")]),
+            y=[1.0, 2.0],
+            yerr=[3.0, 2.0],
+        )
+
+        report = _piwd_compute_training_fit_quality(fitted)
+
+        self.assertEqual(
+            report["standardization_sigma_source"],
+            "observed_predictive_standard_deviation_with_transformed_yerr_fallback",
+        )
+        self.assertAlmostEqual(report["normalized_rmse"], (0.625) ** 0.5)
+        self.assertAlmostEqual(report["reduced_chi2"], 1.25)
 
 
 class TestPeriodIndependentWavelengthModelKernelConfigQuality(unittest.TestCase):

--- a/tests/test_transformed_uncertainties.py
+++ b/tests/test_transformed_uncertainties.py
@@ -1,0 +1,147 @@
+"""Regression tests for scale-only dependent-variable uncertainty transforms."""
+
+import unittest
+
+import torch
+
+from pgmuvi.lightcurve import Lightcurve, MinMax, RobustZScore, Shift, ZScore
+
+
+class TestTransformerUncertaintyScaling(unittest.TestCase):
+    def setUp(self):
+        self.y = torch.tensor([10.0, 12.0, 14.0, 16.0], dtype=torch.float64)
+        self.yerr = torch.tensor([1.0, 2.0, 3.0, 4.0], dtype=torch.float64)
+
+    def test_minmax_uses_fitted_range_without_minimum_shift(self):
+        transformer = MinMax()
+        transformer.transform(self.y)
+
+        transformed = transformer.transform_uncertainty(self.yerr)
+
+        self.assertTrue(torch.allclose(transformed, self.yerr / 6.0))
+        self.assertTrue(torch.all(transformed > 0))
+
+    def test_zscore_uses_fitted_standard_deviation_without_mean_shift(self):
+        transformer = ZScore()
+        transformer.transform(self.y)
+
+        transformed = transformer.transform_uncertainty(self.yerr)
+
+        self.assertTrue(torch.allclose(transformed, self.yerr / torch.std(self.y)))
+        self.assertTrue(torch.all(transformed > 0))
+
+    def test_robust_zscore_uses_fitted_mad_without_median_shift(self):
+        transformer = RobustZScore()
+        transformer.transform(self.y)
+
+        transformed = transformer.transform_uncertainty(self.yerr)
+
+        expected = self.yerr / transformer.mad
+        self.assertTrue(torch.allclose(transformed, expected))
+        self.assertTrue(torch.all(transformed > 0))
+
+    def test_shift_leaves_uncertainty_scales_unchanged(self):
+        transformer = Shift(method="midpoint")
+        transformer.transform(self.y)
+
+        transformed = transformer.transform_uncertainty(self.yerr)
+
+        self.assertTrue(torch.equal(transformed, self.yerr))
+
+    def test_variances_use_the_square_of_the_fitted_scale(self):
+        transformer = MinMax()
+        transformer.transform(self.y)
+        variances = self.yerr**2
+
+        transformed = transformer.transform_variance(variances)
+
+        self.assertTrue(torch.allclose(transformed, variances / 36.0))
+
+    def test_unfitted_scale_transform_rejects_uncertainties(self):
+        with self.assertRaisesRegex(RuntimeError, "fitted range"):
+            MinMax().transform_uncertainty(self.yerr)
+
+
+class TestLightcurveTransformedUncertainties(unittest.TestCase):
+    def setUp(self):
+        self.x = torch.arange(4, dtype=torch.float64)
+        self.y = torch.tensor([10.0, 12.0, 14.0, 16.0], dtype=torch.float64)
+        self.yerr = torch.tensor([1.0, 2.0, 3.0, 4.0], dtype=torch.float64)
+
+    def test_minmax_constructor_scales_errors_without_shifting_them(self):
+        lc = Lightcurve(
+            self.x,
+            self.y,
+            yerr=self.yerr,
+            ytransform="minmax",
+            center_time=False,
+        )
+
+        self.assertTrue(torch.allclose(lc._yerr_transformed, self.yerr / 6.0))
+        self.assertTrue(torch.all(lc._yerr_transformed > 0))
+
+    def test_zscore_constructor_scales_errors_without_shifting_them(self):
+        lc = Lightcurve(
+            self.x,
+            self.y,
+            yerr=self.yerr,
+            ytransform="zscore",
+            center_time=False,
+        )
+
+        expected = self.yerr / torch.std(self.y)
+        self.assertTrue(torch.allclose(lc._yerr_transformed, expected))
+
+    def test_robust_zscore_constructor_scales_errors_without_shifting_them(self):
+        lc = Lightcurve(
+            self.x,
+            self.y,
+            yerr=self.yerr,
+            ytransform="robust_zscore",
+            center_time=False,
+        )
+
+        expected = self.yerr / lc.ytransform.mad
+        self.assertTrue(torch.allclose(lc._yerr_transformed, expected))
+
+    def test_transform_y_uncertainty_matches_stored_errors(self):
+        lc = Lightcurve(
+            self.x,
+            self.y,
+            yerr=self.yerr,
+            ytransform="zscore",
+            center_time=False,
+        )
+
+        transformed = lc.transform_y_uncertainty(self.yerr)
+
+        self.assertTrue(torch.allclose(transformed, lc._yerr_transformed))
+
+    def test_no_ytransform_preserves_uncertainties(self):
+        lc = Lightcurve(
+            self.x,
+            self.y,
+            yerr=self.yerr,
+            center_time=False,
+        )
+
+        self.assertTrue(torch.equal(lc._yerr_transformed, self.yerr))
+        self.assertTrue(torch.equal(lc.transform_y_uncertainty(self.yerr), self.yerr))
+
+    def test_variance_true_uses_squared_transform_scale(self):
+        variances = self.yerr**2
+        lc = Lightcurve(
+            self.x,
+            self.y,
+            yerr=variances,
+            ytransform="minmax",
+            center_time=False,
+        )
+
+        lc.set_likelihood(variance=True)
+
+        self.assertTrue(torch.allclose(lc.likelihood.noise, variances / 36.0))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -121,7 +121,10 @@ class TestLightCurve(unittest.TestCase):
 
     def test_yerr_setter_with_transform(self):
         self.lightcurve.ytransform = MinMax()
-        self.test_yerr_transformed = self.lightcurve.ytransform.transform(self.test_ydata)
+        self.lightcurve.ytransform.transform(self.test_ydata)
+        self.test_yerr_transformed = (
+            self.lightcurve.ytransform.transform_uncertainty(self.test_ydata)
+        )
 
         self.lightcurve.yerr = self.test_ydata
         self.assertTrue(torch.equal(self.lightcurve._yerr_raw, self.test_ydata))


### PR DESCRIPTION
## Summary

- add scale-only uncertainty transformations for MinMax, ZScore, RobustZScore, and Shift
- transform variances using the square of the fitted scale
- prevent training residual diagnostics from adding measurement uncertainty twice
- use transformed measurement uncertainty only when observed predictive variance is unavailable
- record predictive-variance and standardization provenance in advisory and batch outputs
- add analytic regression tests and update the relevant documentation

## Validation

- targeted A3 tests passed
- Ruff CI-equivalent check passed
- strict Sphinx documentation build passed
- full test suite passed
