### PR TITLE
Correct retained-state marginal likelihood evaluation

### DIFF
--- a/docs/source/howto/interpreting_results.rst
+++ b/docs/source/howto/interpreting_results.rst
@@ -226,6 +226,47 @@ Read ``fit_quality_ranking_status`` before reading any rank:
 In every state, ``automatic_model_selection_applied=False`` and
 ``selected_model=None`` remain the scientific contract.
 
+Retained-state marginal-likelihood fields
+------------------------------------------
+
+The advisory result also records exact-GP marginal-likelihood diagnostics at the
+currently retained parameter state.  These fields are descriptive and are not
+used by ``fit_quality_score``.
+
+``training_log_marginal_likelihood``
+   Data log marginal likelihood **per observation**, evaluated in training mode
+   from ``likelihood(model(x_train)).log_prob(y_train)``.  It excludes registered
+   priors and additional objective terms.
+
+``training_log_marginal_likelihood_total``
+   The corresponding total data log marginal likelihood.
+
+``training_map_objective`` and ``training_map_objective_total``
+   The exact ``ExactMarginalLogLikelihood`` objective at the retained parameter
+   state, reported per observation and in total.  Registered priors are included
+   when present.
+
+``training_registered_log_prior`` and ``training_registered_log_prior_total``
+   The registered-prior contribution, separated from the data likelihood.
+   ``training_registered_prior_count`` and
+   ``training_map_objective_includes_registered_priors`` record whether such
+   terms were present.
+
+``training_additional_objective_terms``
+   Any remaining non-prior terms added by the exact MLL objective, separated
+   from both the data likelihood and registered priors.
+
+``training_marginal_likelihood_evaluation_mode`` is ``train`` and
+``training_marginal_likelihood_parameter_state`` is
+``retained_current_state``.  The evaluator temporarily switches the model and
+likelihood to training mode, computes all terms from the current parameters, and
+then restores their original modes.  It does not reuse the last loss recorded
+before an optimizer step.
+
+These are full-data training quantities, not held-out predictive scores and not
+Bayesian model probabilities.  Compare them only when candidates use identical
+analysis data, target transforms, likelihood policy, and fitting assumptions.
+
 Spectral-mixture ARD scale-ceiling diagnostics
 ----------------------------------------------
 

--- a/docs/source/howto/wavelength_advisory.rst
+++ b/docs/source/howto/wavelength_advisory.rst
@@ -375,6 +375,15 @@ unavailable.
    for triage and debugging, but they are not cross-validation, not posterior
    predictive checking, and not a formal marginal-likelihood model comparison.
 
+The fit-quality payload nevertheless records retained-state exact-GP objective
+terms for later inspection.  ``training_log_marginal_likelihood`` is the data
+log marginal likelihood per observation, excluding registered priors;
+``training_map_objective`` is the exact MLL objective per observation, including
+registered priors when present.  Total-valued companions and explicit prior and
+additional-objective contributions are retained separately.  Evaluation occurs
+in training mode at ``retained_current_state`` and the original model and
+likelihood modes are restored afterwards.
+
 Stage 5: format and plot
 ------------------------
 

--- a/docs/source/howto/wavelength_advisory_batch.rst
+++ b/docs/source/howto/wavelength_advisory_batch.rst
@@ -405,6 +405,20 @@ Important columns include:
      - Fraction of large standardized residuals.
    * - ``training_reduced_chi2``
      - Reduced-chi-square-like training residual diagnostic.
+   * - ``training_log_marginal_likelihood`` /
+       ``training_log_marginal_likelihood_total``
+     - Retained-state data log marginal likelihood per observation and in total,
+       excluding registered priors and additional objective terms.
+   * - ``training_map_objective`` / ``training_map_objective_total``
+     - Exact MLL objective per observation and in total at the retained parameter
+       state.
+   * - ``training_registered_log_prior`` /
+       ``training_registered_log_prior_total``
+     - Registered-prior contribution, separated from the data likelihood.
+   * - ``training_marginal_likelihood_evaluation_mode`` /
+       ``training_marginal_likelihood_parameter_state``
+     - Explicit provenance, currently ``train`` and
+       ``retained_current_state``.
    * - ``training_standardization_sigma_source``
      - Whether standardized residuals used observed predictive variance or the
        transformed-uncertainty fallback. Observed predictive variance already

--- a/pgmuvi/wavelength_diagnostics.py
+++ b/pgmuvi/wavelength_diagnostics.py
@@ -3560,6 +3560,187 @@ def _piwd_training_fit_quality_unavailable(reason: str) -> dict[str, Any]:
     )
 
 
+def _piwd_compute_retained_state_marginal_likelihood(
+    fitted_lightcurve: Any,
+) -> dict[str, Any]:
+    """Evaluate exact-GP objective terms at the retained parameter state.
+
+    The data log marginal likelihood is evaluated in training mode from
+    ``likelihood(model(train_x)).log_prob(train_y)``.  The exact MLL objective
+    is evaluated separately so registered-prior and any other objective-term
+    contributions remain distinguishable.  Original model/likelihood modes are
+    restored before returning.
+    """
+
+    base = {
+        "available": False,
+        "reason": None,
+        "evaluation_mode": "train",
+        "parameter_state": "retained_current_state",
+        "n_data": 0,
+        "data_log_marginal_likelihood_per_observation": None,
+        "data_log_marginal_likelihood_total": None,
+        "map_objective_per_observation": None,
+        "map_objective_total": None,
+        "registered_log_prior_per_observation": None,
+        "registered_log_prior_total": None,
+        "registered_prior_count": 0,
+        "map_objective_includes_registered_priors": False,
+        "additional_objective_terms_per_observation": None,
+        "additional_objective_terms_total": None,
+    }
+
+    if fitted_lightcurve is None:
+        base["reason"] = "no fitted Lightcurve was provided"
+        return _clean_scalar_dict(base)
+
+    model = getattr(fitted_lightcurve, "model", None)
+    likelihood = getattr(fitted_lightcurve, "likelihood", None)
+    train_x = getattr(fitted_lightcurve, "_xdata_transformed", None)
+    train_y = getattr(fitted_lightcurve, "_ydata_transformed", None)
+    if model is None or likelihood is None:
+        base["reason"] = "fitted Lightcurve has no model/likelihood"
+        return _clean_scalar_dict(base)
+    if train_x is None or train_y is None:
+        base["reason"] = "fitted Lightcurve has no transformed training data"
+        return _clean_scalar_dict(base)
+
+    model_was_training = getattr(model, "training", None)
+    likelihood_was_training = getattr(likelihood, "training", None)
+
+    try:
+        import torch as _torch
+        import gpytorch as _gpytorch
+
+        if int(train_y.numel()) <= 0:
+            raise ValueError("transformed training target is empty")
+
+        model.train()
+        likelihood.train()
+        with _torch.no_grad():
+            latent = model(train_x)
+            n_data = int(latent.event_shape.numel())
+            if n_data <= 0:
+                raise ValueError("latent training distribution has no events")
+            observed = likelihood(latent)
+
+            data_total_tensor = observed.log_prob(train_y)
+            if data_total_tensor.numel() != 1:
+                data_total_tensor = data_total_tensor.sum()
+
+            mll = _gpytorch.mlls.ExactMarginalLogLikelihood(likelihood, model)
+            objective_per_observation_tensor = mll(latent, train_y)
+            if objective_per_observation_tensor.numel() != 1:
+                objective_per_observation_tensor = (
+                    objective_per_observation_tensor.sum()
+                )
+
+            prior_total_tensor = data_total_tensor.new_zeros(())
+            registered_prior_count = 0
+            for _name, module, prior, closure, _setting_closure in mll.named_priors():
+                prior_value = closure(module)
+                prior_total_tensor = prior_total_tensor + prior.log_prob(
+                    prior_value
+                ).sum()
+                registered_prior_count += 1
+
+            objective_total_tensor = objective_per_observation_tensor * n_data
+            additional_total_tensor = (
+                objective_total_tensor - data_total_tensor - prior_total_tensor
+            )
+
+        data_total = _piwd_safe_float(data_total_tensor.detach().cpu().item())
+        objective_per_observation = _piwd_safe_float(
+            objective_per_observation_tensor.detach().cpu().item()
+        )
+        prior_total = _piwd_safe_float(prior_total_tensor.detach().cpu().item())
+        additional_total = _piwd_safe_float(
+            additional_total_tensor.detach().cpu().item()
+        )
+        if data_total is None or objective_per_observation is None:
+            raise ValueError("marginal-likelihood evaluation was non-finite")
+
+        base.update(
+            {
+                "available": True,
+                "n_data": n_data,
+                "data_log_marginal_likelihood_per_observation": (
+                    data_total / n_data
+                ),
+                "data_log_marginal_likelihood_total": data_total,
+                "map_objective_per_observation": objective_per_observation,
+                "map_objective_total": objective_per_observation * n_data,
+                "registered_log_prior_per_observation": (
+                    prior_total / n_data if prior_total is not None else None
+                ),
+                "registered_log_prior_total": prior_total,
+                "registered_prior_count": registered_prior_count,
+                "map_objective_includes_registered_priors": bool(
+                    registered_prior_count
+                ),
+                "additional_objective_terms_per_observation": (
+                    additional_total / n_data
+                    if additional_total is not None
+                    else None
+                ),
+                "additional_objective_terms_total": additional_total,
+            }
+        )
+    except Exception as exc:
+        base["reason"] = (
+            "could not evaluate retained-state marginal likelihood: "
+            f"{type(exc).__name__}: {exc}"
+        )
+    finally:
+        try:
+            if isinstance(model_was_training, bool):
+                model.train(model_was_training)
+            if isinstance(likelihood_was_training, bool):
+                likelihood.train(likelihood_was_training)
+        except Exception:
+            pass
+
+    return _clean_scalar_dict(base)
+
+
+_PIWD_TRAINING_MARGINAL_LIKELIHOOD_FIELDS = {
+    "training_log_marginal_likelihood": "log_marginal_likelihood",
+    "training_log_marginal_likelihood_total": "log_marginal_likelihood_total",
+    "training_marginal_likelihood_available": "marginal_likelihood_available",
+    "training_marginal_likelihood_reason": "marginal_likelihood_reason",
+    "training_marginal_likelihood_evaluation_mode": (
+        "marginal_likelihood_evaluation_mode"
+    ),
+    "training_marginal_likelihood_parameter_state": (
+        "marginal_likelihood_parameter_state"
+    ),
+    "training_map_objective": "map_objective",
+    "training_map_objective_total": "map_objective_total",
+    "training_registered_log_prior": "registered_log_prior",
+    "training_registered_log_prior_total": "registered_log_prior_total",
+    "training_registered_prior_count": "registered_prior_count",
+    "training_map_objective_includes_registered_priors": (
+        "map_objective_includes_registered_priors"
+    ),
+    "training_additional_objective_terms": "additional_objective_terms",
+    "training_additional_objective_terms_total": (
+        "additional_objective_terms_total"
+    ),
+}
+
+
+def _piwd_training_marginal_likelihood_fields(
+    fit_quality: dict[str, Any],
+) -> dict[str, Any]:
+    """Return stable flattened retained-state MLL fields."""
+    return {
+        output_name: fit_quality.get(input_name)
+        for output_name, input_name in (
+            _PIWD_TRAINING_MARGINAL_LIKELIHOOD_FIELDS.items()
+        )
+    }
+
+
 def _piwd_compute_training_fit_quality(fitted_lightcurve: Any) -> dict[str, Any]:
     """Compute best-effort training-space residual diagnostics for a fitted GP.
 
@@ -3677,20 +3858,9 @@ def _piwd_compute_training_fit_quality(fitted_lightcurve: Any) -> dict[str, Any]
             dof = max(int(std_resid.size) - 1, 1)
             reduced_chi2 = float(np.sum(std_resid**2) / dof)
 
-    log_mll = None
-    try:
-        import torch as _torch
-        import gpytorch as _gpytorch
-
-        with _torch.no_grad():
-            output = fitted_lightcurve.model(fitted_lightcurve._xdata_transformed)
-            mll = _gpytorch.mlls.ExactMarginalLogLikelihood(
-                fitted_lightcurve.likelihood, fitted_lightcurve.model
-            )
-            value = mll(output, fitted_lightcurve._ydata_transformed)
-            log_mll = _piwd_safe_float(value.detach().cpu().item())
-    except Exception:
-        log_mll = None
+    marginal_likelihood = _piwd_compute_retained_state_marginal_likelihood(
+        fitted_lightcurve
+    )
 
     by_band = []
     try:
@@ -3743,7 +3913,49 @@ def _piwd_compute_training_fit_quality(fitted_lightcurve: Any) -> dict[str, Any]
             "median_abs_standardized_residual": median_abs_standardized_residual,
             "outlier_fraction_3sigma": outlier_fraction_3sigma,
             "reduced_chi2": reduced_chi2,
-            "log_marginal_likelihood": log_mll,
+            # Backward-compatible field: retained-state *data* log marginal
+            # likelihood per observation, excluding registered priors and any
+            # additional objective terms.
+            "log_marginal_likelihood": marginal_likelihood.get(
+                "data_log_marginal_likelihood_per_observation"
+            ),
+            "log_marginal_likelihood_total": marginal_likelihood.get(
+                "data_log_marginal_likelihood_total"
+            ),
+            "marginal_likelihood_available": marginal_likelihood.get(
+                "available"
+            ),
+            "marginal_likelihood_reason": marginal_likelihood.get("reason"),
+            "marginal_likelihood_evaluation_mode": marginal_likelihood.get(
+                "evaluation_mode"
+            ),
+            "marginal_likelihood_parameter_state": marginal_likelihood.get(
+                "parameter_state"
+            ),
+            "map_objective": marginal_likelihood.get(
+                "map_objective_per_observation"
+            ),
+            "map_objective_total": marginal_likelihood.get(
+                "map_objective_total"
+            ),
+            "registered_log_prior": marginal_likelihood.get(
+                "registered_log_prior_per_observation"
+            ),
+            "registered_log_prior_total": marginal_likelihood.get(
+                "registered_log_prior_total"
+            ),
+            "registered_prior_count": marginal_likelihood.get(
+                "registered_prior_count"
+            ),
+            "map_objective_includes_registered_priors": marginal_likelihood.get(
+                "map_objective_includes_registered_priors"
+            ),
+            "additional_objective_terms": marginal_likelihood.get(
+                "additional_objective_terms_per_observation"
+            ),
+            "additional_objective_terms_total": marginal_likelihood.get(
+                "additional_objective_terms_total"
+            ),
             "by_band": by_band,
         }
     )
@@ -4086,7 +4298,7 @@ def _piwd_extract_fit_outcome(
         "training_reduced_chi2": fit_quality.get("reduced_chi2"),
         "training_median_abs_standardized_residual": fit_quality.get("median_abs_standardized_residual"),
         "training_outlier_fraction_3sigma": fit_quality.get("outlier_fraction_3sigma"),
-        "training_log_marginal_likelihood": fit_quality.get("log_marginal_likelihood"),
+        **_piwd_training_marginal_likelihood_fields(fit_quality),
         "training_predictive_variance_kind": fit_quality.get(
             "predictive_variance_kind"
         ),
@@ -4537,7 +4749,7 @@ def _piwd_score_one_wavelength_fit_quality(scored_or_outcome: dict[str, Any]) ->
             "training_median_abs_standardized_residual": fit_quality.get("median_abs_standardized_residual"),
             "training_outlier_fraction_3sigma": fit_quality.get("outlier_fraction_3sigma"),
             "training_reduced_chi2": fit_quality.get("reduced_chi2"),
-            "training_log_marginal_likelihood": fit_quality.get("log_marginal_likelihood"),
+            **_piwd_training_marginal_likelihood_fields(fit_quality),
             "training_predictive_variance_kind": fit_quality.get(
                 "predictive_variance_kind"
             ),
@@ -5955,9 +6167,10 @@ def _piwd_batch_extract_model_kernel_config_rows(*, source_row, workflow):
                 "training_outlier_fraction_3sigma"
             ),
             "training_reduced_chi2": item.get("training_reduced_chi2"),
-            "training_log_marginal_likelihood": item.get(
-                "training_log_marginal_likelihood"
-            ),
+            **{
+                field_name: item.get(field_name)
+                for field_name in _PIWD_TRAINING_MARGINAL_LIKELIHOOD_FIELDS
+            },
             "training_predictive_variance_kind": item.get(
                 "training_predictive_variance_kind"
             ),
@@ -6030,7 +6243,7 @@ def _piwd_batch_model_kernel_config_csv_fields():
         "training_median_abs_standardized_residual",
         "training_outlier_fraction_3sigma",
         "training_reduced_chi2",
-        "training_log_marginal_likelihood",
+        *_PIWD_TRAINING_MARGINAL_LIKELIHOOD_FIELDS.keys(),
         "training_predictive_variance_kind",
         "training_standardization_sigma_source",
         "training_measurement_uncertainty_added_separately",

--- a/tests/test_docs_result_interpretation.py
+++ b/tests/test_docs_result_interpretation.py
@@ -74,6 +74,26 @@ class TestResultInterpretationDocs(unittest.TestCase):
             with self.subTest(token=token):
                 self.assertIn(token, self.normalized)
 
+    def test_retained_state_marginal_likelihood_semantics(self):
+        required = [
+            "Retained-state marginal-likelihood fields",
+            "training_log_marginal_likelihood",
+            "Data log marginal likelihood **per observation**",
+            "training_log_marginal_likelihood_total",
+            "training_map_objective",
+            "training_registered_log_prior",
+            "training_registered_prior_count",
+            "training_additional_objective_terms",
+            "training_marginal_likelihood_evaluation_mode",
+            "retained_current_state",
+            "does not reuse the last loss recorded before an optimizer step",
+            "not held-out predictive scores",
+            "not Bayesian model probabilities",
+        ]
+        for token in required:
+            with self.subTest(token=token):
+                self.assertIn(token, self.normalized)
+
     def test_ard_ceiling_interpretation_is_coordinate_specific(self):
         required = [
             "time_frequency",

--- a/tests/test_docs_wavelength_advisory.py
+++ b/tests/test_docs_wavelength_advisory.py
@@ -77,6 +77,32 @@ class TestWavelengthAdvisoryDocs(unittest.TestCase):
             with self.subTest(document="batch", token=token):
                 self.assertIn(token, batch)
 
+    def test_docs_explain_retained_state_marginal_likelihood(self):
+        single = self._read("docs/source/howto/wavelength_advisory.rst")
+        batch = self._read("docs/source/howto/wavelength_advisory_batch.rst")
+        single = " ".join(single.split())
+        batch = " ".join(batch.split())
+
+        for token in [
+            "training_log_marginal_likelihood",
+            "data log marginal likelihood per observation",
+            "excluding registered priors",
+            "training_map_objective",
+            "retained_current_state",
+        ]:
+            with self.subTest(document="single", token=token):
+                self.assertIn(token, single)
+
+        for token in [
+            "training_log_marginal_likelihood_total",
+            "training_map_objective_total",
+            "training_registered_log_prior_total",
+            "training_marginal_likelihood_evaluation_mode",
+            "retained_current_state",
+        ]:
+            with self.subTest(document="batch", token=token):
+                self.assertIn(token, batch)
+
     def test_docs_explain_training_residual_noise_semantics(self):
         single = self._read("docs/source/howto/wavelength_advisory.rst")
         batch = self._read("docs/source/howto/wavelength_advisory_batch.rst")

--- a/tests/test_period_independent_wavelength_advisory_workflow_batch.py
+++ b/tests/test_period_independent_wavelength_advisory_workflow_batch.py
@@ -431,6 +431,17 @@ class TestPeriodIndependentWavelengthAdvisoryWorkflowBatch(unittest.TestCase):
                         "fit_quality_available": True,
                         "fit_quality_score": 42.0,
                         "training_reduced_chi2": 0.5,
+                        "training_log_marginal_likelihood": -1.25,
+                        "training_log_marginal_likelihood_total": -12.5,
+                        "training_marginal_likelihood_available": True,
+                        "training_marginal_likelihood_evaluation_mode": "train",
+                        "training_marginal_likelihood_parameter_state": (
+                            "retained_current_state"
+                        ),
+                        "training_map_objective": -1.30,
+                        "training_registered_log_prior": -0.05,
+                        "training_registered_prior_count": 1,
+                        "training_map_objective_includes_registered_priors": True,
                         "training_predictive_variance_kind": "observed",
                         "training_standardization_sigma_source": (
                             "observed_predictive_standard_deviation"
@@ -488,6 +499,22 @@ class TestPeriodIndependentWavelengthAdvisoryWorkflowBatch(unittest.TestCase):
         self.assertEqual(dust["quality_rank"], 1)
         self.assertEqual(dust["time_kernel_type"], "quasi_periodic")
         self.assertEqual(dust["fit_quality_score"], 42.0)
+        self.assertEqual(dust["training_log_marginal_likelihood"], -1.25)
+        self.assertEqual(dust["training_log_marginal_likelihood_total"], -12.5)
+        self.assertTrue(dust["training_marginal_likelihood_available"])
+        self.assertEqual(
+            dust["training_marginal_likelihood_evaluation_mode"], "train"
+        )
+        self.assertEqual(
+            dust["training_marginal_likelihood_parameter_state"],
+            "retained_current_state",
+        )
+        self.assertEqual(dust["training_map_objective"], -1.30)
+        self.assertEqual(dust["training_registered_log_prior"], -0.05)
+        self.assertEqual(dust["training_registered_prior_count"], 1)
+        self.assertTrue(
+            dust["training_map_objective_includes_registered_priors"]
+        )
         self.assertEqual(dust["training_predictive_variance_kind"], "observed")
         self.assertEqual(
             dust["training_standardization_sigma_source"],
@@ -505,6 +532,22 @@ class TestPeriodIndependentWavelengthAdvisoryWorkflowBatch(unittest.TestCase):
                 "training_standardization_sigma_source"
             ],
             "observed_predictive_standard_deviation",
+        )
+        self.assertEqual(
+            csv_by_model["2DDustMean"][
+                "training_marginal_likelihood_evaluation_mode"
+            ],
+            "train",
+        )
+        self.assertEqual(
+            csv_by_model["2DDustMean"][
+                "training_marginal_likelihood_parameter_state"
+            ],
+            "retained_current_state",
+        )
+        self.assertEqual(
+            csv_by_model["2DDustMean"]["training_registered_prior_count"],
+            "1",
         )
         self.assertEqual(csv_by_model["2DWavelengthDependent"]["quality_rank"], "2")
 

--- a/tests/test_retained_state_marginal_likelihood.py
+++ b/tests/test_retained_state_marginal_likelihood.py
@@ -1,0 +1,178 @@
+"""Tests for retained-state exact marginal-likelihood diagnostics."""
+
+import unittest
+
+import gpytorch
+import torch
+
+from pgmuvi.wavelength_diagnostics import (
+    _piwd_compute_retained_state_marginal_likelihood,
+    _piwd_compute_training_fit_quality,
+)
+
+
+class _TinyExactGP(gpytorch.models.ExactGP):
+    def __init__(self, train_x, train_y, likelihood):
+        super().__init__(train_x, train_y, likelihood)
+        self.mean_module = gpytorch.means.ConstantMean()
+        self.covar_module = gpytorch.kernels.ScaleKernel(
+            gpytorch.kernels.RBFKernel()
+        )
+
+    def forward(self, x):
+        mean = self.mean_module(x)
+        covariance = self.covar_module(x)
+        return gpytorch.distributions.MultivariateNormal(mean, covariance)
+
+
+class _FittedLightcurve:
+    def __init__(self, *, with_prior=False):
+        self._xdata_transformed = torch.linspace(
+            0.0, 1.0, 6, dtype=torch.float64
+        )
+        self._ydata_transformed = torch.tensor(
+            [0.1, 0.5, 0.8, 0.4, -0.1, -0.3], dtype=torch.float64
+        )
+        self._yerr_transformed = torch.full(
+            (6,), 0.2, dtype=torch.float64
+        )
+        self.likelihood = gpytorch.likelihoods.GaussianLikelihood().double()
+        self.likelihood.noise = 0.2
+        self.model = _TinyExactGP(
+            self._xdata_transformed,
+            self._ydata_transformed,
+            self.likelihood,
+        ).double()
+        self.model.covar_module.outputscale = 1.3
+        self.model.covar_module.base_kernel.lengthscale = 0.4
+        self.outputscale_prior = None
+        if with_prior:
+            self.outputscale_prior = gpytorch.priors.LogNormalPrior(
+                0.0, 0.5
+            )
+            self.model.covar_module.register_prior(
+                "outputscale_prior",
+                self.outputscale_prior,
+                "outputscale",
+            )
+
+    def _eval(self):
+        self.model.eval()
+        self.likelihood.eval()
+
+
+class TestRetainedStateMarginalLikelihood(unittest.TestCase):
+    def _direct_values(self, fitted):
+        fitted.model.train()
+        fitted.likelihood.train()
+        with torch.no_grad():
+            latent = fitted.model(fitted._xdata_transformed)
+            observed = fitted.likelihood(latent)
+            data_total = observed.log_prob(
+                fitted._ydata_transformed
+            ).item()
+            objective = gpytorch.mlls.ExactMarginalLogLikelihood(
+                fitted.likelihood, fitted.model
+            )(latent, fitted._ydata_transformed).item()
+        fitted.model.eval()
+        fitted.likelihood.eval()
+        return data_total, objective
+
+    def test_evaluates_training_mode_and_restores_original_modes(self):
+        fitted = _FittedLightcurve()
+        fitted.model.eval()
+        fitted.likelihood.eval()
+        expected_data_total, expected_objective = self._direct_values(fitted)
+
+        report = _piwd_compute_retained_state_marginal_likelihood(fitted)
+
+        self.assertTrue(report["available"])
+        self.assertEqual(report["evaluation_mode"], "train")
+        self.assertEqual(report["parameter_state"], "retained_current_state")
+        self.assertFalse(fitted.model.training)
+        self.assertFalse(fitted.likelihood.training)
+        self.assertAlmostEqual(
+            report["data_log_marginal_likelihood_total"],
+            expected_data_total,
+        )
+        self.assertAlmostEqual(
+            report["map_objective_per_observation"],
+            expected_objective,
+        )
+        self.assertAlmostEqual(
+            report["data_log_marginal_likelihood_per_observation"],
+            expected_data_total / report["n_data"],
+        )
+        self.assertEqual(report["registered_prior_count"], 0)
+        self.assertFalse(report["map_objective_includes_registered_priors"])
+        self.assertAlmostEqual(
+            report["map_objective_total"],
+            report["data_log_marginal_likelihood_total"]
+            + report["additional_objective_terms_total"],
+        )
+
+    def test_registered_prior_is_reported_separately(self):
+        fitted = _FittedLightcurve(with_prior=True)
+        fitted.model.eval()
+        fitted.likelihood.eval()
+
+        report = _piwd_compute_retained_state_marginal_likelihood(fitted)
+
+        expected_prior_total = fitted.outputscale_prior.log_prob(
+            fitted.model.covar_module.outputscale
+        ).sum().item()
+        self.assertTrue(report["available"])
+        self.assertGreaterEqual(report["registered_prior_count"], 1)
+        self.assertTrue(report["map_objective_includes_registered_priors"])
+        self.assertAlmostEqual(
+            report["registered_log_prior_total"], expected_prior_total
+        )
+        self.assertAlmostEqual(
+            report["registered_log_prior_per_observation"],
+            expected_prior_total / report["n_data"],
+        )
+        self.assertAlmostEqual(
+            report["map_objective_total"],
+            report["data_log_marginal_likelihood_total"]
+            + report["registered_log_prior_total"]
+            + report["additional_objective_terms_total"],
+        )
+
+    def test_uses_current_retained_parameters_not_a_stale_loss(self):
+        fitted = _FittedLightcurve()
+        before = _piwd_compute_retained_state_marginal_likelihood(fitted)
+
+        fitted.model.mean_module.constant = 4.0
+        after = _piwd_compute_retained_state_marginal_likelihood(fitted)
+
+        self.assertTrue(before["available"])
+        self.assertTrue(after["available"])
+        self.assertNotAlmostEqual(
+            before["data_log_marginal_likelihood_total"],
+            after["data_log_marginal_likelihood_total"],
+        )
+
+    def test_training_fit_quality_exposes_precise_mll_provenance(self):
+        fitted = _FittedLightcurve(with_prior=True)
+
+        report = _piwd_compute_training_fit_quality(fitted)
+
+        self.assertTrue(report["available"])
+        self.assertTrue(report["marginal_likelihood_available"])
+        self.assertEqual(
+            report["marginal_likelihood_evaluation_mode"], "train"
+        )
+        self.assertEqual(
+            report["marginal_likelihood_parameter_state"],
+            "retained_current_state",
+        )
+        self.assertAlmostEqual(
+            report["log_marginal_likelihood"],
+            report["log_marginal_likelihood_total"] / 6,
+        )
+        self.assertTrue(report["map_objective_includes_registered_priors"])
+        self.assertGreaterEqual(report["registered_prior_count"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- recompute exact marginal-likelihood diagnostics from the retained model and likelihood state
- evaluate in training mode and restore the original module modes afterward
- define `training_log_marginal_likelihood` as data log marginal likelihood per observation
- record the full MAP objective separately
- expose registered-prior contributions and additional objective terms
- propagate marginal-likelihood provenance through advisory and batch outputs
- add exact-GP regression tests and update the relevant documentation

## Validation

- targeted A4 tests passed
- Ruff CI-equivalent check passed
- strict Sphinx documentation build passed
- full test suite passed
