### PR TITLE
Unify wavelength attempt statuses and failures

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -58,4 +58,5 @@ Data, diagnostics, and validation
    pgmuvi.preprocess
    pgmuvi.multiband_ls_significance
    pgmuvi.wavelength_diagnostics
+   pgmuvi.wavelength_status
    pgmuvi.upload_validation

--- a/docs/source/howto/interpreting_results.rst
+++ b/docs/source/howto/interpreting_results.rst
@@ -331,6 +331,35 @@ A failed fit is not a low-quality successful fit.  Read ``status``,
 ``fit_success``, ``fit_failed``, ``exception_type``, ``exception_message``, and
 ``failure_stage`` before comparing scores.
 
+For maintained advisory outcomes, also inspect the canonical status dimensions:
+
+``attempt_disposition``
+   Whether the configured attempt was attempted, skipped, or not attempted.
+
+``execution_stage``
+   The furthest stage reached, such as ``precondition``, ``consensus``,
+   ``optimization``, ``diagnostics``, or ``completed``.
+
+``technical_outcome``
+   One of ``failed``, ``initialized_only``, ``completed``,
+   ``completed_with_warnings``, or ``completed_with_recovery``.  A zero-iteration
+   fit is initialization-only even though the legacy status remains ``passed``.
+
+``diagnostic_validity`` / ``scientific_usability``
+   Whether diagnostics are valid, partial, unavailable, or invalid, and whether
+   the attempt is usable, limited, or unusable for scientific interpretation.
+
+``comparison_eligibility``
+   Whether the attempt can participate in the current fit-quality comparison.
+   Initialization-only and diagnostically unavailable attempts are
+   comparison-ineligible rather than assigned a very poor score.
+
+``failure_code`` / ``failure_substage``
+   Stable machine-readable failure identity and optional more specific stage.
+   Structured ``failure_diagnostics`` and ``failure_summary`` are retained when
+   supplied by a consensus failure, and general outer fit exceptions now also
+   populate the canonical ``Lightcurve`` failure state.
+
 The advisory failure classifier uses descriptive stages:
 
 ``input_validation``

--- a/docs/source/howto/wavelength_advisory.rst
+++ b/docs/source/howto/wavelength_advisory.rst
@@ -103,6 +103,17 @@ Terminology
    ``single_valid_candidate``, or ``unavailable``.  At least two candidates
    with valid fit-quality diagnostics are required for ``available``.
 
+Canonical attempt status fields
+   Each maintained model/kernel-config outcome also records
+   ``attempt_disposition``, ``execution_stage``, ``technical_outcome``,
+   ``diagnostic_validity``, ``scientific_usability``, and
+   ``comparison_eligibility``.  These fields are orthogonal: for example, a
+   fit may have legacy ``status="passed"`` while
+   ``technical_outcome="initialized_only"`` and
+   ``comparison_eligibility="ineligible"`` when ``training_iter=0``.  The
+   compatibility fields remain available, but new interpretation code should
+   use the canonical dimensions.
+
 ``top_ranked_model``
    The model name with the best score when
    ``fit_quality_ranking_status="available"``.  It is ``None`` when every

--- a/docs/source/howto/wavelength_advisory_batch.rst
+++ b/docs/source/howto/wavelength_advisory_batch.rst
@@ -322,7 +322,13 @@ Important columns include:
    * - ``source_id``
      - User-facing source identifier.
    * - ``status``
-     - ``passed`` or failure status.
+     - Legacy outer source status, retained for compatibility.
+   * - ``attempt_disposition`` / ``execution_stage`` / ``technical_outcome``
+     - Canonical source-level execution status dimensions.
+   * - ``diagnostic_validity`` / ``scientific_usability`` /
+       ``comparison_eligibility``
+     - Whether the completed source workflow produced usable and comparable
+       evidence.
    * - ``fit_quality_ranking_status``
      - ``available``, ``single_valid_candidate``, or ``unavailable``.
    * - ``fit_quality_ranking_available``
@@ -390,7 +396,16 @@ Important columns include:
    * - ``training_iter`` / ``miniter``
      - Training controls used for the fit.
    * - ``fit_success`` / ``fit_failed``
-     - Per-config fit status.
+     - Legacy per-config fit aliases retained for compatibility.
+   * - ``attempt_disposition`` / ``execution_stage`` / ``technical_outcome``
+     - Canonical execution dimensions, including ``initialized_only``,
+       ``completed_with_warnings``, and ``completed_with_recovery``.
+   * - ``diagnostic_validity`` / ``scientific_usability`` /
+       ``comparison_eligibility``
+     - Diagnostic and comparison status.  Rows marked
+       ``comparison_eligibility="ineligible"`` remain unscored.
+   * - ``warning_severity`` / ``warning_count``
+     - Structured warning summary captured during the candidate fit.
    * - ``fit_quality_score``
      - Advisory residual-quality score.
    * - ``consensus_period`` / ``consensus_frequency``
@@ -425,8 +440,10 @@ Important columns include:
        includes likelihood noise and is not combined with ``yerr`` again.
    * - ``exception_type`` / ``exception_message``
      - Per-config failure diagnostics.
-   * - ``failure_stage`` / ``failure_stage_reason``
-     - Broad failure classification and short reason for failed configs.
+   * - ``failure_code`` / ``failure_stage`` / ``failure_substage`` /
+       ``failure_stage_reason``
+     - Stable failure identity, broad stage, optional substage, and readable
+       reason for failed configs.
    * - ``is_consensus_failure`` / ``is_numerical_failure`` / ``is_input_validation_failure``
      - Boolean triage flags for common failure modes.
    * - ``n_constrained_sm_ard_components``

--- a/docs/source/pgmuvi.wavelength_status.rst
+++ b/docs/source/pgmuvi.wavelength_status.rst
@@ -1,0 +1,11 @@
+pgmuvi.wavelength_status
+========================
+
+The maintained wavelength-advisory workflow keeps the historical
+``status``, ``fit_success``, and ``fit_failed`` fields for compatibility, but
+new code should also read the orthogonal status dimensions defined here.
+
+.. automodule:: pgmuvi.wavelength_status
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/pgmuvi/__init__.py
+++ b/pgmuvi/__init__.py
@@ -22,4 +22,5 @@ __all__ = [
     "synthetic",
     "trainers",
     "wavelength_diagnostics",
+    "wavelength_status",
 ]

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 from pathlib import Path
 import time
+import traceback
 from typing import ClassVar
 import numpy as np
 import torch
@@ -2661,11 +2662,28 @@ class PeriodSummaryResult:
 class FitFailureSummary:
     """Lightweight structured summary for failed fit attempts."""
 
-    def __init__(self, status="failed", reason=None, message="", diagnostics=None):
+    def __init__(
+        self,
+        status="failed",
+        reason=None,
+        message="",
+        diagnostics=None,
+        *,
+        failure_code=None,
+        stage=None,
+        substage=None,
+        exception_type=None,
+        traceback_reference=None,
+    ):
         self.status = status
         self.reason = reason
         self.message = message
         self.diagnostics = dict(diagnostics or {})
+        self.failure_code = failure_code or reason
+        self.stage = stage
+        self.substage = substage
+        self.exception_type = exception_type
+        self.traceback_reference = traceback_reference
 
     def _json_serialize(self, obj):
         if obj is None or isinstance(obj, (bool, str, int)):
@@ -2689,13 +2707,19 @@ class FitFailureSummary:
 
     def to_dict(self, include_fit_history=False, fit_history=None):
         """Return a JSON-safe failure-summary dictionary.
-        
-        When requested, the returned dictionary also includes sanitized fit-history
-        information supplied by the caller."""
+
+        When requested, the returned dictionary also includes sanitized
+        fit-history information supplied by the caller.
+        """
         payload = {
             "status": self.status,
             "reason": self.reason,
             "message": self.message,
+            "failure_code": self.failure_code,
+            "stage": self.stage,
+            "substage": self.substage,
+            "exception_type": self.exception_type,
+            "traceback_reference": self.traceback_reference,
             "diagnostics": self.diagnostics,
         }
         if include_fit_history:
@@ -2710,12 +2734,16 @@ class FitFailureSummary:
             "===================",
             f"Status : {self.status}",
             f"Reason : {self.reason or 'N/A'}",
+            f"Code   : {self.failure_code or 'N/A'}",
+            f"Stage  : {self.stage or 'N/A'}",
             f"Message: {self.message or 'N/A'}",
         ]
         if self.diagnostics:
             lines.append("Diagnostics:")
             for key in sorted(self.diagnostics):
-                lines.append(f"  - {key}: {self.to_dict()['diagnostics'].get(key)}")
+                lines.append(
+                    f"  - {key}: {self.to_dict()['diagnostics'].get(key)}"
+                )
         return "\n".join(lines)
 
     def write_json(
@@ -2735,6 +2763,7 @@ class FitFailureSummary:
                 indent=2,
                 allow_nan=False,
             )
+
 
 class Lightcurve(InputHelpers, gpytorch.Module):
     """A class for storing, manipulating and fitting light curves
@@ -6258,11 +6287,24 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         diagnostics=None,
         clear_model_state=False,
         clear_consensus=False,
+        failure_code=None,
+        stage=None,
+        substage=None,
+        exception_type="ConsensusFitError",
+        traceback_reference=None,
+        is_consensus_failure=True,
+        source="_record_failure_state",
+        elapsed_seconds=None,
     ):
         """Set canonical failed-fit state and return a failure summary object."""
         _diagnostics = self._consensus_make_json_safe(dict(diagnostics or {}))
         _diagnostics.setdefault("status", "failed")
         _diagnostics.setdefault("reason", reason)
+        _diagnostics.setdefault("failure_code", failure_code or reason)
+        _diagnostics.setdefault("failure_stage", stage)
+        _diagnostics.setdefault("failure_substage", substage)
+        _diagnostics.setdefault("exception_type", exception_type)
+        _diagnostics.setdefault("is_consensus_failure", bool(is_consensus_failure))
 
         self._reset_fit_state(
             clear_failure=False,
@@ -6278,14 +6320,28 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             reason=reason,
             message=message,
             diagnostics=_diagnostics,
+            failure_code=failure_code or reason,
+            stage=stage,
+            substage=substage,
+            exception_type=exception_type,
+            traceback_reference=traceback_reference,
         )
-        self.consensus_failure_summary = self.failure_summary
+        self.consensus_failure_summary = (
+            self.failure_summary if is_consensus_failure else None
+        )
         self._append_fit_history(
             success=False,
             failed=True,
-            exception_type="ConsensusFitError",
+            exception_type=exception_type,
             exception_message=message,
-            notes={"reason": reason, "source": "_record_failure_state"},
+            elapsed_seconds=elapsed_seconds,
+            notes={
+                "reason": reason,
+                "failure_code": failure_code or reason,
+                "stage": stage,
+                "substage": substage,
+                "source": source,
+            },
         )
         self._fit_history_recorded = True
         return self.failure_summary
@@ -6299,9 +6355,14 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         if not self.fit_failed:
             return
 
+        _is_consensus_failure = bool(
+            isinstance(self.failure_diagnostics, dict)
+            and self.failure_diagnostics.get("is_consensus_failure") is True
+        )
+        _fit_label = "consensus fit" if _is_consensus_failure else "fit"
         _base_message = (
             "Cannot generate "
-            f"{action_message}: the most recent consensus fit failed"
+            f"{action_message}: the most recent {_fit_label} failed"
         )
         _reason_messages = {
             "no_accepted_bands": (
@@ -6320,7 +6381,11 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         }
         _tail = _reason_messages.get(
             self.failure_reason,
-            "because the data did not support a coherent shared period.",
+            (
+                "because the data did not support a coherent shared period."
+                if _is_consensus_failure
+                else "because the fit did not complete successfully."
+            ),
         )
         _message = f"{_base_message} {_tail}"
         exc = ConsensusFitError(
@@ -10114,13 +10179,22 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             result = self._fit_core(*args, **kwargs)
         except Exception as exc:
             if not bool(getattr(self, "_fit_history_recorded", False)):
-                self._append_fit_history(
-                    success=False,
-                    failed=True,
+                self._record_failure_state(
+                    reason="fit_exception",
+                    failure_code="fit_execution_failed",
+                    stage="fit_execution",
+                    substage="outer_fit",
+                    message=str(exc),
+                    diagnostics={
+                        "exception_type": exc.__class__.__name__,
+                        "elapsed_seconds": time.perf_counter() - _fit_start,
+                        "traceback": traceback.format_exc(),
+                    },
                     exception_type=exc.__class__.__name__,
-                    exception_message=str(exc),
+                    traceback_reference="failure_diagnostics.traceback",
+                    is_consensus_failure=False,
+                    source="fit_exception",
                     elapsed_seconds=time.perf_counter() - _fit_start,
-                    notes={"source": "fit_exception"},
                 )
             raise
         else:
@@ -10996,12 +11070,20 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             _failure_diagnostics = getattr(exc, "failure_diagnostics", None) or {}
             _failure_reason = _failure_diagnostics.get("reason") or "consensus_failure"
             _failure_message = str(exc)
+            _failure_diagnostics.setdefault("traceback", traceback.format_exc())
             failure_summary = self._record_failure_state(
                 reason=_failure_reason,
+                failure_code=_failure_reason,
+                stage="consensus",
+                substage=_failure_diagnostics.get("failure_stage"),
                 message=_failure_message,
                 diagnostics=_failure_diagnostics,
                 clear_model_state=False,
                 clear_consensus=False,
+                exception_type=exc.__class__.__name__,
+                traceback_reference="failure_diagnostics.traceback",
+                is_consensus_failure=True,
+                source="_consensus_fit",
             )
             exc.failure_diagnostics = self.failure_diagnostics
             exc.failure_summary = failure_summary

--- a/pgmuvi/wavelength_diagnostics.py
+++ b/pgmuvi/wavelength_diagnostics.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import copy
 import time
+import warnings
 from typing import Any
 
 import numpy as np
@@ -22,6 +23,13 @@ except ImportError:  # pragma: no cover - pgmuvi normally depends on torch
 
 from pgmuvi.preprocess.quality import assess_sampling_quality, robust_scale
 from pgmuvi.preprocess.variability import is_variable
+from pgmuvi.wavelength_status import (
+    ExecutionStage,
+    WarningSeverity,
+    WavelengthFailureRecord,
+    coerce_execution_stage,
+    derive_wavelength_attempt_status,
+)
 
 
 _TWO_PI = 2.0 * np.pi
@@ -4272,6 +4280,7 @@ def _piwd_extract_sm_ard_scale_diagnostics(
 
 def _piwd_classify_model_kernel_config_failure(
     exception: BaseException | None,
+    fitted_lightcurve=None,
 ) -> dict[str, Any]:
     """Classify a failed advisory model/kernel-config fit for reporting.
 
@@ -4281,27 +4290,82 @@ def _piwd_classify_model_kernel_config_failure(
     """
     if exception is None:
         return {
+            "failure_code": None,
             "failure_stage": None,
+            "failure_substage": None,
             "failure_stage_reason": None,
             "is_consensus_failure": False,
             "is_numerical_failure": False,
             "is_input_validation_failure": False,
+            "structured_failure_diagnostics": {},
+            "failure_summary": None,
         }
 
     exception_type = type(exception).__name__
     message = str(exception)
     text = f"{exception_type} {message}".lower()
 
+    structured = getattr(exception, "failure_diagnostics", None)
+    structured = dict(structured) if isinstance(structured, dict) else {}
+    if not structured and fitted_lightcurve is not None:
+        candidate_diagnostics = getattr(
+            fitted_lightcurve, "failure_diagnostics", None
+        )
+        if isinstance(candidate_diagnostics, dict):
+            structured = dict(candidate_diagnostics)
+    summary = getattr(exception, "failure_summary", None)
+    if summary is None and fitted_lightcurve is not None:
+        summary = getattr(fitted_lightcurve, "failure_summary", None)
+    if summary is not None and hasattr(summary, "to_dict"):
+        try:
+            summary = summary.to_dict()
+        except Exception:
+            summary = None
+    elif not isinstance(summary, dict):
+        summary = None
+
     stage = "fit_execution"
+    substage = None
     reason = "model/kernel config fit raised an exception"
+    failure_code = "fit_execution_failed"
     is_consensus = False
     is_numerical = False
     is_input_validation = False
 
-    if "consensus" in text or "period consensus" in text:
+    structured_reason = structured.get("reason")
+    structured_code = structured.get("failure_code") or structured_reason
+    if structured_code:
+        failure_code = str(structured_code)
+    structured_stage = structured.get("failure_stage") or structured.get("stage")
+    structured_substage = structured.get("failure_substage")
+    if structured_substage:
+        substage = str(structured_substage)
+
+    structured_is_consensus = structured.get("is_consensus_failure") is True
+    if "consensus" in text or "period consensus" in text or structured_is_consensus:
         stage = "consensus"
         reason = "fit failed while deriving or applying temporal consensus information"
+        if not structured_code:
+            failure_code = "consensus_failed"
+        if substage is None and structured_stage not in {
+            None,
+            "consensus",
+        }:
+            substage = str(structured_stage)
         is_consensus = True
+    elif structured:
+        stage = str(structured_stage or stage)
+        reason = str(
+            structured.get("failure_stage_reason")
+            or structured.get("message")
+            or reason
+        )
+        is_numerical = stage in {"numerical_stability", "optimization"}
+        is_input_validation = stage in {
+            "input_validation",
+            "data_quality",
+            "precondition",
+        }
     elif (
         "notpsd" in text
         or "not positive definite" in text
@@ -4312,6 +4376,7 @@ def _piwd_classify_model_kernel_config_failure(
     ):
         stage = "numerical_stability"
         reason = "fit failed due to a numerical stability or covariance-matrix issue"
+        failure_code = "numerical_stability_failed"
         is_numerical = True
     elif (
         "constraint" in text
@@ -4321,6 +4386,7 @@ def _piwd_classify_model_kernel_config_failure(
     ):
         stage = "parameter_constraint"
         reason = "fit failed while satisfying parameter values or constraints"
+        failure_code = "parameter_constraint_failed"
     elif (
         "sampling" in text
         or "variability" in text
@@ -4330,19 +4396,118 @@ def _piwd_classify_model_kernel_config_failure(
     ):
         stage = "data_quality"
         reason = "fit failed because the input data did not satisfy a quality or availability requirement"
+        failure_code = "data_quality_precondition_failed"
         is_input_validation = True
     elif isinstance(exception, (ValueError, TypeError, AttributeError, KeyError)):
         stage = "input_validation"
         reason = "fit failed due to invalid or unsupported input for this model/kernel config"
+        failure_code = "input_validation_failed"
         is_input_validation = True
 
     return {
+        "failure_code": failure_code,
         "failure_stage": stage,
+        "failure_substage": substage,
         "failure_stage_reason": reason,
         "is_consensus_failure": bool(is_consensus),
         "is_numerical_failure": bool(is_numerical),
         "is_input_validation_failure": bool(is_input_validation),
+        "structured_failure_diagnostics": structured,
+        "failure_summary": summary,
     }
+
+
+def _piwd_warning_records(captured_warnings) -> list[dict[str, Any]]:
+    """Normalize captured Python warnings for attempt-level reporting."""
+    records = []
+    for item in captured_warnings or []:
+        records.append(
+            {
+                "severity": WarningSeverity.WARNING.value,
+                "category": getattr(item.category, "__name__", str(item.category)),
+                "message": str(item.message),
+                "filename": str(item.filename),
+                "lineno": int(item.lineno),
+            }
+        )
+    return records
+
+
+def _piwd_reemit_captured_warnings(captured_warnings) -> None:
+    """Re-emit captured warnings so attempt reporting does not hide them."""
+    for item in captured_warnings or []:
+        warnings.warn_explicit(
+            str(item.message),
+            item.category,
+            item.filename,
+            item.lineno,
+        )
+
+
+def _piwd_training_recovery_metadata(fitted_lightcurve, fit_result) -> dict[str, Any]:
+    """Return trainer recovery fields from the retained fit result."""
+    result = fit_result if isinstance(fit_result, dict) else None
+    if result is None and fitted_lightcurve is not None:
+        candidate = getattr(fitted_lightcurve, "results", None)
+        result = candidate if isinstance(candidate, dict) else {}
+    result = result or {}
+    keys = (
+        "training_recovered_from_failure",
+        "training_failure_iteration",
+        "training_failure_type",
+        "training_failure_message",
+        "training_restored_best_iteration",
+        "training_restored_best_loss",
+        "training_best_iteration",
+        "training_best_loss",
+    )
+    return {key: result.get(key) for key in keys}
+
+
+def _piwd_failure_record(exception, failure_info) -> dict[str, Any] | None:
+    """Build the canonical structured failure record for an exception."""
+    if exception is None:
+        return None
+    record = WavelengthFailureRecord(
+        failure_code=str(failure_info.get("failure_code") or "fit_execution_failed"),
+        stage=coerce_execution_stage(failure_info.get("failure_stage")),
+        substage=failure_info.get("failure_substage"),
+        exception_type=type(exception).__name__,
+        message=str(exception),
+        diagnostics=failure_info.get("structured_failure_diagnostics") or {},
+        traceback_reference="inline:traceback",
+    )
+    return record.to_dict()
+
+
+def _piwd_has_partial_scientific_failure_diagnostics(
+    failure_info: dict[str, Any],
+) -> bool:
+    """Return whether a failed attempt retained partial scientific evidence.
+
+    Generic exception metadata is useful for triage but does not make the
+    scientific diagnostics partially valid.  At present, partial validity is
+    reserved for consensus failures that retain band- or period-level evidence.
+    """
+    if failure_info.get("is_consensus_failure") is not True:
+        return False
+    diagnostics = failure_info.get("structured_failure_diagnostics")
+    if not isinstance(diagnostics, dict):
+        return False
+    evidence_keys = {
+        "accepted_bands",
+        "rejected_bands",
+        "per_band_diagnostics",
+        "per_band_dominant_periods",
+        "period_summaries",
+        "consensus_frequency",
+        "consensus_period",
+        "n_accepted_bands",
+        "n_rejected_bands",
+        "n_total_bands",
+    }
+    return any(key in diagnostics for key in evidence_keys)
+
 
 def _piwd_extract_fit_outcome(
     candidate: dict[str, Any],
@@ -4351,6 +4516,7 @@ def _piwd_extract_fit_outcome(
     fitted_lightcurve=None,
     fit_result: Any = None,
     exception: BaseException | None = None,
+    captured_warnings=None,
 ) -> dict[str, Any]:
     """Build a JSON-safe outcome record for one candidate execution."""
     diagnostics = None
@@ -4360,31 +4526,62 @@ def _piwd_extract_fit_outcome(
     fit_quality = (
         _piwd_compute_training_fit_quality(fitted_lightcurve)
         if status == "passed"
-        else _piwd_training_fit_quality_unavailable("model/kernel config fit did not complete")
+        else _piwd_training_fit_quality_unavailable(
+            "model/kernel config fit did not complete"
+        )
     )
     sm_ard_diagnostics = _piwd_extract_sm_ard_scale_diagnostics(
         fitted_lightcurve,
         diagnostics,
     )
-    sm_ard_counts = sm_ard_diagnostics.get("constrained_sm_ard_dimension_counts") or {}
-    failure_info = _piwd_classify_model_kernel_config_failure(exception)
+    sm_ard_counts = (
+        sm_ard_diagnostics.get("constrained_sm_ard_dimension_counts") or {}
+    )
+    failure_info = _piwd_classify_model_kernel_config_failure(
+        exception, fitted_lightcurve=fitted_lightcurve
+    )
+    failure_record = _piwd_failure_record(exception, failure_info)
+    warning_records = _piwd_warning_records(captured_warnings)
+    recovery = _piwd_training_recovery_metadata(fitted_lightcurve, fit_result)
+    fit_kwargs = dict(candidate.get("fit_kwargs") or {})
+    attempt_status = derive_wavelength_attempt_status(
+        legacy_status=status,
+        training_iter=fit_kwargs.get("training_iter"),
+        recovered_from_failure=bool(
+            recovery.get("training_recovered_from_failure")
+        ),
+        diagnostics_available=fit_quality.get("available"),
+        diagnostics_partial=_piwd_has_partial_scientific_failure_diagnostics(
+            failure_info
+        ),
+        warning_count=len(warning_records),
+        failure_stage=failure_info.get("failure_stage"),
+    )
 
     outcome: dict[str, Any] = {
         "model_kernel_config_id": candidate.get("model_kernel_config_id"),
         "rank": candidate.get("rank"),
         "model": candidate.get("model"),
         "status": status,
-
+        **attempt_status.to_dict(),
         "fit_success": bool(status == "passed"),
-
         "fit_failed": bool(status == "failed"),
+        "failure_code": failure_info.get("failure_code"),
         "failure_stage": failure_info.get("failure_stage"),
+        "failure_substage": failure_info.get("failure_substage"),
         "failure_stage_reason": failure_info.get("failure_stage_reason"),
         "is_consensus_failure": failure_info.get("is_consensus_failure"),
         "is_numerical_failure": failure_info.get("is_numerical_failure"),
-        "is_input_validation_failure": failure_info.get("is_input_validation_failure"),
+        "is_input_validation_failure": failure_info.get(
+            "is_input_validation_failure"
+        ),
         "fit_failure_diagnostics": failure_info,
-        "fit_kwargs": dict(candidate.get("fit_kwargs") or {}),
+        "structured_failure_record": failure_record,
+        "structured_failure_diagnostics": failure_info.get(
+            "structured_failure_diagnostics"
+        ),
+        "failure_summary": failure_info.get("failure_summary"),
+        "fit_kwargs": fit_kwargs,
         "recommendation_strength": candidate.get("recommendation_strength"),
         "hard_exclusion": bool(candidate.get("hard_exclusion", False)),
         "source": candidate.get("source"),
@@ -4394,7 +4591,9 @@ def _piwd_extract_fit_outcome(
                 candidate.get("applies_parameter_suggestions", False),
             )
         ),
-        "constraints_applied_from_plan": bool(candidate.get("applies_constraints", False)),
+        "constraints_applied_from_plan": bool(
+            candidate.get("applies_constraints", False)
+        ),
         "consensus_success": diagnostics.get("consensus_success"),
         "consensus_frequency": diagnostics.get("consensus_frequency"),
         "consensus_period": diagnostics.get("consensus_period"),
@@ -4405,17 +4604,27 @@ def _piwd_extract_fit_outcome(
         "n_rejected_bands": diagnostics.get("n_rejected_bands"),
         "accepted_bands": diagnostics.get("accepted_bands"),
         "rejected_bands": diagnostics.get("rejected_bands"),
-        "fit_result_type": type(fit_result).__name__ if fit_result is not None else None,
+        "fit_result_type": (
+            type(fit_result).__name__ if fit_result is not None else None
+        ),
         "fit_quality": fit_quality,
         "fit_quality_available": fit_quality.get("available"),
         "training_rmse": fit_quality.get("rmse"),
         "training_mae": fit_quality.get("mae"),
-        "training_median_abs_residual": fit_quality.get("median_abs_residual"),
+        "training_median_abs_residual": fit_quality.get(
+            "median_abs_residual"
+        ),
         "training_normalized_rmse": fit_quality.get("normalized_rmse"),
-        "training_nrmse_by_target_scale": fit_quality.get("normalized_rmse_by_target_scale"),
+        "training_nrmse_by_target_scale": fit_quality.get(
+            "normalized_rmse_by_target_scale"
+        ),
         "training_reduced_chi2": fit_quality.get("reduced_chi2"),
-        "training_median_abs_standardized_residual": fit_quality.get("median_abs_standardized_residual"),
-        "training_outlier_fraction_3sigma": fit_quality.get("outlier_fraction_3sigma"),
+        "training_median_abs_standardized_residual": fit_quality.get(
+            "median_abs_standardized_residual"
+        ),
+        "training_outlier_fraction_3sigma": fit_quality.get(
+            "outlier_fraction_3sigma"
+        ),
         **_piwd_training_marginal_likelihood_fields(fit_quality),
         "training_predictive_variance_kind": fit_quality.get(
             "predictive_variance_kind"
@@ -4426,6 +4635,9 @@ def _piwd_extract_fit_outcome(
         "training_measurement_uncertainty_added_separately": fit_quality.get(
             "measurement_uncertainty_added_separately"
         ),
+        **recovery,
+        "warning_count": len(warning_records),
+        "warning_records": warning_records,
         "sm_ard_scale_diagnostics": sm_ard_diagnostics,
         "constrained_sm_ard_components": sm_ard_diagnostics.get(
             "constrained_sm_ard_components"
@@ -4434,7 +4646,9 @@ def _piwd_extract_fit_outcome(
             "n_constrained_sm_ard_components"
         ),
         "constrained_sm_ard_dimension_counts": sm_ard_counts,
-        "n_constrained_sm_time_components": sm_ard_counts.get("time_frequency", 0),
+        "n_constrained_sm_time_components": sm_ard_counts.get(
+            "time_frequency", 0
+        ),
         "n_constrained_sm_wavelength_components": sm_ard_counts.get(
             "wavelength_frequency", 0
         ),
@@ -4452,6 +4666,7 @@ def _piwd_extract_fit_outcome(
                         type(exception), exception, exception.__traceback__
                     )
                 ),
+                "traceback_reference": "inline:traceback",
             }
         )
 
@@ -4509,33 +4724,53 @@ def run_period_independent_wavelength_model_kernel_configs(
             lc_to_fit = lightcurve
 
         fit_kwargs = dict(candidate.get("fit_kwargs") or {})
+        captured_warnings = []
+        fit_result = None
+        fit_exception = None
         try:
-            if fit_runner is None:
-                fit_result = lc_to_fit.fit(**fit_kwargs)
-            else:
-                fit_result = fit_runner(lc_to_fit, fit_kwargs, candidate)
+            with warnings.catch_warnings(record=True) as captured_warnings:
+                warnings.simplefilter("always")
+                if fit_runner is None:
+                    fit_result = lc_to_fit.fit(**fit_kwargs)
+                else:
+                    fit_result = fit_runner(lc_to_fit, fit_kwargs, candidate)
+        except Exception as exc:
+            fit_exception = exc
+
+        if fit_exception is None:
             outcomes.append(
                 _piwd_extract_fit_outcome(
                     candidate,
                     status="passed",
                     fitted_lightcurve=lc_to_fit,
                     fit_result=fit_result,
+                    captured_warnings=captured_warnings,
                 )
             )
-        except Exception as exc:
+        else:
             outcomes.append(
                 _piwd_extract_fit_outcome(
                     candidate,
                     status="failed",
                     fitted_lightcurve=lc_to_fit,
-                    exception=exc,
+                    exception=fit_exception,
+                    captured_warnings=captured_warnings,
                 )
             )
-            if stop_on_error:
-                raise
+
+        if fit_exception is not None and stop_on_error:
+            try:
+                _piwd_reemit_captured_warnings(captured_warnings)
+            finally:
+                raise fit_exception
+        _piwd_reemit_captured_warnings(captured_warnings)
 
     passed = [outcome for outcome in outcomes if outcome.get("status") == "passed"]
     failed = [outcome for outcome in outcomes if outcome.get("status") == "failed"]
+    technical_outcome_counts = {}
+    for outcome in outcomes:
+        key = outcome.get("technical_outcome") or "unknown"
+        technical_outcome_counts[key] = technical_outcome_counts.get(key, 0) + 1
 
     return _clean_scalar_dict(
         {
@@ -4560,6 +4795,14 @@ def run_period_independent_wavelength_model_kernel_configs(
             "n_attempted": len(outcomes),
             "n_passed": len(passed),
             "n_failed": len(failed),
+            "technical_outcome_counts": technical_outcome_counts,
+            "n_initialized_only": technical_outcome_counts.get("initialized_only", 0),
+            "n_completed_with_recovery": technical_outcome_counts.get(
+                "completed_with_recovery", 0
+            ),
+            "n_completed_with_warnings": technical_outcome_counts.get(
+                "completed_with_warnings", 0
+            ),
             "passed_models": [outcome.get("model") for outcome in passed],
             "failed_models": [outcome.get("model") for outcome in failed],
             "outcomes": outcomes,
@@ -4809,7 +5052,12 @@ def _piwd_score_one_wavelength_fit_quality(scored_or_outcome: dict[str, Any]) ->
     fit_success = _piwd_bool_from_status(
         outcome.get("fit_success"), status=outcome.get("status")
     )
-    available = bool(fit_quality.get("available")) and fit_success
+    comparison_eligibility = outcome.get("comparison_eligibility")
+    available = (
+        bool(fit_quality.get("available"))
+        and fit_success
+        and comparison_eligibility != "ineligible"
+    )
 
     nrmse = _piwd_quality_metric(
         fit_quality.get("normalized_rmse_by_target_scale"), fallback=1.0e6
@@ -4832,17 +5080,32 @@ def _piwd_score_one_wavelength_fit_quality(scored_or_outcome: dict[str, Any]) ->
         fit_quality_score -= 0.25 * np.log1p(red_chi2)
         reason = "training residual diagnostics available"
     else:
-        # Unavailable diagnostics are not a very poor scientific score.  Keep
-        # them unscored so they cannot become a top-ranked candidate when every
-        # fit failed or every diagnostic was unavailable.
+        # Unavailable or comparison-ineligible diagnostics are not a very poor
+        # scientific score.  Keep them unscored so they cannot become a
+        # top-ranked candidate when every fit failed, every diagnostic was
+        # unavailable, or the attempt was initialization-only.
         fit_quality_score = None
-        reason = fit_quality.get("reason") or "training residual diagnostics unavailable"
+        if comparison_eligibility == "ineligible":
+            reason = "canonical attempt status marks this result comparison-ineligible"
+        else:
+            reason = (
+                fit_quality.get("reason")
+                or "training residual diagnostics unavailable"
+            )
 
     return _clean_scalar_dict(
         {
             "rank": outcome.get("rank"),
             "model": outcome.get("model"),
             "status": outcome.get("status"),
+            "attempt_disposition": outcome.get("attempt_disposition"),
+            "execution_stage": outcome.get("execution_stage"),
+            "technical_outcome": outcome.get("technical_outcome"),
+            "diagnostic_validity": outcome.get("diagnostic_validity"),
+            "scientific_usability": outcome.get("scientific_usability"),
+            "comparison_eligibility": comparison_eligibility,
+            "warning_severity": outcome.get("warning_severity"),
+            "warning_count": outcome.get("warning_count"),
             "fit_success": fit_success,
             "consensus_success": outcome.get("consensus_success"),
             "consensus_period": outcome.get("consensus_period"),
@@ -5351,6 +5614,12 @@ def _piwd_build_advisory_workflow_fallback_summary(
         if item.get("fit_failed") is True or item.get("status") == "failed"
     ]
 
+    technical_outcome_counts = _piwd_count_values(
+        [item.get("technical_outcome") for item in outcomes]
+    )
+    failure_code_counts = _piwd_count_values(
+        [item.get("failure_code") for item in failed]
+    )
     failure_stage_counts = _piwd_count_values(
         [item.get("failure_stage") for item in failed]
     )
@@ -5428,8 +5697,25 @@ def _piwd_build_advisory_workflow_fallback_summary(
             "n_failed": len(failed),
             "n_with_fit_quality": n_with_fit_quality,
             "failed_models": [item.get("model") for item in failed],
+            "technical_outcome_counts": technical_outcome_counts,
+            "failure_code_counts": failure_code_counts,
             "failure_stage_counts": failure_stage_counts,
             "exception_type_counts": exception_type_counts,
+            "initialized_only_models": [
+                item.get("model")
+                for item in outcomes
+                if item.get("technical_outcome") == "initialized_only"
+            ],
+            "recovered_models": [
+                item.get("model")
+                for item in outcomes
+                if item.get("technical_outcome") == "completed_with_recovery"
+            ],
+            "comparison_ineligible_models": [
+                item.get("model")
+                for item in outcomes
+                if item.get("comparison_eligibility") == "ineligible"
+            ],
             "consensus_failure_models": consensus_failure_models,
             "n_consensus_failure_models": len(consensus_failure_models),
             "numerical_failure_models": numerical_failure_models,
@@ -6250,9 +6536,19 @@ def _piwd_batch_extract_model_kernel_config_rows(*, source_row, workflow):
             "is_top_ranked": item.get("is_top_ranked"),
             "model": item.get("model"),
             "status": item.get("status"),
+            "attempt_disposition": item.get("attempt_disposition"),
+            "execution_stage": item.get("execution_stage"),
+            "technical_outcome": item.get("technical_outcome"),
+            "diagnostic_validity": item.get("diagnostic_validity"),
+            "scientific_usability": item.get("scientific_usability"),
+            "comparison_eligibility": item.get("comparison_eligibility"),
+            "warning_severity": item.get("warning_severity"),
+            "warning_count": item.get("warning_count"),
             "fit_success": item.get("fit_success"),
             "fit_failed": item.get("fit_failed"),
+            "failure_code": item.get("failure_code"),
             "failure_stage": item.get("failure_stage"),
+            "failure_substage": item.get("failure_substage"),
             "failure_stage_reason": item.get("failure_stage_reason"),
             "is_consensus_failure": item.get("is_consensus_failure"),
             "is_numerical_failure": item.get("is_numerical_failure"),
@@ -6265,6 +6561,14 @@ def _piwd_batch_extract_model_kernel_config_rows(*, source_row, workflow):
             "learn_additional_noise": fit_kwargs.get("learn_additional_noise"),
             "training_iter": fit_kwargs.get("training_iter"),
             "miniter": fit_kwargs.get("miniter"),
+            "training_recovered_from_failure": item.get(
+                "training_recovered_from_failure"
+            ),
+            "training_failure_iteration": item.get("training_failure_iteration"),
+            "training_failure_type": item.get("training_failure_type"),
+            "training_restored_best_iteration": item.get(
+                "training_restored_best_iteration"
+            ),
             "consensus_success": item.get("consensus_success"),
             "consensus_period": item.get("consensus_period"),
             "consensus_frequency": item.get("consensus_frequency"),
@@ -6334,9 +6638,19 @@ def _piwd_batch_model_kernel_config_csv_fields():
         "is_top_ranked",
         "model",
         "status",
+        "attempt_disposition",
+        "execution_stage",
+        "technical_outcome",
+        "diagnostic_validity",
+        "scientific_usability",
+        "comparison_eligibility",
+        "warning_severity",
+        "warning_count",
         "fit_success",
         "fit_failed",
+        "failure_code",
         "failure_stage",
+        "failure_substage",
         "failure_stage_reason",
         "is_consensus_failure",
         "is_numerical_failure",
@@ -6349,6 +6663,10 @@ def _piwd_batch_model_kernel_config_csv_fields():
         "learn_additional_noise",
         "training_iter",
         "miniter",
+        "training_recovered_from_failure",
+        "training_failure_iteration",
+        "training_failure_type",
+        "training_restored_best_iteration",
         "consensus_success",
         "consensus_period",
         "consensus_frequency",
@@ -6851,10 +7169,14 @@ def run_period_independent_wavelength_advisory_workflow_batch(
 
     for index, source in enumerate(source_list):
         source_id = _piwd_batch_safe_source_id(None, index)
+        source_execution_stage = "ingestion"
         row = {
             "source_index": index,
             "source_id": source_id,
             "status": "not_started",
+            **derive_wavelength_attempt_status(
+                legacy_status="not_attempted"
+            ).to_dict(),
             "advisory_only": True,
             "runs_fits": True,
             "applies_to_fit": True,
@@ -6909,6 +7231,7 @@ def run_period_independent_wavelength_advisory_workflow_batch(
                     "n_rows_dropped"
                 )
 
+            source_execution_stage = "optimization"
             workflow = lc.run_period_independent_wavelength_advisory_workflow(
                 **workflow_kwargs
             )
@@ -6957,9 +7280,36 @@ def run_period_independent_wavelength_advisory_workflow_batch(
                 if workflow_ranking_available
                 else None
             )
+            candidate_warning_count = sum(
+                int(item.get("warning_count") or 0)
+                for item in candidate_rows
+                if isinstance(item, dict)
+            )
+            candidate_recovery = any(
+                item.get("technical_outcome") == "completed_with_recovery"
+                or item.get("training_recovered_from_failure") is True
+                for item in candidate_rows
+                if isinstance(item, dict)
+            )
+            all_initialized_only = bool(candidate_rows) and all(
+                item.get("technical_outcome") == "initialized_only"
+                for item in candidate_rows
+                if isinstance(item, dict)
+            )
+            source_status = derive_wavelength_attempt_status(
+                legacy_status="passed",
+                training_iter=0 if all_initialized_only else None,
+                recovered_from_failure=candidate_recovery,
+                diagnostics_available=workflow_ranking_available,
+                diagnostics_partial=(
+                    workflow_ranking_status == "single_valid_candidate"
+                ),
+                warning_count=candidate_warning_count,
+            )
             row.update(
                 {
                     "status": "passed",
+                    **source_status.to_dict(),
                     "workflow_kind": workflow.get("kind"),
                     "fit_quality_ranking_status": workflow_ranking_status,
                     "fit_quality_ranking_available": workflow_ranking_available,
@@ -6967,6 +7317,8 @@ def run_period_independent_wavelength_advisory_workflow_batch(
                     "top_ranked_model": workflow_top_ranked_model,
                     "top_ranked_fit_quality_score": workflow_top_ranked_score,
                     "score_kind": workflow.get("score_kind"),
+                    "warning_count": candidate_warning_count,
+                    "training_recovered_from_failure": candidate_recovery,
                     "n_model_kernel_configs": n_model_kernel_configs,
                     "n_successful_model_kernel_configs": n_successful_model_kernel_configs,
                     "n_failed_model_kernel_configs": n_failed_model_kernel_configs,
@@ -6993,6 +7345,7 @@ def run_period_independent_wavelength_advisory_workflow_batch(
             model_kernel_config_rows.extend(source_model_kernel_config_rows)
 
             if export and outdir is not None:
+                source_execution_stage = "export"
                 source_component = _piwd_batch_safe_path_component(source_id, index)
                 source_outdir = outdir / source_component
                 source_prefix = f"{source_component}_wavelength_advisory"
@@ -7012,12 +7365,32 @@ def run_period_independent_wavelength_advisory_workflow_batch(
         except Exception as exc:
             if stop_on_error:
                 raise
+            source_status = derive_wavelength_attempt_status(
+                legacy_status="failed",
+                diagnostics_partial=False,
+                failure_stage=source_execution_stage,
+            )
+            source_failure_code = f"source_{source_execution_stage}_failed"
+            source_failure_record = WavelengthFailureRecord(
+                failure_code=source_failure_code,
+                stage=ExecutionStage(source_execution_stage),
+                substage=None,
+                exception_type=type(exc).__name__,
+                message=str(exc),
+                diagnostics={},
+                traceback_reference="inline:traceback",
+            ).to_dict()
             row.update(
                 {
                     "status": "failed",
+                    **source_status.to_dict(),
+                    "failure_code": source_failure_code,
+                    "failure_stage": source_execution_stage,
+                    "structured_failure_record": source_failure_record,
                     "exception_type": type(exc).__name__,
                     "exception_message": str(exc),
                     "traceback": traceback.format_exc(),
+                    "traceback_reference": "inline:traceback",
                 }
             )
             if export and outdir is not None:

--- a/pgmuvi/wavelength_status.py
+++ b/pgmuvi/wavelength_status.py
@@ -1,0 +1,309 @@
+"""Canonical status and failure records for wavelength-advisory attempts.
+
+The maintained wavelength-advisory workflow historically exposed a mixture of
+``passed``/``failed`` strings and Boolean aliases.  This module adds orthogonal,
+JSON-safe status dimensions without removing those compatibility fields.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from collections.abc import Mapping
+from typing import Any
+
+__all__ = [
+    "AttemptDisposition",
+    "ComparisonEligibility",
+    "DiagnosticValidity",
+    "ExecutionStage",
+    "ScientificUsability",
+    "TechnicalOutcome",
+    "WarningSeverity",
+    "WavelengthAttemptStatus",
+    "WavelengthFailureRecord",
+    "coerce_execution_stage",
+    "derive_wavelength_attempt_status",
+]
+
+
+class _StringEnum(str, Enum):
+    """Enum whose members serialize and display as their string values."""
+
+    def __str__(self) -> str:
+        return self.value
+
+
+class AttemptDisposition(_StringEnum):
+    """Whether a configured attempt was actually executed."""
+
+    NOT_ATTEMPTED = "not_attempted"
+    ATTEMPTED = "attempted"
+    SKIPPED = "skipped"
+
+
+class ExecutionStage(_StringEnum):
+    """Furthest execution stage reached by an attempt."""
+
+    NOT_STARTED = "not_started"
+    PRECONDITION = "precondition"
+    INGESTION = "ingestion"
+    PREPROCESSING = "preprocessing"
+    SETUP = "setup"
+    CONSENSUS = "consensus"
+    OPTIMIZATION = "optimization"
+    DIAGNOSTICS = "diagnostics"
+    EXPORT = "export"
+    COMPLETED = "completed"
+    UNKNOWN = "unknown"
+
+
+class TechnicalOutcome(_StringEnum):
+    """Technical completion state of an attempt."""
+
+    NOT_ATTEMPTED = "not_attempted"
+    SKIPPED = "skipped"
+    FAILED = "failed"
+    INITIALIZED_ONLY = "initialized_only"
+    COMPLETED = "completed"
+    COMPLETED_WITH_WARNINGS = "completed_with_warnings"
+    COMPLETED_WITH_RECOVERY = "completed_with_recovery"
+
+
+class DiagnosticValidity(_StringEnum):
+    """Validity of diagnostics produced by the attempt."""
+
+    NOT_EVALUATED = "not_evaluated"
+    VALID = "valid"
+    PARTIAL = "partial"
+    UNAVAILABLE = "unavailable"
+    INVALID = "invalid"
+
+
+class ScientificUsability(_StringEnum):
+    """Whether the attempt can support scientific interpretation."""
+
+    NOT_EVALUATED = "not_evaluated"
+    USABLE = "usable"
+    LIMITED = "limited"
+    UNUSABLE = "unusable"
+
+
+class ComparisonEligibility(_StringEnum):
+    """Whether the attempt is eligible for like-for-like comparison."""
+
+    NOT_EVALUATED = "not_evaluated"
+    ELIGIBLE = "eligible"
+    INELIGIBLE = "ineligible"
+
+
+class WarningSeverity(_StringEnum):
+    """Severity used by structured warning records."""
+
+    INFO = "info"
+    WARNING = "warning"
+    ERROR = "error"
+
+
+@dataclass(frozen=True)
+class WavelengthAttemptStatus:
+    """Orthogonal status dimensions for one wavelength-model attempt."""
+
+    disposition: AttemptDisposition
+    execution_stage: ExecutionStage
+    technical_outcome: TechnicalOutcome
+    diagnostic_validity: DiagnosticValidity
+    scientific_usability: ScientificUsability
+    comparison_eligibility: ComparisonEligibility
+    warning_severity: WarningSeverity | None = None
+
+    def to_dict(self) -> dict[str, str | None]:
+        """Return a JSON-safe dictionary using stable public field names."""
+        return {
+            "attempt_disposition": self.disposition.value,
+            "execution_stage": self.execution_stage.value,
+            "technical_outcome": self.technical_outcome.value,
+            "diagnostic_validity": self.diagnostic_validity.value,
+            "scientific_usability": self.scientific_usability.value,
+            "comparison_eligibility": self.comparison_eligibility.value,
+            "warning_severity": (
+                self.warning_severity.value
+                if self.warning_severity is not None
+                else None
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class WavelengthFailureRecord:
+    """Structured, JSON-safe record for a failed wavelength-model attempt."""
+
+    failure_code: str
+    stage: ExecutionStage
+    substage: str | None
+    exception_type: str | None
+    message: str
+    diagnostics: Mapping[str, Any]
+    traceback_reference: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a shallow JSON-safe representation.
+
+        Nested diagnostic values are expected to have been sanitized by the
+        caller because the advisory workflow already owns the package-wide
+        scalar-cleaning rules.
+        """
+        return {
+            "failure_code": self.failure_code,
+            "failure_stage": self.stage.value,
+            "failure_substage": self.substage,
+            "exception_type": self.exception_type,
+            "exception_message": self.message,
+            "failure_diagnostics": dict(self.diagnostics),
+            "traceback_reference": self.traceback_reference,
+        }
+
+
+def coerce_execution_stage(value: str | ExecutionStage | None) -> ExecutionStage:
+    """Map legacy stage labels onto the canonical execution-stage enum."""
+    if isinstance(value, ExecutionStage):
+        return value
+    normalized = str(value or "").strip().lower()
+    mapping = {
+        "": ExecutionStage.UNKNOWN,
+        "not_started": ExecutionStage.NOT_STARTED,
+        "input_validation": ExecutionStage.PRECONDITION,
+        "data_quality": ExecutionStage.PRECONDITION,
+        "precondition": ExecutionStage.PRECONDITION,
+        "ingestion": ExecutionStage.INGESTION,
+        "preprocessing": ExecutionStage.PREPROCESSING,
+        "parameter_constraint": ExecutionStage.SETUP,
+        "fit_execution": ExecutionStage.OPTIMIZATION,
+        "numerical_stability": ExecutionStage.OPTIMIZATION,
+        "optimization": ExecutionStage.OPTIMIZATION,
+        "consensus": ExecutionStage.CONSENSUS,
+        "diagnostics": ExecutionStage.DIAGNOSTICS,
+        "export": ExecutionStage.EXPORT,
+        "completed": ExecutionStage.COMPLETED,
+    }
+    return mapping.get(normalized, ExecutionStage.UNKNOWN)
+
+
+def derive_wavelength_attempt_status(
+    *,
+    legacy_status: str | None,
+    training_iter: int | None = None,
+    recovered_from_failure: bool = False,
+    diagnostics_available: bool | None = None,
+    diagnostics_partial: bool = False,
+    warning_count: int = 0,
+    failure_stage: str | ExecutionStage | None = None,
+) -> WavelengthAttemptStatus:
+    """Derive canonical dimensions from the maintained legacy attempt fields.
+
+    This helper intentionally leaves the legacy ``status``, ``fit_success`` and
+    ``fit_failed`` fields untouched.  It is therefore safe to introduce before
+    the later typed-result migration.
+    """
+    status = str(legacy_status or "").strip().lower()
+
+    if status in {"skipped", "not_attempted"}:
+        disposition = (
+            AttemptDisposition.SKIPPED
+            if status == "skipped"
+            else AttemptDisposition.NOT_ATTEMPTED
+        )
+        technical = (
+            TechnicalOutcome.SKIPPED
+            if status == "skipped"
+            else TechnicalOutcome.NOT_ATTEMPTED
+        )
+        stage = (
+            ExecutionStage.PRECONDITION
+            if status == "skipped"
+            else ExecutionStage.NOT_STARTED
+        )
+        return WavelengthAttemptStatus(
+            disposition=disposition,
+            execution_stage=stage,
+            technical_outcome=technical,
+            diagnostic_validity=DiagnosticValidity.NOT_EVALUATED,
+            scientific_usability=ScientificUsability.NOT_EVALUATED,
+            comparison_eligibility=(
+                ComparisonEligibility.INELIGIBLE
+                if status == "skipped"
+                else ComparisonEligibility.NOT_EVALUATED
+            ),
+            warning_severity=None,
+        )
+
+    disposition = AttemptDisposition.ATTEMPTED
+    if status in {"failed", "failure"}:
+        return WavelengthAttemptStatus(
+            disposition=disposition,
+            execution_stage=coerce_execution_stage(failure_stage),
+            technical_outcome=TechnicalOutcome.FAILED,
+            diagnostic_validity=(
+                DiagnosticValidity.PARTIAL
+                if diagnostics_partial
+                else DiagnosticValidity.UNAVAILABLE
+            ),
+            scientific_usability=ScientificUsability.UNUSABLE,
+            comparison_eligibility=ComparisonEligibility.INELIGIBLE,
+            warning_severity=WarningSeverity.ERROR,
+        )
+
+    try:
+        initialized_only = training_iter is not None and int(training_iter) == 0
+    except (TypeError, ValueError):
+        initialized_only = False
+    if initialized_only:
+        technical = TechnicalOutcome.INITIALIZED_ONLY
+    elif recovered_from_failure:
+        technical = TechnicalOutcome.COMPLETED_WITH_RECOVERY
+    elif warning_count > 0:
+        technical = TechnicalOutcome.COMPLETED_WITH_WARNINGS
+    else:
+        technical = TechnicalOutcome.COMPLETED
+
+    if diagnostics_available is True:
+        diagnostic_validity = DiagnosticValidity.VALID
+    elif diagnostics_partial:
+        diagnostic_validity = DiagnosticValidity.PARTIAL
+    elif diagnostics_available is False:
+        diagnostic_validity = DiagnosticValidity.UNAVAILABLE
+    else:
+        diagnostic_validity = DiagnosticValidity.NOT_EVALUATED
+
+    if initialized_only or recovered_from_failure:
+        usability = ScientificUsability.LIMITED
+    elif diagnostic_validity is DiagnosticValidity.VALID:
+        usability = ScientificUsability.USABLE
+    elif diagnostic_validity in {
+        DiagnosticValidity.PARTIAL,
+        DiagnosticValidity.UNAVAILABLE,
+        DiagnosticValidity.NOT_EVALUATED,
+    }:
+        usability = ScientificUsability.LIMITED
+    else:
+        usability = ScientificUsability.UNUSABLE
+
+    comparison = (
+        ComparisonEligibility.ELIGIBLE
+        if (
+            diagnostic_validity is DiagnosticValidity.VALID
+            and not initialized_only
+        )
+        else ComparisonEligibility.INELIGIBLE
+    )
+
+    severity = WarningSeverity.WARNING if warning_count > 0 else None
+    return WavelengthAttemptStatus(
+        disposition=disposition,
+        execution_stage=ExecutionStage.COMPLETED,
+        technical_outcome=technical,
+        diagnostic_validity=diagnostic_validity,
+        scientific_usability=usability,
+        comparison_eligibility=comparison,
+        warning_severity=severity,
+    )

--- a/tests/test_docs_wavelength_attempt_statuses.py
+++ b/tests/test_docs_wavelength_attempt_statuses.py
@@ -1,0 +1,63 @@
+"""Documentation contracts for canonical wavelength-attempt statuses."""
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class TestWavelengthAttemptStatusDocumentation(unittest.TestCase):
+    def test_api_reference_exposes_status_module(self):
+        api = (ROOT / "docs/source/api.rst").read_text(encoding="utf-8")
+        page = ROOT / "docs/source/pgmuvi.wavelength_status.rst"
+        self.assertTrue(page.exists())
+        self.assertIn("pgmuvi.wavelength_status", api)
+        self.assertIn("automodule:: pgmuvi.wavelength_status", page.read_text())
+
+    def test_single_source_guide_documents_orthogonal_statuses(self):
+        text = (ROOT / "docs/source/howto/wavelength_advisory.rst").read_text(
+            encoding="utf-8"
+        )
+        for field in (
+            "attempt_disposition",
+            "execution_stage",
+            "technical_outcome",
+            "diagnostic_validity",
+            "scientific_usability",
+            "comparison_eligibility",
+            'technical_outcome="initialized_only"',
+        ):
+            self.assertIn(field, text)
+
+    def test_interpretation_guide_documents_failure_and_recovery_semantics(self):
+        text = (ROOT / "docs/source/howto/interpreting_results.rst").read_text(
+            encoding="utf-8"
+        )
+        for term in (
+            "completed_with_warnings",
+            "completed_with_recovery",
+            "failure_code",
+            "failure_substage",
+            "comparison-ineligible",
+        ):
+            self.assertIn(term, text)
+
+    def test_batch_guide_documents_canonical_long_form_columns(self):
+        text = (ROOT / "docs/source/howto/wavelength_advisory_batch.rst").read_text(
+            encoding="utf-8"
+        )
+        for field in (
+            "attempt_disposition",
+            "technical_outcome",
+            "diagnostic_validity",
+            "comparison_eligibility",
+            "warning_severity",
+            "failure_code",
+            "failure_substage",
+        ):
+            self.assertIn(field, text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_period_independent_wavelength_advisory_workflow_batch.py
+++ b/tests/test_period_independent_wavelength_advisory_workflow_batch.py
@@ -192,6 +192,36 @@ class TestPeriodIndependentWavelengthAdvisoryWorkflowBatch(unittest.TestCase):
             )
         )
 
+    def test_source_rows_include_canonical_status_dimensions(self):
+        report = run_period_independent_wavelength_advisory_workflow_batch(
+            [{"source_id": "src", "lightcurve": _FakeLightcurve()}],
+            export=False,
+        )
+        source = report["source_results"][0]
+        self.assertEqual(source["status"], "passed")
+        self.assertEqual(source["attempt_disposition"], "attempted")
+        self.assertEqual(source["execution_stage"], "completed")
+        self.assertEqual(source["technical_outcome"], "completed")
+        self.assertEqual(source["diagnostic_validity"], "valid")
+        self.assertEqual(source["scientific_usability"], "usable")
+        self.assertEqual(source["comparison_eligibility"], "eligible")
+
+    def test_failed_source_rows_include_structured_failure_status(self):
+        report = run_period_independent_wavelength_advisory_workflow_batch(
+            [{"source_id": "bad", "lightcurve": _FakeLightcurve(fail=True)}],
+            export=False,
+        )
+        source = report["source_results"][0]
+        self.assertEqual(source["technical_outcome"], "failed")
+        self.assertEqual(source["scientific_usability"], "unusable")
+        self.assertEqual(source["comparison_eligibility"], "ineligible")
+        self.assertEqual(source["failure_code"], "source_optimization_failed")
+        self.assertEqual(source["failure_stage"], "optimization")
+        self.assertEqual(
+            source["structured_failure_record"]["failure_code"],
+            "source_optimization_failed",
+        )
+
     def test_report_contract_is_advisory_and_nonselecting(self):
         report = run_period_independent_wavelength_advisory_workflow_batch(
             [{"source_id": "src", "lightcurve": _FakeLightcurve()}],

--- a/tests/test_period_independent_wavelength_model_kernel_config_quality.py
+++ b/tests/test_period_independent_wavelength_model_kernel_config_quality.py
@@ -296,6 +296,30 @@ class TestPeriodIndependentWavelengthModelKernelConfigQuality(unittest.TestCase)
         self.assertEqual(valid["quality_rank"], 1)
         self.assertFalse(valid["is_top_ranked"])
 
+    def test_comparison_ineligible_attempt_remains_unscored(self):
+        run_report = _quality_run_report()
+        run_report["model_kernel_config_results"][0][
+            "comparison_eligibility"
+        ] = "ineligible"
+        run_report["model_kernel_config_results"][0][
+            "technical_outcome"
+        ] = "initialized_only"
+
+        report = score_period_independent_wavelength_model_kernel_config_quality(
+            run_report
+        )
+        row = next(
+            item
+            for item in report["ranked_results"]
+            if item["model"] == "2DWavelengthDependent"
+        )
+
+        self.assertFalse(row["fit_quality_available"])
+        self.assertIsNone(row["fit_quality_score"])
+        self.assertEqual(row["comparison_eligibility"], "ineligible")
+        self.assertEqual(row["technical_outcome"], "initialized_only")
+        self.assertIn("comparison-ineligible", row["score_components"][0])
+
     def test_report_aliases_are_present(self):
         report = score_period_independent_wavelength_model_kernel_config_quality(
             _quality_run_report()

--- a/tests/test_wavelength_advisory_failure_fallback.py
+++ b/tests/test_wavelength_advisory_failure_fallback.py
@@ -78,6 +78,50 @@ class TestWavelengthAdvisoryFailureFallback(unittest.TestCase):
         self.assertEqual(fallback["n_numerical_failure_models"], 1)
         self.assertTrue(fallback["recommended_next_steps"])
 
+    def test_fallback_summary_surfaces_canonical_status_counts(self):
+        run_report = {
+            "outcomes": [
+                {
+                    "status": "passed",
+                    "fit_success": True,
+                    "model": "2DDustMean",
+                    "technical_outcome": "initialized_only",
+                    "comparison_eligibility": "ineligible",
+                },
+                {
+                    "status": "failed",
+                    "fit_failed": True,
+                    "model": "2D",
+                    "technical_outcome": "failed",
+                    "comparison_eligibility": "ineligible",
+                    "failure_code": "no_accepted_bands",
+                },
+            ]
+        }
+        quality_report = {
+            "ranking_status": "unavailable",
+            "fit_quality_ranking_available": False,
+            "n_with_fit_quality": 0,
+        }
+
+        fallback = _piwd_build_advisory_workflow_fallback_summary(
+            run_report, quality_report
+        )
+
+        self.assertEqual(
+            fallback["technical_outcome_counts"],
+            {"initialized_only": 1, "failed": 1},
+        )
+        self.assertEqual(
+            fallback["failure_code_counts"],
+            {"no_accepted_bands": 1},
+        )
+        self.assertEqual(fallback["initialized_only_models"], ["2DDustMean"])
+        self.assertEqual(
+            fallback["comparison_ineligible_models"],
+            ["2DDustMean", "2D"],
+        )
+
     def test_fallback_summary_is_inactive_when_comparative_ranking_exists(self):
         run_report = {
             "outcomes": [
@@ -163,8 +207,18 @@ class TestWavelengthAdvisoryFailureFallback(unittest.TestCase):
                         "rank": 1,
                         "model": "2D",
                         "status": "failed",
+                        "attempt_disposition": "attempted",
+                        "execution_stage": "consensus",
+                        "technical_outcome": "failed",
+                        "diagnostic_validity": "partial",
+                        "scientific_usability": "unusable",
+                        "comparison_eligibility": "ineligible",
+                        "warning_severity": "error",
+                        "warning_count": 0,
                         "fit_failed": True,
+                        "failure_code": "no_accepted_bands",
                         "failure_stage": "consensus",
+                        "failure_substage": "band_quality",
                         "failure_stage_reason": "fit failed while deriving consensus",
                         "is_consensus_failure": True,
                         "is_numerical_failure": False,
@@ -185,7 +239,11 @@ class TestWavelengthAdvisoryFailureFallback(unittest.TestCase):
 
         self.assertEqual(len(rows), 1)
         row = rows[0]
+        self.assertEqual(row["technical_outcome"], "failed")
+        self.assertEqual(row["comparison_eligibility"], "ineligible")
+        self.assertEqual(row["failure_code"], "no_accepted_bands")
         self.assertEqual(row["failure_stage"], "consensus")
+        self.assertEqual(row["failure_substage"], "band_quality")
         self.assertIs(row["is_consensus_failure"], True)
         self.assertEqual(row["exception_type"], "ConsensusFitError")
 

--- a/tests/test_wavelength_attempt_statuses.py
+++ b/tests/test_wavelength_attempt_statuses.py
@@ -1,0 +1,188 @@
+"""Tests for canonical wavelength-advisory attempt and failure statuses."""
+
+import unittest
+import warnings
+from unittest import mock
+
+from pgmuvi.lightcurve import FitFailureSummary, Lightcurve
+from pgmuvi.wavelength_diagnostics import (
+    _piwd_extract_fit_outcome,
+    run_period_independent_wavelength_model_kernel_configs,
+)
+
+
+class _CandidateLightcurve:
+    def __init__(self):
+        self.consensus_diagnostics = {"consensus_success": True}
+        self.results = None
+
+
+class TestAttemptOutcomeCompatibility(unittest.TestCase):
+    def setUp(self):
+        self.candidate = {
+            "model_kernel_config_id": "cfg",
+            "rank": 1,
+            "model": "2DDustMean",
+            "fit_kwargs": {"training_iter": 0},
+        }
+
+    def test_legacy_fields_remain_while_canonical_fields_are_added(self):
+        outcome = _piwd_extract_fit_outcome(
+            self.candidate,
+            status="passed",
+            fitted_lightcurve=_CandidateLightcurve(),
+            fit_result={},
+        )
+        self.assertEqual(outcome["status"], "passed")
+        self.assertTrue(outcome["fit_success"])
+        self.assertFalse(outcome["fit_failed"])
+        self.assertEqual(outcome["attempt_disposition"], "attempted")
+        self.assertEqual(outcome["technical_outcome"], "initialized_only")
+        self.assertEqual(outcome["comparison_eligibility"], "ineligible")
+
+    def test_recovery_metadata_changes_technical_outcome(self):
+        candidate = dict(self.candidate)
+        candidate["fit_kwargs"] = {"training_iter": 20}
+        outcome = _piwd_extract_fit_outcome(
+            candidate,
+            status="passed",
+            fitted_lightcurve=_CandidateLightcurve(),
+            fit_result={"training_recovered_from_failure": True},
+        )
+        self.assertEqual(outcome["technical_outcome"], "completed_with_recovery")
+        self.assertTrue(outcome["training_recovered_from_failure"])
+
+    def test_structured_failure_diagnostics_and_summary_survive(self):
+        class StructuredFailure(RuntimeError):
+            pass
+
+        exc = StructuredFailure("consensus failed")
+        exc.failure_diagnostics = {
+            "status": "failed",
+            "reason": "no_accepted_bands",
+            "failure_stage": "band_quality",
+        }
+        exc.failure_summary = FitFailureSummary(
+            reason="no_accepted_bands",
+            message="consensus failed",
+            failure_code="no_accepted_bands",
+            stage="consensus",
+            substage="band_quality",
+            exception_type="StructuredFailure",
+        )
+        outcome = _piwd_extract_fit_outcome(
+            self.candidate,
+            status="failed",
+            fitted_lightcurve=_CandidateLightcurve(),
+            exception=exc,
+        )
+        self.assertEqual(outcome["technical_outcome"], "failed")
+        self.assertEqual(outcome["failure_code"], "no_accepted_bands")
+        self.assertEqual(outcome["failure_stage"], "consensus")
+        self.assertEqual(outcome["failure_substage"], "band_quality")
+        self.assertEqual(
+            outcome["structured_failure_diagnostics"]["reason"],
+            "no_accepted_bands",
+        )
+        self.assertEqual(
+            outcome["failure_summary"]["failure_code"],
+            "no_accepted_bands",
+        )
+        self.assertEqual(outcome["traceback_reference"], "inline:traceback")
+        self.assertEqual(outcome["diagnostic_validity"], "unavailable")
+
+    def test_consensus_failure_with_band_evidence_is_partial(self):
+        class StructuredFailure(RuntimeError):
+            pass
+
+        exc = StructuredFailure("consensus failed")
+        exc.failure_diagnostics = {
+            "reason": "no_accepted_bands",
+            "failure_stage": "band_quality",
+            "accepted_bands": [],
+            "rejected_bands": ["g", "r"],
+            "per_band_diagnostics": {"g": {}, "r": {}},
+        }
+        outcome = _piwd_extract_fit_outcome(
+            self.candidate,
+            status="failed",
+            fitted_lightcurve=_CandidateLightcurve(),
+            exception=exc,
+        )
+        self.assertEqual(outcome["diagnostic_validity"], "partial")
+        self.assertEqual(outcome["scientific_usability"], "unusable")
+        self.assertEqual(outcome["comparison_eligibility"], "ineligible")
+
+
+class TestRunnerWarningAndOutcomeCounts(unittest.TestCase):
+    def test_runner_captures_warnings_and_counts_outcomes(self):
+        report = {
+            "kind": "period_independent_wavelength_model_kernel_configs",
+            "model_kernel_configs": [
+                {
+                    "model_kernel_config_id": "cfg",
+                    "rank": 1,
+                    "model": "2DDustMean",
+                    "fit_kwargs": {"model": "2DDustMean", "training_iter": 5},
+                }
+            ],
+        }
+        source = _CandidateLightcurve()
+
+        def runner(candidate_lc, fit_kwargs, candidate):
+            warnings.warn("synthetic warning", UserWarning)
+            candidate_lc.consensus_diagnostics = {"consensus_success": True}
+            return {}
+
+        with self.assertWarnsRegex(UserWarning, "synthetic warning"):
+            outcome_report = (
+                run_period_independent_wavelength_model_kernel_configs(
+                    source,
+                    model_kernel_config_report=report,
+                    fit_runner=runner,
+                )
+            )
+        outcome = outcome_report["outcomes"][0]
+        self.assertEqual(outcome["technical_outcome"], "completed_with_warnings")
+        self.assertEqual(outcome["warning_count"], 1)
+        self.assertEqual(outcome["warning_severity"], "warning")
+        self.assertEqual(outcome["warning_records"][0]["category"], "UserWarning")
+        self.assertIsInstance(outcome["warning_records"][0]["lineno"], int)
+        self.assertEqual(
+            outcome_report["technical_outcome_counts"],
+            {"completed_with_warnings": 1},
+        )
+
+
+class TestOuterFitFailureState(unittest.TestCase):
+    def test_non_consensus_fit_exception_sets_canonical_failure_state(self):
+        lc = Lightcurve([0.0, 1.0, 2.0], [1.0, 2.0, 3.0])
+        with mock.patch.object(
+            lc,
+            "_fit_core",
+            side_effect=ValueError("synthetic outer failure"),
+        ):
+            with self.assertRaisesRegex(ValueError, "synthetic outer failure"):
+                lc.fit(model="1D", training_iter=1)
+
+        self.assertTrue(lc.fit_failed)
+        self.assertFalse(lc.is_fitted)
+        self.assertEqual(lc.failure_reason, "fit_exception")
+        self.assertIsNotNone(lc.failure_summary)
+        summary = lc.failure_summary.to_dict()
+        self.assertEqual(summary["failure_code"], "fit_execution_failed")
+        self.assertEqual(summary["stage"], "fit_execution")
+        self.assertEqual(summary["substage"], "outer_fit")
+        self.assertEqual(summary["exception_type"], "ValueError")
+        self.assertEqual(
+            summary["traceback_reference"],
+            "failure_diagnostics.traceback",
+        )
+        self.assertIn("ValueError: synthetic outer failure", summary["diagnostics"]["traceback"])
+        self.assertFalse(
+            summary["diagnostics"].get("is_consensus_failure")
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wavelength_status_types.py
+++ b/tests/test_wavelength_status_types.py
@@ -1,0 +1,136 @@
+"""Unit tests for canonical wavelength-advisory status types."""
+
+import json
+import unittest
+
+from pgmuvi.wavelength_status import (
+    AttemptDisposition,
+    ComparisonEligibility,
+    DiagnosticValidity,
+    ExecutionStage,
+    ScientificUsability,
+    TechnicalOutcome,
+    WarningSeverity,
+    WavelengthAttemptStatus,
+    WavelengthFailureRecord,
+    derive_wavelength_attempt_status,
+)
+
+
+class TestWavelengthStatusEnums(unittest.TestCase):
+    def test_string_enums_serialize_as_stable_values(self):
+        self.assertEqual(str(TechnicalOutcome.COMPLETED), "completed")
+        payload = WavelengthAttemptStatus(
+            disposition=AttemptDisposition.ATTEMPTED,
+            execution_stage=ExecutionStage.COMPLETED,
+            technical_outcome=TechnicalOutcome.COMPLETED,
+            diagnostic_validity=DiagnosticValidity.VALID,
+            scientific_usability=ScientificUsability.USABLE,
+            comparison_eligibility=ComparisonEligibility.ELIGIBLE,
+            warning_severity=None,
+        ).to_dict()
+        self.assertEqual(payload["attempt_disposition"], "attempted")
+        self.assertEqual(payload["comparison_eligibility"], "eligible")
+        json.dumps(payload)
+
+    def test_initialized_only_is_limited_and_comparison_ineligible(self):
+        status = derive_wavelength_attempt_status(
+            legacy_status="passed",
+            training_iter=0,
+            diagnostics_available=True,
+        )
+        self.assertEqual(status.technical_outcome, TechnicalOutcome.INITIALIZED_ONLY)
+        self.assertEqual(status.scientific_usability, ScientificUsability.LIMITED)
+        self.assertEqual(
+            status.comparison_eligibility,
+            ComparisonEligibility.INELIGIBLE,
+        )
+
+    def test_skipped_attempt_is_comparison_ineligible(self):
+        status = derive_wavelength_attempt_status(legacy_status="skipped")
+        self.assertEqual(status.disposition, AttemptDisposition.SKIPPED)
+        self.assertEqual(status.execution_stage, ExecutionStage.PRECONDITION)
+        self.assertEqual(status.technical_outcome, TechnicalOutcome.SKIPPED)
+        self.assertEqual(
+            status.comparison_eligibility,
+            ComparisonEligibility.INELIGIBLE,
+        )
+
+    def test_completed_without_diagnostics_is_limited_and_ineligible(self):
+        status = derive_wavelength_attempt_status(
+            legacy_status="passed",
+            training_iter=20,
+            diagnostics_available=False,
+        )
+        self.assertEqual(status.technical_outcome, TechnicalOutcome.COMPLETED)
+        self.assertEqual(
+            status.diagnostic_validity, DiagnosticValidity.UNAVAILABLE
+        )
+        self.assertEqual(status.scientific_usability, ScientificUsability.LIMITED)
+        self.assertEqual(
+            status.comparison_eligibility,
+            ComparisonEligibility.INELIGIBLE,
+        )
+
+    def test_recovered_fit_is_explicit(self):
+        status = derive_wavelength_attempt_status(
+            legacy_status="passed",
+            training_iter=20,
+            recovered_from_failure=True,
+            diagnostics_available=True,
+        )
+        self.assertEqual(
+            status.technical_outcome,
+            TechnicalOutcome.COMPLETED_WITH_RECOVERY,
+        )
+        self.assertEqual(status.scientific_usability, ScientificUsability.LIMITED)
+        self.assertEqual(
+            status.comparison_eligibility,
+            ComparisonEligibility.ELIGIBLE,
+        )
+
+    def test_completed_with_warnings_has_structured_severity(self):
+        status = derive_wavelength_attempt_status(
+            legacy_status="passed",
+            training_iter=20,
+            diagnostics_available=True,
+            warning_count=2,
+        )
+        self.assertEqual(
+            status.technical_outcome,
+            TechnicalOutcome.COMPLETED_WITH_WARNINGS,
+        )
+        self.assertEqual(status.warning_severity, WarningSeverity.WARNING)
+
+    def test_failed_attempt_uses_failure_stage(self):
+        status = derive_wavelength_attempt_status(
+            legacy_status="failed",
+            diagnostics_partial=True,
+            failure_stage="consensus",
+        )
+        self.assertEqual(status.disposition, AttemptDisposition.ATTEMPTED)
+        self.assertEqual(status.execution_stage, ExecutionStage.CONSENSUS)
+        self.assertEqual(status.technical_outcome, TechnicalOutcome.FAILED)
+        self.assertEqual(status.diagnostic_validity, DiagnosticValidity.PARTIAL)
+        self.assertEqual(status.scientific_usability, ScientificUsability.UNUSABLE)
+        self.assertEqual(
+            status.comparison_eligibility,
+            ComparisonEligibility.INELIGIBLE,
+        )
+
+    def test_failure_record_is_json_safe(self):
+        record = WavelengthFailureRecord(
+            failure_code="no_accepted_bands",
+            stage=ExecutionStage.CONSENSUS,
+            substage="band_quality",
+            exception_type="ConsensusFitError",
+            message="no consensus",
+            diagnostics={"reason": "no_accepted_bands"},
+            traceback_reference="inline:traceback",
+        ).to_dict()
+        self.assertEqual(record["failure_stage"], "consensus")
+        json.dumps(record)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- introduce canonical orthogonal status types for wavelength-model attempts
- represent execution stage, technical outcome, diagnostic validity, scientific usability, comparison eligibility, and warning severity separately
- preserve the existing legacy status and fit-success fields for compatibility
- add structured failure records with failure code, stage, exception type, summary, and traceback reference
- propagate canonical statuses through candidate outcomes, quality rows, fallback summaries, source-level batch rows, and long-form exports
- distinguish initialization-only, warning-completed, recovered, failed, and skipped attempts
- preserve structured consensus failure diagnostics and summaries
- add canonical failure metadata to non-consensus `Lightcurve.fit()` exceptions
- prevent diagnostically unavailable attempts from entering comparative rankings
- add focused regression tests and public API documentation

## Validation

- targeted B1 tests passed
- Ruff CI-equivalent check passed
- strict Sphinx documentation build passed
- full test suite passed
