### PR TITLE
Correct wavelength period diagnostic semantics

### DIFF
--- a/docs/source/howto/consensus_fitting.rst
+++ b/docs/source/howto/consensus_fitting.rst
@@ -307,6 +307,13 @@ including:
    Controls rejection of per-band frequencies that are inconsistent with the
    robust consensus.
 
+``two_band_max_fractional_frequency_difference``
+   Applies only when exactly two bands provide valid dominant frequencies.
+   Because two values cannot support MAD-based outlier rejection, their
+   symmetric fractional frequency difference must not exceed this limit
+   (default ``0.10``).  Incompatible pairs fail explicitly rather than being
+   averaged into a midpoint period supported by neither band.
+
 ``use_acf``
    Enables the optional ACF contribution to the consensus diagnostics.
 

--- a/docs/source/howto/interpreting_results.rst
+++ b/docs/source/howto/interpreting_results.rst
@@ -100,6 +100,17 @@ only a single dominant period.  Compare ``consensus_period``,
 component-identity warning or a large drift flag means the final fit may no
 longer represent the component handed off by consensus.
 
+Two-band consensus requires direct agreement
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When exactly two bands contribute dominant frequencies, MAD clipping cannot
+identify which value is an outlier.  Inspect
+``two_band_fractional_frequency_difference``,
+``two_band_max_fractional_frequency_difference``, and
+``two_band_frequency_agreement``.  If the pair exceeds the configured limit,
+consensus fails and ``final_consensus_frequency`` remains unavailable; PGMUVI
+does not report the arithmetic midpoint as a shared period.
+
 Kernel-component diagnostics are not final periods
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -180,6 +191,21 @@ model veto or a hard parameter constraint.
 A trend is only interpretable when at least two bands are usable and the
 wavelength coordinate is physically meaningful.  Integer band codes are not
 physical wavelengths.
+
+Fixed-frequency phase and lag diagnostics
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Every band must use one common ``reference_time`` before phases or lags are
+compared.  When the caller does not provide one, the diagnostic uses the
+midpoint of the full multiband time range and records
+``fixed_frequency_reference_time_source="global_time_midpoint"``.
+
+Lag values are periodic.  ``lag_linear_span`` preserves the naive signed
+maximum-minus-minimum range for inspection, while ``lag_span`` uses the
+``minimum_circular_arc`` method.  The circular value prevents phases lying on
+opposite sides of the period boundary from being misclassified as almost one
+full cycle apart.  A lag trend remains descriptive and conditional on the
+supplied period or frequency.
 
 Training-residual fit-quality scores
 ------------------------------------

--- a/docs/source/howto/preprocessing.rst
+++ b/docs/source/howto/preprocessing.rst
@@ -138,14 +138,22 @@ long-timescale variability remains detectable after subsampling.
 
    :mod:`pgmuvi.preprocess` — full API reference for the preprocessing subpackage.
 
-Quality Filtering
-------------------
+Quality filtering and SNR thresholds
+------------------------------------
 
-.. note::
+:func:`pgmuvi.preprocess.quality.assess_sampling_quality` applies the
+configured ``min_snr`` threshold to both the median-SNR gate and the fraction
+of points above that threshold.  The returned metrics record the actual
+``snr_threshold`` and ``fraction_snr_gt_min`` used for the decision.
 
-   This section will describe how to apply quality flags or sigma-clipping to remove
-   outliers before fitting.  The relevant utilities are located in
-   :mod:`pgmuvi.preprocess.quality`.
+The legacy descriptive fields ``fraction_snr_gt_3`` and
+``fraction_snr_gt_5`` remain available, but they do not control a gate when a
+different ``min_snr`` is supplied.  Record ``min_snr`` and
+``min_fraction_good_snr`` with every scientific run.
+
+Quality flags and sigma clipping should be applied before fitting when their
+scientific meaning is justified.  The relevant utilities are located in
+:mod:`pgmuvi.preprocess.quality`.
 
 Preprocessing Tutorial
 -----------------------

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -388,6 +388,18 @@ _CONSENSUS_TOP_LEVEL_SCHEMA_FIELDS = MappingProxyType(
         ),
         "median_frequency": _consensus_schema_field(default=None, nullable=True),
         "mad_frequency_scatter": _consensus_schema_field(default=None, nullable=True),
+        "two_band_pairwise_check_applied": _consensus_schema_field(
+            default=False, nullable=False
+        ),
+        "two_band_fractional_frequency_difference": _consensus_schema_field(
+            default=None, nullable=True
+        ),
+        "two_band_max_fractional_frequency_difference": _consensus_schema_field(
+            default=None, nullable=True
+        ),
+        "two_band_frequency_agreement": _consensus_schema_field(
+            default=None, nullable=True
+        ),
         "consensus_inlier_bands": _consensus_schema_field(
             default_factory="list", nullable=False, container_type="list"
         ),
@@ -4331,7 +4343,8 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         #       consensus kwarg was set); contains: constrain_consensus,
         #       consensus_method, consensus_sigma_clip, consensus_sigma,
         #       consensus_tolerance, consensus_max_harmonic,
-        #       min_consensus_inliers, use_gp_validation
+        #       min_consensus_inliers,
+        #       two_band_max_fractional_frequency_difference, use_gp_validation
         #   "min_consensus_inliers" : int | None
         #   "outlier_thresholds" : dict | None  (non-None only if any outlier
         #       kwarg was set); contains: outlier_sigma_threshold,
@@ -4453,6 +4466,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 "consensus_tolerance",
                 "consensus_max_harmonic",
                 "min_consensus_inliers",
+                "two_band_max_fractional_frequency_difference",
                 "use_gp_validation",
             ]
             _consensus_configuration = {
@@ -9570,7 +9584,8 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             Fixed temporal period.  Mutually exclusive with ``frequency``.
         amplitude_phase_kwargs : dict or None, optional
             Extra keyword arguments for the fixed-frequency sinusoid fit.
-            Currently supports ``reference_time`` and ``min_points``.
+            Currently supports ``reference_time`` and ``min_points``.  When
+            omitted, one global time-range midpoint is shared by all bands.
         classification_kwargs : dict or None, optional
             Extra keyword arguments for the wavelength-dependence classifier.
 
@@ -15356,6 +15371,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             "outlier_sigma",
             "consensus_width_factor",
             "consensus_dedup_rtol",
+            "two_band_max_fractional_frequency_difference",
             "min_points_per_band",
             "max_gap_fraction",
             "min_duty_cycle",
@@ -15818,6 +15834,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         outlier_sigma=3.5,
         dedup_rtol=0.01,
         min_consensus_inliers=2,
+        two_band_max_fractional_frequency_difference=0.10,
         verbose=False,
     ):
         """Build a robust cross-band consensus frequency from dominant candidates.
@@ -15846,6 +15863,12 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             ``final_consensus_frequency=nan`` so the caller can finalize
             diagnostics and raise an informative ``RuntimeError``.  Defaults
             to ``2``, meaning at least two bands must agree.
+        two_band_max_fractional_frequency_difference : float, optional
+            Maximum symmetric fractional frequency difference accepted when
+            exactly two original bands provide valid dominant frequencies.
+            The robust MAD stage cannot identify an outlier from only two
+            values, so pairs farther apart than this threshold fail rather
+            than producing an unsupported midpoint consensus.
         verbose : bool, optional
             If ``True``, print outlier decisions and final consensus values.
 
@@ -15876,6 +15899,58 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 "Consensus fit failed: no valid dominant per-band frequencies "
                 "were available after quality gating."
             )
+
+        two_band_limit = float(two_band_max_fractional_frequency_difference)
+        if not np.isfinite(two_band_limit) or two_band_limit <= 0.0:
+            raise ValueError(
+                "two_band_max_fractional_frequency_difference must be a "
+                "finite, strictly positive float."
+            )
+
+        two_band_check_applied = len(freq_pairs) == 2
+        two_band_fractional_difference = None
+        two_band_frequency_agreement = None
+        if two_band_check_applied:
+            two_band_fractional_difference = (
+                self._consensus_fractional_frequency_difference(
+                    freq_pairs[0][1], freq_pairs[1][1]
+                )
+            )
+            two_band_frequency_agreement = bool(
+                two_band_fractional_difference <= two_band_limit
+            )
+            if not two_band_frequency_agreement:
+                original_freqs = np.asarray(
+                    [frequency for _, frequency in freq_pairs], dtype=float
+                )
+                original_bands = [band for band, _ in freq_pairs]
+                median_frequency = float(np.median(original_freqs))
+                mad_frequency = float(
+                    np.median(np.abs(original_freqs - median_frequency))
+                )
+                return {
+                    "frequencies_all": original_freqs.tolist(),
+                    "bands_all": original_bands,
+                    "median_frequency": median_frequency,
+                    "mad_frequency_scatter": mad_frequency,
+                    "inlier_bands": [],
+                    "outlier_bands": [],
+                    "final_consensus_frequency": float("nan"),
+                    "final_mad_frequency_scatter": float("nan"),
+                    "insufficient_inliers": True,
+                    "insufficient_inliers_count": 0,
+                    "required_min_consensus_inliers": int(
+                        min_consensus_inliers
+                    ),
+                    "two_band_pairwise_check_applied": True,
+                    "two_band_fractional_frequency_difference": float(
+                        two_band_fractional_difference
+                    ),
+                    "two_band_max_fractional_frequency_difference": (
+                        two_band_limit
+                    ),
+                    "two_band_frequency_agreement": False,
+                }
 
         # Deduplicate near-identical frequencies to prevent floating-point
         # jitter from counting equivalent peaks multiple times.
@@ -15966,6 +16041,16 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 "insufficient_inliers": True,
                 "insufficient_inliers_count": n_original_inlier_bands,
                 "required_min_consensus_inliers": int(min_consensus_inliers),
+                "two_band_pairwise_check_applied": two_band_check_applied,
+                "two_band_fractional_frequency_difference": (
+                    two_band_fractional_difference
+                ),
+                "two_band_max_fractional_frequency_difference": (
+                    two_band_limit if two_band_check_applied else None
+                ),
+                "two_band_frequency_agreement": (
+                    two_band_frequency_agreement
+                ),
             }
 
         final_consensus_frequency = float(np.median(inlier_freqs))
@@ -15997,6 +16082,14 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             "outlier_bands": outlier_bands,
             "final_consensus_frequency": final_consensus_frequency,
             "final_mad_frequency_scatter": mad_scatter,
+            "two_band_pairwise_check_applied": two_band_check_applied,
+            "two_band_fractional_frequency_difference": (
+                two_band_fractional_difference
+            ),
+            "two_band_max_fractional_frequency_difference": (
+                two_band_limit if two_band_check_applied else None
+            ),
+            "two_band_frequency_agreement": two_band_frequency_agreement,
         }
 
     @staticmethod
@@ -16526,7 +16619,9 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             ``min_points_per_band``, ``max_gap_fraction``, ``min_duty_cycle``,
             ``outlier_sigma``, ``min_consensus_inliers``, ``use_acf``,
             ``constrain_consensus``, ``consensus_width_factor``,
-            ``consensus_dedup_rtol``, ``use_gp_validation``,
+            ``consensus_dedup_rtol``,
+            ``two_band_max_fractional_frequency_difference``,
+            ``use_gp_validation``,
             ``gp_validation_kwargs``, and ``gp_frequency_tolerance_factor``.
 
             Manual overrides are also accepted via:
@@ -16561,6 +16656,12 @@ class Lightcurve(InputHelpers, gpytorch.Module):
               ``consensus_success`` is ``False``.
               This guards against spurious consensus frequencies when all
               accepted bands have mutually inconsistent periods.
+            - ``two_band_max_fractional_frequency_difference`` : float,
+              default ``0.10``
+              Maximum symmetric fractional difference allowed when exactly
+              two bands provide valid dominant frequencies.  Pairs farther
+              apart fail instead of being averaged into a midpoint unsupported
+              by either band.
             - ``use_gp_validation`` : bool, default ``False``
               If ``True``, run optional per-band 1D GP frequency validation on
               LS/ACF-vetted candidates before final consensus aggregation.
@@ -16620,6 +16721,9 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         use_acf = fit_kwargs.pop("use_acf", False)
         consensus_width_factor = fit_kwargs.pop("consensus_width_factor", None)
         consensus_dedup_rtol = fit_kwargs.pop("consensus_dedup_rtol", 0.01)
+        two_band_max_fractional_frequency_difference = fit_kwargs.pop(
+            "two_band_max_fractional_frequency_difference", 0.10
+        )
         use_gp_validation = fit_kwargs.pop("use_gp_validation", False)
         gp_validation_kwargs = fit_kwargs.pop("gp_validation_kwargs", None)
         gp_frequency_tolerance_factor = fit_kwargs.pop(
@@ -16632,6 +16736,17 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             raise ValueError(
                 "consensus_dedup_rtol must be a finite, strictly positive "
                 "float."
+            )
+        two_band_max_fractional_frequency_difference = float(
+            two_band_max_fractional_frequency_difference
+        )
+        if (
+            not np.isfinite(two_band_max_fractional_frequency_difference)
+            or two_band_max_fractional_frequency_difference <= 0.0
+        ):
+            raise ValueError(
+                "two_band_max_fractional_frequency_difference must be a "
+                "finite, strictly positive float."
             )
         if not isinstance(use_gp_validation, bool):
             raise ValueError("use_gp_validation must be a boolean.")
@@ -16752,6 +16867,9 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                     ),
                     dedup_rtol=consensus_dedup_rtol,
                     min_consensus_inliers=int(min_consensus_inliers),
+                    two_band_max_fractional_frequency_difference=(
+                        two_band_max_fractional_frequency_difference
+                    ),
                     verbose=verbose,
                 )
             except Exception as exc:
@@ -16792,6 +16910,22 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 result_diagnostics.update({
                     "median_frequency": consensus_diag["median_frequency"],
                     "mad_frequency_scatter": consensus_diag["mad_frequency_scatter"],
+                    "two_band_pairwise_check_applied": bool(
+                        consensus_diag.get("two_band_pairwise_check_applied", False)
+                    ),
+                    "two_band_fractional_frequency_difference": (
+                        consensus_diag.get(
+                            "two_band_fractional_frequency_difference"
+                        )
+                    ),
+                    "two_band_max_fractional_frequency_difference": (
+                        consensus_diag.get(
+                            "two_band_max_fractional_frequency_difference"
+                        )
+                    ),
+                    "two_band_frequency_agreement": consensus_diag.get(
+                        "two_band_frequency_agreement"
+                    ),
                     "consensus_inlier_bands": consensus_diag["inlier_bands"],
                     "consensus_outlier_bands": consensus_diag["outlier_bands"],
                     "candidate_count": len(
@@ -16816,6 +16950,9 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                         "consensus_width_factor": _resolved_width_factor,
                         "consensus_scale_width_factor": float(consensus_scale_width_factor),
                         "consensus_dedup_rtol": float(consensus_dedup_rtol),
+                        "two_band_max_fractional_frequency_difference": float(
+                            two_band_max_fractional_frequency_difference
+                        ),
                         "use_gp_validation": bool(use_gp_validation),
                         "gp_frequency_tolerance_factor": float(
                             gp_frequency_tolerance_factor
@@ -16829,13 +16966,30 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                     (float(1.0 / f) if f and f > 0 else None)
                     for f in consensus_diag.get("frequencies_all", [])
                 ]
+                _two_band_failed = bool(
+                    consensus_diag.get("two_band_pairwise_check_applied")
+                    and consensus_diag.get("two_band_frequency_agreement") is False
+                )
+                if _two_band_failed:
+                    _failure_message = (
+                        "Consensus fit failed: the two accepted bands have "
+                        "incompatible dominant frequencies. Their fractional "
+                        "frequency difference exceeds the configured two-band "
+                        "agreement threshold, so no midpoint consensus was "
+                        "constructed. This is a data-quality or period-ambiguity "
+                        "issue, not a software error."
+                    )
+                else:
+                    _failure_message = (
+                        f"Consensus fit failed: the inferred periods are mutually "
+                        f"inconsistent across bands. Only {n_found} band(s) "
+                        f"clustered around a common frequency after outlier "
+                        f"rejection, but {n_req} are required. The bands do not "
+                        "support a coherent shared period — this is a data-quality "
+                        "issue, not a software error."
+                    )
                 raise ConsensusFitError(
-                    f"Consensus fit failed: the inferred periods are mutually "
-                    f"inconsistent across bands. Only {n_found} band(s) "
-                    f"clustered around a common frequency after outlier "
-                    f"rejection, but {n_req} are required. The bands do not "
-                    "support a coherent shared period — this is a data-quality "
-                    "issue, not a software error.",
+                    _failure_message,
                     failure_diagnostics={
                         "status": "failed",
                         "reason": "insufficient_consensus_inliers",
@@ -16845,6 +16999,24 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                             consensus_diag.get("frequencies_all", [])
                         ),
                         "candidate_periods": _cand_periods,
+                        "two_band_pairwise_check_applied": bool(
+                            consensus_diag.get(
+                                "two_band_pairwise_check_applied", False
+                            )
+                        ),
+                        "two_band_fractional_frequency_difference": (
+                            consensus_diag.get(
+                                "two_band_fractional_frequency_difference"
+                            )
+                        ),
+                        "two_band_max_fractional_frequency_difference": (
+                            consensus_diag.get(
+                                "two_band_max_fractional_frequency_difference"
+                            )
+                        ),
+                        "two_band_frequency_agreement": consensus_diag.get(
+                            "two_band_frequency_agreement"
+                        ),
                     },
                 )
 
@@ -16929,6 +17101,20 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 "consensus_frequency_scatter": consensus_diag["mad_frequency_scatter"],
                 "median_frequency": consensus_diag["median_frequency"],
                 "mad_frequency_scatter": consensus_diag["mad_frequency_scatter"],
+                "two_band_pairwise_check_applied": bool(
+                    consensus_diag.get("two_band_pairwise_check_applied", False)
+                ),
+                "two_band_fractional_frequency_difference": (
+                    consensus_diag.get("two_band_fractional_frequency_difference")
+                ),
+                "two_band_max_fractional_frequency_difference": (
+                    consensus_diag.get(
+                        "two_band_max_fractional_frequency_difference"
+                    )
+                ),
+                "two_band_frequency_agreement": consensus_diag.get(
+                    "two_band_frequency_agreement"
+                ),
                 "consensus_inlier_bands": consensus_diag["inlier_bands"],
                 "consensus_outlier_bands": consensus_diag["outlier_bands"],
                 "final_consensus_frequency": final_consensus_frequency,
@@ -16942,6 +17128,9 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                     "constrain_consensus": bool(apply_consensus_constraints),
                     "consensus_width_factor": float(consensus_width_factor),
                     "consensus_dedup_rtol": float(consensus_dedup_rtol),
+                    "two_band_max_fractional_frequency_difference": float(
+                        two_band_max_fractional_frequency_difference
+                    ),
                     "use_gp_validation": bool(use_gp_validation),
                     "gp_frequency_tolerance_factor": float(
                         gp_frequency_tolerance_factor
@@ -17061,6 +17250,9 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                     "consensus_width_factor": consensus_width_factor,
                     "consensus_scale_width_factor": float(consensus_scale_width_factor),
                     "consensus_dedup_rtol": float(consensus_dedup_rtol),
+                    "two_band_max_fractional_frequency_difference": float(
+                        two_band_max_fractional_frequency_difference
+                    ),
                     "use_gp_validation": bool(use_gp_validation),
                     "gp_frequency_tolerance_factor": float(
                         gp_frequency_tolerance_factor

--- a/pgmuvi/preprocess/quality.py
+++ b/pgmuvi/preprocess/quality.py
@@ -297,19 +297,37 @@ def assess_sampling_quality(
                 f"< {min_baseline_factor} required"
             )
 
-    # Gate 4: SNR check (if data provided)
+    # Gate 4: SNR check (if data provided).  The fraction gate must use
+    # the caller's configured threshold rather than the legacy hard-coded
+    # SNR > 3 metric retained by compute_sampling_metrics().
     if "median_snr" in metrics:
-        fraction_snr_gt_min = float(metrics.get("fraction_snr_gt_3", 0.0))
+        y_arr = np.asarray(y)
+        yerr_arr = np.asarray(yerr)
+        valid_snr = (
+            np.isfinite(y_arr)
+            & np.isfinite(yerr_arr)
+            & (yerr_arr > 0)
+        )
+        if np.any(valid_snr):
+            snr = np.abs(y_arr[valid_snr]) / yerr_arr[valid_snr]
+            fraction_snr_gt_min = float(np.mean(snr > float(min_snr)))
+        else:
+            fraction_snr_gt_min = 0.0
 
+        metrics["snr_threshold"] = float(min_snr)
+        metrics["fraction_snr_gt_min"] = fraction_snr_gt_min
         gates["min_snr"] = (
             metrics["median_snr"] >= min_snr
             and fraction_snr_gt_min >= min_fraction_good_snr
         )
         if not gates["min_snr"]:
             warning_msgs.append(
-                f"Poor SNR: median={metrics['median_snr']:.1f} < {min_snr}, "
-                f"fraction>={min_snr:.1f}={100 * fraction_snr_gt_min:.0f}%"
-                f" < {100 * min_fraction_good_snr:.0f}%"
+                "Poor SNR: "
+                f"median={metrics['median_snr']:.1f} "
+                f"(required >= {min_snr:.1f}); "
+                f"fraction with SNR > {min_snr:.1f}="
+                f"{100 * fraction_snr_gt_min:.0f}% "
+                f"(required >= {100 * min_fraction_good_snr:.0f}%)"
             )
     else:
         gates["min_snr"] = True  # Pass by default if not checkable
@@ -346,12 +364,8 @@ def assess_sampling_quality(
             print("\nSignal Quality:")
             print(f"  • Median SNR: {metrics['median_snr']:.1f}")
             print(
-                f"  • Points with SNR > 3: "
-                f"{100 * metrics['fraction_snr_gt_3']:.0f}%"
-            )
-            print(
-                f"  • Points with SNR > 5: "
-                f"{100 * metrics['fraction_snr_gt_5']:.0f}%"
+                f"  • Points with SNR > {float(min_snr):g}: "
+                f"{100 * metrics['fraction_snr_gt_min']:.0f}%"
             )
 
         print("\nQuality Gates:")

--- a/pgmuvi/wavelength_diagnostics.py
+++ b/pgmuvi/wavelength_diagnostics.py
@@ -134,6 +134,51 @@ def _phase_to_lag(phase_radians: float, frequency: float) -> float:
     return float(((lag + 0.5 * period) % period) - 0.5 * period)
 
 
+def _minimum_circular_span(values: np.ndarray, period: float) -> float:
+    """Return the minimum circular arc containing all finite values."""
+    period = float(period)
+    if not np.isfinite(period) or period <= 0.0:
+        raise ValueError("period must be a positive finite value.")
+
+    finite = np.asarray(values, dtype=float)
+    finite = finite[np.isfinite(finite)]
+    if finite.size <= 1:
+        return 0.0
+
+    wrapped = np.sort(np.mod(finite, period))
+    circular_gaps = np.diff(np.concatenate([wrapped, wrapped[:1] + period]))
+    return float(max(0.0, period - np.max(circular_gaps)))
+
+
+def _unwrap_periodic_values(values: np.ndarray, period: float) -> np.ndarray:
+    """Unwrap an ordered periodic sequence using nearest-cycle continuity."""
+    period = float(period)
+    if not np.isfinite(period) or period <= 0.0:
+        raise ValueError("period must be a positive finite value.")
+    values = np.asarray(values, dtype=float)
+    angles = _TWO_PI * values / period
+    return np.unwrap(angles) * period / _TWO_PI
+
+
+def _resolve_common_reference_time(
+    times: np.ndarray,
+    reference_time: float | None,
+) -> tuple[float, str]:
+    """Resolve one reference epoch shared by every fixed-frequency band fit."""
+    if reference_time is not None:
+        value = float(reference_time)
+        if not np.isfinite(value):
+            raise ValueError("reference_time must be finite when provided.")
+        return value, "user_supplied"
+
+    finite = np.asarray(times, dtype=float)
+    finite = finite[np.isfinite(finite)]
+    if finite.size == 0:
+        raise ValueError("A common reference_time requires finite observation times.")
+    value = float(0.5 * (np.min(finite) + np.max(finite)))
+    return value, "global_time_midpoint"
+
+
 def _fit_fixed_frequency_sinusoid(
     t: np.ndarray,
     y: np.ndarray,
@@ -338,9 +383,14 @@ def _amplitude_phase_summary(band_table: list[dict[str, Any]]) -> dict[str, Any]
         "amplitude_loglog_slope": None,
         "fractional_amplitude_median": None,
         "fractional_amplitude_scatter": None,
+        "reference_time": None,
+        "reference_time_consistent": None,
         "lag_min": None,
         "lag_max": None,
+        "lag_linear_span": None,
         "lag_span": None,
+        "lag_span_method": None,
+        "lag_period": None,
     }
 
     if amplitude_values:
@@ -363,11 +413,43 @@ def _amplitude_phase_summary(band_table: list[dict[str, Any]]) -> dict[str, Any]
         summary["fractional_amplitude_median"] = float(np.median(frac))
         summary["fractional_amplitude_scatter"] = float(robust_scale(frac))
 
+    reference_times = []
+    periods = []
+    for row in band_table:
+        periodic = row.get("fixed_frequency_diagnostics", {})
+        if periodic.get("status") != "ok":
+            continue
+        reference = _finite_float(periodic.get("reference_time"))
+        period = _finite_float(periodic.get("period"))
+        if reference is not None:
+            reference_times.append(reference)
+        if period is not None and period > 0.0:
+            periods.append(period)
+
+    if reference_times:
+        reference_array = np.asarray(reference_times, dtype=float)
+        reference_consistent = bool(
+            np.allclose(
+                reference_array,
+                reference_array[0],
+                rtol=0.0,
+                atol=np.finfo(float).eps * max(1.0, abs(reference_array[0])),
+            )
+        )
+        summary["reference_time_consistent"] = reference_consistent
+        if reference_consistent:
+            summary["reference_time"] = float(reference_array[0])
+
     if lag_values:
         lags = np.asarray(lag_values, dtype=float)
         summary["lag_min"] = float(np.min(lags))
         summary["lag_max"] = float(np.max(lags))
-        summary["lag_span"] = float(np.max(lags) - np.min(lags))
+        summary["lag_linear_span"] = float(np.max(lags) - np.min(lags))
+        if periods:
+            period = float(np.median(np.asarray(periods, dtype=float)))
+            summary["lag_span"] = _minimum_circular_span(lags, period)
+            summary["lag_span_method"] = "minimum_circular_arc"
+            summary["lag_period"] = period
 
     return _clean_scalar_dict(summary)
 
@@ -688,11 +770,16 @@ def classify_wavelength_diagnostics(
     finite_lag = np.isfinite(lags)
     if np.count_nonzero(finite_lag) >= 2:
         lag_values = lags[finite_lag]
-        lag_span = float(np.nanmax(lag_values) - np.nanmin(lag_values))
+        lag_values_unwrapped = _unwrap_periodic_values(lag_values, fixed_period)
+        lag_span = _minimum_circular_span(lag_values, fixed_period)
         lag_span_fraction = (
             float(lag_span / fixed_period) if fixed_period > 0.0 else None
         )
+        classification["lag_linear_span"] = float(
+            np.nanmax(lag_values) - np.nanmin(lag_values)
+        )
         classification["lag_span"] = lag_span
+        classification["lag_span_method"] = "minimum_circular_arc"
         classification["lag_span_fraction_of_period"] = lag_span_fraction
         if (
             lag_span_fraction is not None
@@ -707,7 +794,7 @@ def classify_wavelength_diagnostics(
             lag_span_fraction is not None
             and lag_span_fraction >= significant_lag_fraction
         ):
-            lag_monotonic = _values_are_monotonic(lag_values)
+            lag_monotonic = _values_are_monotonic(lag_values_unwrapped)
             classification["phase_lag_class"] = (
                 "possible_monotonic_wavelength_lag"
                 if lag_monotonic
@@ -1160,6 +1247,7 @@ def compute_wavelength_residual_diagnostics(
     *,
     frequency: float | None = None,
     period: float | None = None,
+    reference_time: float | None = None,
     min_points_per_band: int = 3,
 ) -> dict[str, Any]:
     """Compute residual and predictive diagnostics for a fitted light curve.
@@ -1197,6 +1285,13 @@ def compute_wavelength_residual_diagnostics(
             "overall": {},
             "predictive_score": {"available": False},
         }
+
+    common_reference_time = None
+    common_reference_time_source = None
+    if fixed_frequency is not None:
+        common_reference_time, common_reference_time_source = (
+            _resolve_common_reference_time(x_raw[:, 0], reference_time)
+        )
 
     mean, variance, prediction_source = _training_prediction_arrays(lightcurve)
     if mean is None:
@@ -1252,6 +1347,7 @@ def compute_wavelength_residual_diagnostics(
                     residual[mask],
                     None,
                     frequency=fixed_frequency,
+                    reference_time=common_reference_time,
                     min_points=max(3, min_points_per_band),
                 )
                 row["fixed_frequency_residual"] = periodic
@@ -1278,6 +1374,8 @@ def compute_wavelength_residual_diagnostics(
         "target_space": "transformed_y_training_space",
         "fixed_frequency": fixed_frequency,
         "fixed_period": (None if fixed_frequency is None else float(1.0 / fixed_frequency)),
+        "fixed_frequency_reference_time": common_reference_time,
+        "fixed_frequency_reference_time_source": common_reference_time_source,
         "overall": overall,
         "by_band": band_rows,
         "predictive_score": _clean_scalar_dict(predictive_score),
@@ -2429,6 +2527,7 @@ def diagnose_period_independent_wavelength_structure(
 
     x_np = x_raw.detach().cpu().numpy()
     y_np = lightcurve._ydata_raw.detach().cpu().numpy()
+
     yerr_np = None
     if hasattr(lightcurve, "_yerr_raw") and lightcurve._yerr_raw is not None:
         yerr_np = lightcurve._yerr_raw.detach().cpu().numpy()
@@ -2588,7 +2687,10 @@ def diagnose_wavelength_dependence_prefit(
         Fixed temporal period.  Mutually exclusive with ``frequency``.
     amplitude_phase_kwargs : dict or None, optional
         Keyword arguments for the fixed-frequency sinusoid fit.  Currently
-        supports ``reference_time`` and ``min_points``.
+        supports ``reference_time`` and ``min_points``.  When no
+        ``reference_time`` is supplied, one global midpoint of the full
+        multiband time range is used for every band so phases and lags are
+        directly comparable.
     classification_kwargs : dict or None, optional
         Keyword arguments for :func:`classify_wavelength_diagnostics`.
 
@@ -2620,6 +2722,18 @@ def diagnose_wavelength_dependence_prefit(
 
     x_np = x_raw.detach().cpu().numpy()
     y_np = lightcurve._ydata_raw.detach().cpu().numpy()
+
+    common_reference_time = None
+    common_reference_time_source = None
+    if fixed_frequency is not None:
+        common_reference_time, common_reference_time_source = (
+            _resolve_common_reference_time(
+                x_np[:, 0],
+                amplitude_phase_kwargs.get("reference_time"),
+            )
+        )
+        amplitude_phase_kwargs["reference_time"] = common_reference_time
+
     yerr_np = None
     if hasattr(lightcurve, "_yerr_raw") and lightcurve._yerr_raw is not None:
         yerr_np = lightcurve._yerr_raw.detach().cpu().numpy()
@@ -2758,6 +2872,10 @@ def diagnose_wavelength_dependence_prefit(
     if fixed_frequency is not None:
         report["fixed_frequency"] = float(fixed_frequency)
         report["fixed_period"] = float(1.0 / fixed_frequency)
+        report["fixed_frequency_reference_time"] = common_reference_time
+        report["fixed_frequency_reference_time_source"] = (
+            common_reference_time_source
+        )
         report["amplitude_phase_summary"] = _amplitude_phase_summary(band_table)
 
     classification = classify_wavelength_diagnostics(report, **classification_kwargs)

--- a/tests/test_consensus_diagnostics.py
+++ b/tests/test_consensus_diagnostics.py
@@ -163,6 +163,10 @@ def _make_valid_diagnostics(
         "per_band_dominant_frequencies": {},
         "median_frequency": None,
         "mad_frequency_scatter": None,
+        "two_band_pairwise_check_applied": False,
+        "two_band_fractional_frequency_difference": None,
+        "two_band_max_fractional_frequency_difference": None,
+        "two_band_frequency_agreement": None,
         "consensus_inlier_bands": [],
         "consensus_outlier_bands": [],
         "final_consensus_frequency": consensus_frequency,
@@ -1576,6 +1580,7 @@ class TestPrepareGpValidationFitKwargs(unittest.TestCase):
             "consensus_frequencies": [0.1, 0.2],
             "use_gp_validation": True,
             "outlier_sigma": 3.0,
+            "two_band_max_fractional_frequency_difference": 0.10,
             "min_points_per_band": 10,
         }
         result = Lightcurve._consensus_prepare_gp_validation_fit_kwargs(blocked)

--- a/tests/test_consensus_two_band_frequency_agreement.py
+++ b/tests/test_consensus_two_band_frequency_agreement.py
@@ -1,0 +1,151 @@
+"""Regression tests for two-band consensus frequency agreement."""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+import numpy as np
+import torch
+
+from pgmuvi.lightcurve import ConsensusFitError, Lightcurve
+
+
+def _lightcurve() -> Lightcurve:
+    t = torch.linspace(0.0, 3.0, 4, dtype=torch.float64)
+    y = torch.ones(4, dtype=torch.float64)
+    return Lightcurve(t, y, max_samples=None)
+
+
+def _band_record(lc: Lightcurve, band: str, frequency: float) -> dict:
+    record = lc._consensus_initialize_band_record(band)
+    record.update(
+        {
+            "status": "accepted",
+            "dominant_frequency": float(frequency),
+            "dominant_period": float(1.0 / frequency),
+            "ls_significant": True,
+        }
+    )
+    return record
+
+
+class TestTwoBandFrequencyAgreementHelper(unittest.TestCase):
+    def setUp(self):
+        self.lc = _lightcurve()
+
+    def _build(self, f1: float, f2: float, **kwargs):
+        records = {
+            "g": _band_record(self.lc, "g", f1),
+            "r": _band_record(self.lc, "r", f2),
+        }
+        return self.lc._consensus_build_frequency_consensus(
+            records,
+            ["g", "r"],
+            **kwargs,
+        )
+
+    def test_close_pair_produces_supported_consensus(self):
+        result = self._build(1.0, 1.05)
+
+        self.assertFalse(result.get("insufficient_inliers", False))
+        self.assertAlmostEqual(result["final_consensus_frequency"], 1.025)
+        self.assertTrue(result["two_band_pairwise_check_applied"])
+        self.assertTrue(result["two_band_frequency_agreement"])
+        self.assertAlmostEqual(
+            result["two_band_fractional_frequency_difference"], 0.05
+        )
+
+    def test_incompatible_pair_does_not_create_midpoint_consensus(self):
+        result = self._build(1.0, 1.30)
+
+        self.assertTrue(result["insufficient_inliers"])
+        self.assertTrue(np.isnan(result["final_consensus_frequency"]))
+        self.assertEqual(result["insufficient_inliers_count"], 0)
+        self.assertFalse(result["two_band_frequency_agreement"])
+        self.assertAlmostEqual(
+            result["two_band_fractional_frequency_difference"], 0.30
+        )
+        self.assertEqual(result["inlier_bands"], [])
+
+    def test_custom_pairwise_limit_is_respected(self):
+        result = self._build(
+            1.0,
+            1.30,
+            two_band_max_fractional_frequency_difference=0.40,
+        )
+
+        self.assertFalse(result.get("insufficient_inliers", False))
+        self.assertTrue(result["two_band_frequency_agreement"])
+        self.assertAlmostEqual(result["final_consensus_frequency"], 1.15)
+
+    def test_invalid_pairwise_limit_raises(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "two_band_max_fractional_frequency_difference",
+        ):
+            self._build(
+                1.0,
+                1.05,
+                two_band_max_fractional_frequency_difference=0.0,
+            )
+
+
+class TestTwoBandFrequencyAgreementWorkflow(unittest.TestCase):
+    def test_standard_consensus_surfaces_pairwise_failure(self):
+        lc = _lightcurve()
+        records = {
+            "g": _band_record(lc, "g", 1.0),
+            "r": _band_record(lc, "r", 1.30),
+        }
+        candidate_diag = {
+            "controls": {
+                "outlier_sigma": 3.5,
+                "consensus_width_factor": 3.0,
+            },
+            "band_records": records,
+            "accepted_bands": ["g", "r"],
+            "rejected_bands": [],
+            "rejection_reasons": {},
+        }
+
+        with mock.patch(
+            "pgmuvi.lightcurve.Lightcurve.ndim",
+            new_callable=mock.PropertyMock,
+            return_value=2,
+        ), mock.patch.object(
+            lc,
+            "_consensus_collect_band_candidates",
+            return_value=candidate_diag,
+        ):
+            with self.assertRaises(ConsensusFitError) as caught:
+                lc._consensus_standard_fit(
+                    constrain_consensus=False,
+                    two_band_max_fractional_frequency_difference=0.10,
+                    verbose=False,
+                )
+
+        self.assertIn("two accepted bands", str(caught.exception))
+        failure = caught.exception.failure_diagnostics
+        self.assertEqual(failure["reason"], "insufficient_consensus_inliers")
+        self.assertTrue(failure["two_band_pairwise_check_applied"])
+        self.assertFalse(failure["two_band_frequency_agreement"])
+        self.assertAlmostEqual(
+            failure["two_band_fractional_frequency_difference"], 0.30
+        )
+
+        diagnostics = lc.consensus_diagnostics
+        self.assertFalse(diagnostics["consensus_success"])
+        self.assertTrue(diagnostics["two_band_pairwise_check_applied"])
+        self.assertFalse(diagnostics["two_band_frequency_agreement"])
+        self.assertIsNone(diagnostics["final_consensus_frequency"])
+        self.assertEqual(
+            diagnostics["controls"][
+                "two_band_max_fractional_frequency_difference"
+            ],
+            0.10,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_docs_consensus_fitting.py
+++ b/tests/test_docs_consensus_fitting.py
@@ -52,6 +52,17 @@ class TestConsensusFittingDocumentation(unittest.TestCase):
             with self.subTest(token=token):
                 self.assertIn(token, text)
 
+    def test_guide_documents_two_band_frequency_agreement_guard(self):
+        text = self._read("docs/source/howto/consensus_fitting.rst")
+        required = [
+            "two_band_max_fractional_frequency_difference",
+            "default ``0.10``",
+            "midpoint period supported by neither band",
+        ]
+        for token in required:
+            with self.subTest(token=token):
+                self.assertIn(token, text)
+
     def test_guide_documents_failure_and_multicomponent_limits(self):
         text = self._read("docs/source/howto/consensus_fitting.rst")
         required = [

--- a/tests/test_docs_preprocessing_notebook.py
+++ b/tests/test_docs_preprocessing_notebook.py
@@ -159,6 +159,19 @@ class TestRefreshedPreprocessingNotebook(unittest.TestCase):
             [0.55, 0.80],
         )
 
+    def test_preprocessing_guide_documents_configured_snr_fraction(self):
+        text = PREPROCESSING.read_text(encoding="utf-8")
+        required = [
+            "snr_threshold",
+            "fraction_snr_gt_min",
+            "fraction_snr_gt_3",
+            "min_fraction_good_snr",
+            "do not control a gate",
+        ]
+        for token in required:
+            with self.subTest(token=token):
+                self.assertIn(token, text)
+
     def test_companion_guides_link_notebook_and_remove_tbd_markers(self):
         preprocessing = PREPROCESSING.read_text(encoding="utf-8")
         loading = LOADING.read_text(encoding="utf-8")

--- a/tests/test_docs_result_interpretation.py
+++ b/tests/test_docs_result_interpretation.py
@@ -50,6 +50,23 @@ class TestResultInterpretationDocs(unittest.TestCase):
             with self.subTest(token=token):
                 self.assertIn(token, self.normalized)
 
+    def test_period_and_phase_boundary_semantics(self):
+        required = [
+            "Two-band consensus requires direct agreement",
+            "two_band_fractional_frequency_difference",
+            "two_band_max_fractional_frequency_difference",
+            "two_band_frequency_agreement",
+            "does not report the arithmetic midpoint",
+            "Fixed-frequency phase and lag diagnostics",
+            "one common ``reference_time``",
+            'fixed_frequency_reference_time_source="global_time_midpoint"',
+            "lag_linear_span",
+            "minimum_circular_arc",
+        ]
+        for token in required:
+            with self.subTest(token=token):
+                self.assertIn(token, self.normalized)
+
     def test_fit_quality_caveats_are_explicit(self):
         required = [
             "fit_quality_score",

--- a/tests/test_sampling_quality.py
+++ b/tests/test_sampling_quality.py
@@ -166,6 +166,35 @@ class TestComputeSamplingMetricsTightlyClustered(unittest.TestCase):
         self.assertAlmostEqual(metrics["nyquist_period"], expected)
 
 
+class TestAssessSamplingQualityConfiguredSnrThreshold(unittest.TestCase):
+    """The SNR fraction gate must follow the caller's threshold."""
+
+    def test_fraction_gate_uses_min_snr_not_legacy_threshold_three(self):
+        t = np.linspace(0.0, 100.0, 100)
+        y = np.concatenate([np.full(50, 4.0), np.full(50, 6.0)])
+        yerr = np.ones_like(y)
+
+        passes, diag = assess_sampling_quality(
+            t,
+            y,
+            yerr,
+            min_snr=5.0,
+            min_fraction_good_snr=0.75,
+        )
+
+        self.assertFalse(passes)
+        self.assertFalse(diag["gates"]["min_snr"])
+        self.assertEqual(diag["metrics"]["snr_threshold"], 5.0)
+        self.assertAlmostEqual(
+            diag["metrics"]["fraction_snr_gt_min"],
+            0.5,
+        )
+        self.assertEqual(diag["metrics"]["fraction_snr_gt_3"], 1.0)
+        self.assertTrue(
+            any("SNR > 5.0" in warning for warning in diag["warnings"])
+        )
+
+
 class TestAssessSamplingQualityDuplicateWarning(unittest.TestCase):
     """assess_sampling_quality diagnostic warnings with duplicate timestamps."""
 

--- a/tests/test_wavelength_diagnostics.py
+++ b/tests/test_wavelength_diagnostics.py
@@ -28,6 +28,7 @@ def _make_multiband_lightcurve(
     yerr_value=0.03,
     include_yerr=True,
     band_labels=None,
+    time_offsets=None,
 ):
     times = []
     wls = []
@@ -37,11 +38,14 @@ def _make_multiband_lightcurve(
     t = np.linspace(0.0, 90.0, n_per_band)
     if lags is None:
         lags = tuple(0.0 for _ in wavelengths)
-    for i, (wl, amp, lag) in enumerate(
-        zip(wavelengths, amplitudes, lags, strict=True)
+    if time_offsets is None:
+        time_offsets = tuple(0.0 for _ in wavelengths)
+    for i, (wl, amp, lag, time_offset) in enumerate(
+        zip(wavelengths, amplitudes, lags, time_offsets, strict=True)
     ):
-        y = 1.0 + amp * np.cos(2.0 * np.pi * (t - lag) / period)
-        times.append(t)
+        band_time = t + float(time_offset)
+        y = 1.0 + amp * np.cos(2.0 * np.pi * (band_time - lag) / period)
+        times.append(band_time)
         wls.append(np.full_like(t, wl))
         ys.append(y)
         yerrs.append(np.full_like(t, yerr_value))
@@ -277,6 +281,68 @@ class TestDiagnoseWavelengthDependencePrefit(unittest.TestCase):
         ]
         np.testing.assert_allclose(lags, [0.0, 2.0, 4.0], atol=0.05)
         self.assertGreater(report["amplitude_phase_summary"]["lag_span"], 3.9)
+
+    def test_default_reference_time_is_common_across_unequal_band_windows(self):
+        lc = _make_multiband_lightcurve(
+            n_per_band=90,
+            amplitudes=(0.4, 0.4, 0.4),
+            lags=(0.0, 2.0, 4.0),
+            time_offsets=(0.0, 15.0, 30.0),
+            yerr_value=0.01,
+        )
+
+        report = lc.diagnose_wavelength_dependence(
+            sampling_kwargs={"min_points": 10},
+            variability_kwargs={"min_points": 10, "fvar_min": 0.001},
+            period=30.0,
+        )
+
+        self.assertEqual(
+            report["fixed_frequency_reference_time_source"],
+            "global_time_midpoint",
+        )
+        self.assertAlmostEqual(report["fixed_frequency_reference_time"], 60.0)
+        reference_times = [
+            row["fixed_frequency_diagnostics"]["reference_time"]
+            for row in report["band_table"]
+        ]
+        np.testing.assert_allclose(reference_times, [60.0, 60.0, 60.0])
+        recovered_lags = [
+            row["fixed_frequency_diagnostics"]["lag"]
+            for row in report["band_table"]
+        ]
+        np.testing.assert_allclose(recovered_lags, [0.0, 2.0, 4.0], atol=0.05)
+        self.assertTrue(
+            report["amplitude_phase_summary"]["reference_time_consistent"]
+        )
+
+    def test_circular_lag_span_handles_period_boundary(self):
+        lc = _make_multiband_lightcurve(
+            n_per_band=100,
+            wavelengths=(1.0, 2.0),
+            amplitudes=(0.4, 0.4),
+            lags=(14.5, -14.5),
+            period=30.0,
+            yerr_value=0.005,
+        )
+
+        report = lc.diagnose_wavelength_dependence(
+            sampling_kwargs={"min_points": 10},
+            variability_kwargs={"min_points": 10, "fvar_min": 0.001},
+            period=30.0,
+            amplitude_phase_kwargs={"reference_time": 0.0},
+        )
+
+        summary = report["amplitude_phase_summary"]
+        self.assertGreater(summary["lag_linear_span"], 28.0)
+        self.assertAlmostEqual(summary["lag_span"], 1.0, delta=0.08)
+        self.assertEqual(summary["lag_span_method"], "minimum_circular_arc")
+        classification = report["classification"]
+        self.assertEqual(
+            classification["phase_lag_class"],
+            "consistent_with_zero_lag",
+        )
+        self.assertAlmostEqual(classification["lag_span"], 1.0, delta=0.08)
 
     def test_period_argument_matches_frequency_argument(self):
         lc = _make_multiband_lightcurve(n_per_band=80, amplitudes=(0.2, 0.2, 0.2))
@@ -569,9 +635,21 @@ class TestDiagnoseWavelengthDependencePrefit(unittest.TestCase):
         self.assertEqual(report["predictive_score"]["available"], True)
         self.assertEqual(len(report["by_band"]), 2)
         self.assertLess(report["overall"]["residual_rms"], 1e-12)
+        self.assertEqual(
+            report["fixed_frequency_reference_time_source"],
+            "global_time_midpoint",
+        )
+        residual_reference_times = []
         for row in report["by_band"]:
             self.assertIn("fixed_frequency_residual", row)
             self.assertLess(row["fixed_frequency_residual"]["amplitude"], 1e-12)
+            residual_reference_times.append(
+                row["fixed_frequency_residual"]["reference_time"]
+            )
+        np.testing.assert_allclose(
+            residual_reference_times,
+            [report["fixed_frequency_reference_time"]] * 2,
+        )
 
     def test_compare_wavelength_models_scores_successful_model_kernel_configs(self):
         fake_lc = _FakeLightcurveForComparison(


### PR DESCRIPTION
## Summary

- use the configured SNR threshold in sampling-quality gates
- preserve the legacy SNR metrics while recording the active threshold and matching fraction
- use a common reference epoch for cross-band fixed-frequency phase diagnostics
- calculate wavelength lag spans with circular statistics
- retain the previous linear span separately for provenance
- reject incompatible two-band frequency pairs instead of averaging them into an unsupported midpoint
- preserve pairwise-consensus provenance in success and failure diagnostics
- add focused regression tests and update the relevant documentation

## Validation

- targeted A5 tests passed
- Ruff CI-equivalent check passed
- strict Sphinx documentation build passed
- full test suite passed
