### PR TITLE
Classify wavelength model hypotheses explicitly

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -58,6 +58,7 @@ Data, diagnostics, and validation
    pgmuvi.preprocess
    pgmuvi.multiband_ls_significance
    pgmuvi.wavelength_diagnostics
+   pgmuvi.wavelength_hypotheses
    pgmuvi.wavelength_results
    pgmuvi.wavelength_status
    pgmuvi.upload_validation

--- a/docs/source/howto/interpreting_results.rst
+++ b/docs/source/howto/interpreting_results.rst
@@ -387,6 +387,26 @@ one valid candidate.  Inspect ``fit_quality_ranking_status``,
 Do not turn an all-failed or single-survivor advisory run into a winner.  Fix or
 narrow the workflow, then rerun the relevant configurations.
 
+Mean and covariance hypothesis fields
+-------------------------------------
+
+Read ``model_hypothesis`` before attributing a score difference to one physical
+mechanism.  The fields ``mean_structure`` and ``covariance_structure`` are
+orthogonal descriptions of the complete model/kernel configuration.
+``mean_wavelength_dependent`` and ``covariance_wavelength_dependent`` make that
+separation explicit.
+
+``2DDustMean`` and ``2DPowerLawMean`` are not mean-only alternatives: both also
+contain smooth wavelength covariance.  ``2DWavelengthDependent`` likewise
+changes the mean and covariance relative to the constant-mean separable model.
+``2D`` uses a joint non-separable spectral-mixture covariance and should be read
+as a baseline with a different parameterization, not as a nested special case.
+
+The ``comparison_cautions`` list is part of the report precisely because
+current training-residual rankings cannot identify which changed mechanism
+caused a score difference.  Use the taxonomy for interpretation and grouping,
+not as a substitute score or automatic selection policy.
+
 Typed evidence roles
 --------------------
 

--- a/docs/source/howto/wavelength_advisory.rst
+++ b/docs/source/howto/wavelength_advisory.rst
@@ -437,6 +437,54 @@ The export helper writes files only.  It does not run fits unless the
 ``Lightcurve`` convenience method is called without a precomputed ``workflow``
 and supplied with explicit ``run_workflow_kwargs``.
 
+Explicit model-hypothesis metadata
+----------------------------------
+
+Each generated model/kernel configuration now includes a
+``model_hypothesis`` mapping.  This mapping records the mean structure and
+covariance structure as separate axes.  The public model string still names a
+complete GP configuration; it is not treated as an isolated physical
+mechanism.
+
+For the LPV-focused configurations this distinction is important:
+
+``2D``
+   Constant mean with one joint, non-separable two-dimensional
+   spectral-mixture covariance.  It remains a baseline rather than a member of
+   the separable family.
+
+``2DSeparable``
+   Constant mean with a separable product of time and wavelength covariance
+   kernels.
+
+``2DWavelengthDependent``
+   Quadratic wavelength-dependent mean together with separable smooth
+   wavelength covariance.
+
+``2DDustMean`` and ``2DPowerLawMean``
+   Dust or power-law wavelength means together with the same broad family of
+   separable smooth wavelength covariance.  These are therefore not
+   ``mean-only`` hypotheses.
+
+The metadata is descriptive and versioned.  It does not change advisory order,
+fit kwargs, scores, or comparison eligibility.  In particular, a better score
+for ``2DDustMean`` than ``2DSeparable`` does not by itself isolate evidence for
+the dust mean law because the compared objects are complete model/kernel
+configurations.
+
+The maintained LPV advisory priority remains:
+
+.. code-block:: text
+
+   2DWavelengthDependent
+   2DDustMean
+   2DPowerLawMean
+   2DSeparable
+   2D
+
+``2DAchromatic`` is represented only as an explicit achromatic-control taxonomy
+entry and is not part of that default LPV priority ordering.
+
 Typed result adapters
 ---------------------
 

--- a/docs/source/pgmuvi.wavelength_hypotheses.rst
+++ b/docs/source/pgmuvi.wavelength_hypotheses.rst
@@ -1,0 +1,7 @@
+Wavelength-model hypothesis taxonomy
+====================================
+
+.. automodule:: pgmuvi.wavelength_hypotheses
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/pgmuvi/__init__.py
+++ b/pgmuvi/__init__.py
@@ -22,6 +22,7 @@ __all__ = [
     "synthetic",
     "trainers",
     "wavelength_diagnostics",
+    "wavelength_hypotheses",
     "wavelength_results",
     "wavelength_status",
 ]

--- a/pgmuvi/wavelength_diagnostics.py
+++ b/pgmuvi/wavelength_diagnostics.py
@@ -23,6 +23,11 @@ except ImportError:  # pragma: no cover - pgmuvi normally depends on torch
 
 from pgmuvi.preprocess.quality import assess_sampling_quality, robust_scale
 from pgmuvi.preprocess.variability import is_variable
+from pgmuvi.wavelength_hypotheses import (
+    WAVELENGTH_HYPOTHESIS_SCHEMA_VERSION,
+    WavelengthModelHypothesis,
+    describe_wavelength_model_hypothesis,
+)
 from pgmuvi.wavelength_status import (
     ExecutionStage,
     WarningSeverity,
@@ -3539,6 +3544,9 @@ def build_period_independent_wavelength_model_kernel_configs(
             "parameter_suggestions": (
                 suggestions.get(model) if include_parameter_suggestions else None
             ),
+            "model_hypothesis": describe_wavelength_model_hypothesis(
+                model, fit_kwargs=fit_kwargs
+            ).to_dict(),
         }
         candidates.append(candidate)
 
@@ -3572,6 +3580,9 @@ def build_period_independent_wavelength_model_kernel_configs(
                 "parameter_suggestions_applied": False,
                 "applies_constraints": False,
                 "parameter_suggestions": None,
+                "model_hypothesis": describe_wavelength_model_hypothesis(
+                    "2D", fit_kwargs=baseline_kwargs
+                ).to_dict(),
             }
         )
 
@@ -3589,6 +3600,7 @@ def build_period_independent_wavelength_model_kernel_configs(
             "kind": "period_independent_wavelength_model_kernel_configs",
             "stage": "prefit_period_independent_model_kernel_config",
             "source_plan_kind": plan.get("kind"),
+            "hypothesis_schema_version": WAVELENGTH_HYPOTHESIS_SCHEMA_VERSION,
             "is_period_independent": True,
             "uses_temporal_consensus": False,
             "uses_period_or_frequency": False,
@@ -3606,6 +3618,7 @@ def build_period_independent_wavelength_model_kernel_configs(
                 "Parameter suggestions are metadata only and are not inserted into fit_kwargs.",
                 "LPV separable candidates default to time_kernel_type='quasi_periodic' to use the PR55 period_length handoff.",
                 "The 2D baseline keeps its existing spectral-mixture time-kernel default unless base_fit_kwargs overrides it.",
+                "Model-hypothesis metadata records mean and covariance roles separately and is descriptive rather than selecting.",
             ],
         }
     )
@@ -3638,6 +3651,15 @@ def _piwd_validate_model_kernel_config_report(report: dict[str, Any]) -> list[di
         copied["rank"] = int(copied.get("rank") or index)
         copied["model"] = str(copied.get("model") or fit_kwargs.get("model"))
         copied["fit_kwargs"] = dict(fit_kwargs)
+        hypothesis = copied.get("model_hypothesis")
+        if isinstance(hypothesis, dict):
+            copied["model_hypothesis"] = WavelengthModelHypothesis.from_mapping(
+                hypothesis
+            ).to_dict()
+        else:
+            copied["model_hypothesis"] = describe_wavelength_model_hypothesis(
+                copied["model"], fit_kwargs=copied["fit_kwargs"]
+            ).to_dict()
         normalized.append(copied)
     return normalized
 
@@ -4562,6 +4584,7 @@ def _piwd_extract_fit_outcome(
         "model_kernel_config_id": candidate.get("model_kernel_config_id"),
         "rank": candidate.get("rank"),
         "model": candidate.get("model"),
+        "model_hypothesis": candidate.get("model_hypothesis"),
         "status": status,
         **attempt_status.to_dict(),
         "fit_success": bool(status == "passed"),
@@ -4777,6 +4800,7 @@ def run_period_independent_wavelength_model_kernel_configs(
             "kind": "period_independent_wavelength_model_kernel_config_results",
             "stage": "model_kernel_config_fit_execution_summary",
             "source_model_kernel_config_report_kind": model_kernel_config_report.get("kind"),
+            "hypothesis_schema_version": WAVELENGTH_HYPOTHESIS_SCHEMA_VERSION,
             "is_period_independent": True,
             "uses_temporal_consensus": True,
             "uses_period_or_frequency": True,
@@ -4902,6 +4926,7 @@ def _piwd_score_one_wavelength_fit_outcome(
         {
             "rank": outcome.get("rank"),
             "model": outcome.get("model"),
+            "model_hypothesis": outcome.get("model_hypothesis"),
             "status": status,
             "fit_success": fit_success,
             "consensus_success": consensus_success,
@@ -5097,6 +5122,7 @@ def _piwd_score_one_wavelength_fit_quality(scored_or_outcome: dict[str, Any]) ->
         {
             "rank": outcome.get("rank"),
             "model": outcome.get("model"),
+            "model_hypothesis": outcome.get("model_hypothesis"),
             "status": outcome.get("status"),
             "attempt_disposition": outcome.get("attempt_disposition"),
             "execution_stage": outcome.get("execution_stage"),

--- a/pgmuvi/wavelength_hypotheses.py
+++ b/pgmuvi/wavelength_hypotheses.py
@@ -1,0 +1,474 @@
+"""Explicit scientific-hypothesis metadata for wavelength GP models.
+
+The public model strings used by PGMUVI describe complete GP configurations,
+not isolated scientific mechanisms.  In particular, the LPV-focused
+``2DDustMean`` and ``2DPowerLawMean`` models combine a wavelength-dependent
+mean with the same family of smooth separable wavelength covariance used by
+``2DWavelengthDependent``.  This module records those orthogonal mean and
+covariance roles explicitly so advisory reports do not imply that a score
+change can automatically be attributed to one mechanism.
+
+The taxonomy is descriptive only.  It does not rank, select, instantiate, or
+fit a model.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field, replace
+from enum import Enum
+from typing import Any
+
+WAVELENGTH_HYPOTHESIS_SCHEMA_VERSION = "pgmuvi-wavelength-hypotheses-v1"
+
+LPV_WAVELENGTH_MODEL_PRIORITY = (
+    "2DWavelengthDependent",
+    "2DDustMean",
+    "2DPowerLawMean",
+    "2DSeparable",
+    "2D",
+)
+
+__all__ = [
+    "LPV_WAVELENGTH_MODEL_PRIORITY",
+    "WAVELENGTH_HYPOTHESIS_SCHEMA_VERSION",
+    "WavelengthCovarianceStructure",
+    "WavelengthHypothesisRole",
+    "WavelengthMeanStructure",
+    "WavelengthModelHypothesis",
+    "describe_wavelength_model_hypothesis",
+]
+
+
+class _StringEnum(str, Enum):
+    """Enum whose values serialize as stable public strings."""
+
+    def __str__(self) -> str:
+        return self.value
+
+
+class WavelengthMeanStructure(_StringEnum):
+    """How a complete model represents wavelength dependence in its mean."""
+
+    CONSTANT = "constant"
+    LINEAR = "linear"
+    QUADRATIC = "quadratic"
+    DUST_ATTENUATION = "dust_attenuation"
+    POWER_LAW = "power_law"
+    CUSTOM = "custom"
+    UNKNOWN = "unknown"
+
+
+class WavelengthCovarianceStructure(_StringEnum):
+    """How a complete model represents cross-wavelength covariance."""
+
+    JOINT_2D_SPECTRAL_MIXTURE = "joint_2d_spectral_mixture"
+    SEPARABLE_PRODUCT = "separable_product"
+    SEPARABLE_SMOOTH_WAVELENGTH = "separable_smooth_wavelength"
+    ACHROMATIC_CONSTANT_WAVELENGTH = "achromatic_constant_wavelength"
+    CUSTOM = "custom"
+    UNKNOWN = "unknown"
+
+
+class WavelengthHypothesisRole(_StringEnum):
+    """Broad interpretive role of a complete wavelength-model configuration."""
+
+    JOINT_BASELINE = "joint_baseline"
+    COVARIANCE_FOCUSED = "covariance_focused"
+    MEAN_AND_COVARIANCE = "mean_and_covariance"
+    ACHROMATIC_CONTROL = "achromatic_control"
+    UNKNOWN = "unknown"
+
+
+def _string_tuple(value: Any) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return (value,)
+    if isinstance(value, Sequence):
+        return tuple(str(item) for item in value)
+    return (str(value),)
+
+
+def _json_safe(value: Any) -> Any:
+    """Return a deterministic JSON-safe copy of public metadata."""
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, Mapping):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, Sequence) and not isinstance(
+        value, (str, bytes, bytearray)
+    ):
+        return [_json_safe(item) for item in value]
+    return str(value)
+
+
+def _coerce_enum(enum_type, value: Any, default):
+    if isinstance(value, enum_type):
+        return value
+    try:
+        return enum_type(str(value))
+    except (TypeError, ValueError):
+        return default
+
+
+def _mean_structure_from_override(value: Any) -> WavelengthMeanStructure | None:
+    """Interpret a user-visible ``mean_module`` override when possible."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        return WavelengthMeanStructure.CUSTOM
+    normalized = value.strip().lower()
+    if normalized in {"constant", "constant_mean"}:
+        return WavelengthMeanStructure.CONSTANT
+    if normalized in {"linear", "linear_mean"}:
+        return WavelengthMeanStructure.LINEAR
+    if normalized in {"quad", "quadratic", "quad_constant"}:
+        return WavelengthMeanStructure.QUADRATIC
+    if normalized in {"dust", "dust_mean"}:
+        return WavelengthMeanStructure.DUST_ATTENUATION
+    if normalized in {"power_law", "power_law_mean"}:
+        return WavelengthMeanStructure.POWER_LAW
+    return WavelengthMeanStructure.CUSTOM
+
+
+def _mean_is_wavelength_dependent(
+    structure: WavelengthMeanStructure,
+) -> bool | None:
+    if structure is WavelengthMeanStructure.UNKNOWN:
+        return None
+    return structure is not WavelengthMeanStructure.CONSTANT
+
+
+@dataclass(frozen=True)
+class WavelengthModelHypothesis:
+    """Orthogonal mean/covariance description of one complete GP model.
+
+    ``lpv_advisory_priority`` is descriptive ordering metadata only.  It is not
+    a model score, selection decision, or guarantee that a model is suitable
+    for a particular light curve.
+    """
+
+    model: str
+    role: WavelengthHypothesisRole
+    mean_structure: WavelengthMeanStructure
+    covariance_structure: WavelengthCovarianceStructure
+    mean_wavelength_dependent: bool | None
+    covariance_wavelength_dependent: bool | None
+    covariance_separable: bool | None
+    temporal_kernel_configurable: bool | None
+    baseline: bool = False
+    lpv_advisory_priority: int | None = None
+    summary: str | None = None
+    comparison_cautions: tuple[str, ...] = ()
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    schema_version: str = WAVELENGTH_HYPOTHESIS_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if not str(self.model).strip():
+            raise ValueError("WavelengthModelHypothesis.model must be non-empty.")
+        object.__setattr__(self, "model", str(self.model))
+        object.__setattr__(
+            self, "comparison_cautions", _string_tuple(self.comparison_cautions)
+        )
+        object.__setattr__(
+            self,
+            "metadata",
+            _json_safe(dict(self.metadata)),
+        )
+
+    @classmethod
+    def from_mapping(cls, payload: Mapping[str, Any]) -> WavelengthModelHypothesis:
+        """Construct from the stable public mapping representation."""
+        if not isinstance(payload, Mapping):
+            raise TypeError("payload must be a mapping")
+        model = str(payload.get("model") or "unknown")
+        default = describe_wavelength_model_hypothesis(model)
+        priority = payload.get(
+            "lpv_advisory_priority", default.lpv_advisory_priority
+        )
+        try:
+            priority = int(priority) if priority is not None else None
+        except (TypeError, ValueError):
+            priority = None
+        return cls(
+            model=model,
+            role=_coerce_enum(
+                WavelengthHypothesisRole,
+                payload.get("role"),
+                default.role,
+            ),
+            mean_structure=_coerce_enum(
+                WavelengthMeanStructure,
+                payload.get("mean_structure"),
+                default.mean_structure,
+            ),
+            covariance_structure=_coerce_enum(
+                WavelengthCovarianceStructure,
+                payload.get("covariance_structure"),
+                default.covariance_structure,
+            ),
+            mean_wavelength_dependent=payload.get(
+                "mean_wavelength_dependent",
+                default.mean_wavelength_dependent,
+            ),
+            covariance_wavelength_dependent=payload.get(
+                "covariance_wavelength_dependent",
+                default.covariance_wavelength_dependent,
+            ),
+            covariance_separable=payload.get(
+                "covariance_separable",
+                default.covariance_separable,
+            ),
+            temporal_kernel_configurable=payload.get(
+                "temporal_kernel_configurable",
+                default.temporal_kernel_configurable,
+            ),
+            baseline=bool(payload.get("baseline", default.baseline)),
+            lpv_advisory_priority=priority,
+            summary=payload.get("summary") or default.summary,
+            comparison_cautions=_string_tuple(
+                payload.get("comparison_cautions")
+                or default.comparison_cautions
+            ),
+            metadata=payload.get("metadata") or {},
+            schema_version=str(
+                payload.get("schema_version")
+                or WAVELENGTH_HYPOTHESIS_SCHEMA_VERSION
+            ),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a stable, JSON-safe dictionary."""
+        return {
+            "schema_version": self.schema_version,
+            "model": self.model,
+            "role": self.role.value,
+            "mean_structure": self.mean_structure.value,
+            "covariance_structure": self.covariance_structure.value,
+            "mean_wavelength_dependent": self.mean_wavelength_dependent,
+            "covariance_wavelength_dependent": (
+                self.covariance_wavelength_dependent
+            ),
+            "covariance_separable": self.covariance_separable,
+            "temporal_kernel_configurable": self.temporal_kernel_configurable,
+            "baseline": self.baseline,
+            "lpv_advisory_priority": self.lpv_advisory_priority,
+            "summary": self.summary,
+            "comparison_cautions": list(self.comparison_cautions),
+            "metadata": _json_safe(self.metadata),
+        }
+
+
+_COMMON_COMPLETE_CONFIG_CAUTION = (
+    "This label describes a complete mean-plus-covariance GP configuration, "
+    "not an isolated physical mechanism."
+)
+
+_BASE_HYPOTHESES = {
+    "2D": WavelengthModelHypothesis(
+        model="2D",
+        role=WavelengthHypothesisRole.JOINT_BASELINE,
+        mean_structure=WavelengthMeanStructure.CONSTANT,
+        covariance_structure=(
+            WavelengthCovarianceStructure.JOINT_2D_SPECTRAL_MIXTURE
+        ),
+        mean_wavelength_dependent=False,
+        covariance_wavelength_dependent=True,
+        covariance_separable=False,
+        temporal_kernel_configurable=False,
+        baseline=True,
+        lpv_advisory_priority=5,
+        summary=(
+            "Constant mean with one joint non-separable two-dimensional "
+            "spectral-mixture covariance over time and wavelength."
+        ),
+        comparison_cautions=(
+            _COMMON_COMPLETE_CONFIG_CAUTION,
+            "Its joint spectral-mixture covariance is not the same parameterization "
+            "as the separable LPV configurations.",
+        ),
+    ),
+    "2DSeparable": WavelengthModelHypothesis(
+        model="2DSeparable",
+        role=WavelengthHypothesisRole.COVARIANCE_FOCUSED,
+        mean_structure=WavelengthMeanStructure.CONSTANT,
+        covariance_structure=WavelengthCovarianceStructure.SEPARABLE_PRODUCT,
+        mean_wavelength_dependent=False,
+        covariance_wavelength_dependent=True,
+        covariance_separable=True,
+        temporal_kernel_configurable=True,
+        lpv_advisory_priority=4,
+        summary=(
+            "Constant mean with a separable product of configurable time and "
+            "wavelength covariance kernels."
+        ),
+        comparison_cautions=(
+            _COMMON_COMPLETE_CONFIG_CAUTION,
+            "A constant mean can leave wavelength-dependent baseline structure to "
+            "the covariance model or residuals.",
+        ),
+    ),
+    "2DWavelengthDependent": WavelengthModelHypothesis(
+        model="2DWavelengthDependent",
+        role=WavelengthHypothesisRole.MEAN_AND_COVARIANCE,
+        mean_structure=WavelengthMeanStructure.QUADRATIC,
+        covariance_structure=(
+            WavelengthCovarianceStructure.SEPARABLE_SMOOTH_WAVELENGTH
+        ),
+        mean_wavelength_dependent=True,
+        covariance_wavelength_dependent=True,
+        covariance_separable=True,
+        temporal_kernel_configurable=True,
+        lpv_advisory_priority=1,
+        summary=(
+            "Quadratic wavelength-dependent mean plus separable configurable "
+            "time covariance and smooth wavelength covariance."
+        ),
+        comparison_cautions=(
+            _COMMON_COMPLETE_CONFIG_CAUTION,
+            "A score difference from 2DSeparable changes both the mean structure "
+            "and potentially the instantiated covariance configuration.",
+        ),
+    ),
+    "2DDustMean": WavelengthModelHypothesis(
+        model="2DDustMean",
+        role=WavelengthHypothesisRole.MEAN_AND_COVARIANCE,
+        mean_structure=WavelengthMeanStructure.DUST_ATTENUATION,
+        covariance_structure=(
+            WavelengthCovarianceStructure.SEPARABLE_SMOOTH_WAVELENGTH
+        ),
+        mean_wavelength_dependent=True,
+        covariance_wavelength_dependent=True,
+        covariance_separable=True,
+        temporal_kernel_configurable=True,
+        lpv_advisory_priority=2,
+        summary=(
+            "Dust-attenuation wavelength mean plus the same broad family of "
+            "separable configurable time and smooth wavelength covariance."
+        ),
+        comparison_cautions=(
+            _COMMON_COMPLETE_CONFIG_CAUTION,
+            "This is not a mean-only hypothesis; it also contains wavelength "
+            "covariance.",
+            "A better complete-fit score alone does not isolate evidence for the "
+            "dust mean law.",
+        ),
+    ),
+    "2DPowerLawMean": WavelengthModelHypothesis(
+        model="2DPowerLawMean",
+        role=WavelengthHypothesisRole.MEAN_AND_COVARIANCE,
+        mean_structure=WavelengthMeanStructure.POWER_LAW,
+        covariance_structure=(
+            WavelengthCovarianceStructure.SEPARABLE_SMOOTH_WAVELENGTH
+        ),
+        mean_wavelength_dependent=True,
+        covariance_wavelength_dependent=True,
+        covariance_separable=True,
+        temporal_kernel_configurable=True,
+        lpv_advisory_priority=3,
+        summary=(
+            "Power-law wavelength mean plus the same broad family of separable "
+            "configurable time and smooth wavelength covariance."
+        ),
+        comparison_cautions=(
+            _COMMON_COMPLETE_CONFIG_CAUTION,
+            "This is not a mean-only hypothesis; it also contains wavelength "
+            "covariance.",
+            "A better complete-fit score alone does not isolate evidence for the "
+            "power-law mean.",
+        ),
+    ),
+    "2DAchromatic": WavelengthModelHypothesis(
+        model="2DAchromatic",
+        role=WavelengthHypothesisRole.ACHROMATIC_CONTROL,
+        mean_structure=WavelengthMeanStructure.CONSTANT,
+        covariance_structure=(
+            WavelengthCovarianceStructure.ACHROMATIC_CONSTANT_WAVELENGTH
+        ),
+        mean_wavelength_dependent=False,
+        covariance_wavelength_dependent=False,
+        covariance_separable=True,
+        temporal_kernel_configurable=True,
+        lpv_advisory_priority=None,
+        summary=(
+            "Constant mean with a separable temporal covariance and constant "
+            "wavelength kernel enforcing the same variability pattern across bands."
+        ),
+        comparison_cautions=(
+            _COMMON_COMPLETE_CONFIG_CAUTION,
+            "This model is an achromatic control and is not part of the default "
+            "LPV advisory priority ordering.",
+        ),
+    ),
+}
+
+
+def describe_wavelength_model_hypothesis(
+    model: str,
+    *,
+    fit_kwargs: Mapping[str, Any] | None = None,
+) -> WavelengthModelHypothesis:
+    """Return descriptive hypothesis metadata for a public model string.
+
+    Parameters
+    ----------
+    model : str
+        Public PGMUVI model name.
+    fit_kwargs : mapping, optional
+        Fit configuration used to refine metadata such as an explicit
+        ``mean_module`` override.  The mapping is inspected only; it is never
+        modified.
+
+    Returns
+    -------
+    WavelengthModelHypothesis
+        Immutable descriptive metadata.  Unknown model strings receive an
+        explicit ``unknown`` classification rather than being guessed.
+    """
+    model_name = str(model).strip() or "unknown"
+    hypothesis = _BASE_HYPOTHESES.get(model_name)
+    if hypothesis is None:
+        return WavelengthModelHypothesis(
+            model=model_name,
+            role=WavelengthHypothesisRole.UNKNOWN,
+            mean_structure=WavelengthMeanStructure.UNKNOWN,
+            covariance_structure=WavelengthCovarianceStructure.UNKNOWN,
+            mean_wavelength_dependent=None,
+            covariance_wavelength_dependent=None,
+            covariance_separable=None,
+            temporal_kernel_configurable=None,
+            summary="No maintained wavelength-hypothesis taxonomy is available.",
+            comparison_cautions=(
+                "Do not infer mean or covariance semantics from an unknown model name.",
+            ),
+        )
+
+    kwargs = dict(fit_kwargs or {})
+    override = _mean_structure_from_override(kwargs.get("mean_module"))
+    if override is None or model_name in {
+        "2D",
+        "2DAchromatic",
+        "2DDustMean",
+        "2DPowerLawMean",
+    }:
+        return hypothesis
+
+    return replace(
+        hypothesis,
+        mean_structure=override,
+        mean_wavelength_dependent=_mean_is_wavelength_dependent(override),
+        summary=(
+            f"{hypothesis.summary} The fit configuration overrides the mean "
+            f"structure as {override.value!r}."
+        ),
+        metadata={
+            **dict(hypothesis.metadata),
+            "mean_module_override": str(kwargs.get("mean_module")),
+        },
+    )

--- a/pgmuvi/wavelength_results.py
+++ b/pgmuvi/wavelength_results.py
@@ -17,6 +17,10 @@ from enum import Enum
 import math
 from typing import Any
 
+from .wavelength_hypotheses import (
+    WavelengthModelHypothesis,
+    describe_wavelength_model_hypothesis,
+)
 from .wavelength_status import (
     AttemptDisposition,
     ComparisonEligibility,
@@ -519,9 +523,18 @@ class WavelengthModelAttemptResult:
     scores: Mapping[str, Any] = field(default_factory=dict)
     evidence: tuple[WavelengthEvidenceRecord, ...] = ()
     legacy_payload: Mapping[str, Any] = field(default_factory=dict, repr=False)
+    hypothesis: WavelengthModelHypothesis | None = None
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "fit_kwargs", _mapping_copy(self.fit_kwargs))
+        if self.hypothesis is None:
+            object.__setattr__(
+                self,
+                "hypothesis",
+                describe_wavelength_model_hypothesis(
+                    self.model or "", fit_kwargs=self.fit_kwargs
+                ),
+            )
         object.__setattr__(self, "diagnostics", _mapping_copy(self.diagnostics))
         object.__setattr__(self, "scores", _mapping_copy(self.scores))
         object.__setattr__(self, "warnings", tuple(self.warnings))
@@ -609,6 +622,14 @@ class WavelengthModelAttemptResult:
                 else None
             ),
             status=_attempt_status_from_mapping(payload),
+            hypothesis=(
+                WavelengthModelHypothesis.from_mapping(payload["model_hypothesis"])
+                if isinstance(payload.get("model_hypothesis"), Mapping)
+                else describe_wavelength_model_hypothesis(
+                    str(payload.get("model") or ""),
+                    fit_kwargs=payload.get("fit_kwargs") or {},
+                )
+            ),
             failure=_failure_from_mapping(payload),
             warnings=_warning_records_from_attempt(payload),
             fit_kwargs=payload.get("fit_kwargs") or {},
@@ -627,6 +648,9 @@ class WavelengthModelAttemptResult:
             "rank": self.rank,
             "model": self.model,
             "status": self.status.to_dict(),
+            "hypothesis": (
+                self.hypothesis.to_dict() if self.hypothesis is not None else None
+            ),
             "failure": self.failure.to_dict() if self.failure is not None else None,
             "warnings": [record.to_dict() for record in self.warnings],
             "fit_kwargs": _mapping_copy(self.fit_kwargs),

--- a/tests/test_docs_wavelength_hypotheses.py
+++ b/tests/test_docs_wavelength_hypotheses.py
@@ -1,0 +1,38 @@
+"""Documentation contract tests for wavelength-model hypothesis taxonomy."""
+
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class TestWavelengthHypothesisDocumentation(unittest.TestCase):
+    def test_api_reference_includes_hypothesis_module(self):
+        api = (ROOT / "docs/source/api.rst").read_text()
+        module_page = ROOT / "docs/source/pgmuvi.wavelength_hypotheses.rst"
+        self.assertIn("pgmuvi.wavelength_hypotheses", api)
+        self.assertTrue(module_page.exists())
+        self.assertIn(
+            "automodule:: pgmuvi.wavelength_hypotheses",
+            module_page.read_text(),
+        )
+
+    def test_advisory_docs_distinguish_mean_and_covariance_roles(self):
+        advisory = (
+            ROOT / "docs/source/howto/wavelength_advisory.rst"
+        ).read_text()
+        interpretation = (
+            ROOT / "docs/source/howto/interpreting_results.rst"
+        ).read_text()
+        for text in (advisory, interpretation):
+            self.assertIn("model_hypothesis", text)
+            self.assertIn("2DDustMean", text)
+            self.assertIn("2DPowerLawMean", text)
+            self.assertIn("mean-only", text)
+        self.assertIn("2DAchromatic", advisory)
+        self.assertIn("not part of that default LPV priority", advisory)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_period_independent_wavelength_model_kernel_config_runner.py
+++ b/tests/test_period_independent_wavelength_model_kernel_config_runner.py
@@ -145,6 +145,30 @@ class TestPeriodIndependentWavelengthModelKernelConfigRunner(unittest.TestCase):
         self.assertIn("model_kernel_config_results", report)
         self.assertEqual(report["model_kernel_config_results"], report["outcomes"])
 
+    def test_runner_derives_and_propagates_missing_hypothesis_metadata(self):
+        lc = _make_multiband_lightcurve()
+
+        def runner(candidate_lc, fit_kwargs, candidate):
+            candidate_lc.consensus_diagnostics = {"consensus_success": True}
+            return None
+
+        report = lc.run_period_independent_wavelength_model_kernel_configs(
+            model_kernel_config_report=_model_kernel_config_report(),
+            fit_runner=runner,
+        )
+
+        self.assertEqual(
+            report["hypothesis_schema_version"],
+            "pgmuvi-wavelength-hypotheses-v1",
+        )
+        by_model = {
+            outcome["model"]: outcome["model_hypothesis"]
+            for outcome in report["outcomes"]
+        }
+        self.assertEqual(by_model["2DDustMean"]["role"], "mean_and_covariance")
+        self.assertEqual(by_model["2DDustMean"]["mean_structure"], "dust_attenuation")
+        self.assertEqual(by_model["2D"]["role"], "joint_baseline")
+
     def test_fit_kwargs_are_passed_to_runner(self):
         lc = _make_multiband_lightcurve()
         seen = []

--- a/tests/test_period_independent_wavelength_model_kernel_configs.py
+++ b/tests/test_period_independent_wavelength_model_kernel_configs.py
@@ -170,6 +170,45 @@ class TestPeriodIndependentWavelengthModelKernelConfigs(unittest.TestCase):
             self.assertIn("parameter_suggestions_applied", candidate)
             self.assertFalse(candidate["parameter_suggestions_applied"])
 
+    def test_model_hypothesis_metadata_separates_mean_and_covariance(self):
+        lc = _make_multiband_lightcurve()
+        plan = lc.build_period_independent_wavelength_parameter_plan()
+        plan["ranked_candidates"].append(
+            {
+                "rank": len(plan["ranked_candidates"]) + 1,
+                "model": "2DSeparable",
+                "recommendation_strength": "advisory",
+                "hard_exclusion": False,
+                "primary_reason": "Explicit taxonomy-propagation test candidate.",
+                "reason": "Explicit taxonomy-propagation test candidate.",
+            }
+        )
+
+        report = lc.build_period_independent_wavelength_model_kernel_configs(
+            parameter_plan=plan,
+            include_models=["2DDustMean", "2DSeparable", "2D"],
+            include_2d_baseline=True,
+        )
+
+        self.assertEqual(
+            report["hypothesis_schema_version"],
+            "pgmuvi-wavelength-hypotheses-v1",
+        )
+        by_model = {
+            candidate["model"]: candidate["model_hypothesis"]
+            for candidate in report["model_kernel_configs"]
+        }
+        self.assertEqual(by_model["2DDustMean"]["mean_structure"], "dust_attenuation")
+        self.assertEqual(
+            by_model["2DDustMean"]["covariance_structure"],
+            "separable_smooth_wavelength",
+        )
+        self.assertTrue(by_model["2DDustMean"]["mean_wavelength_dependent"])
+        self.assertTrue(by_model["2DDustMean"]["covariance_wavelength_dependent"])
+        self.assertEqual(by_model["2DSeparable"]["mean_structure"], "constant")
+        self.assertEqual(by_model["2D"]["role"], "joint_baseline")
+        self.assertFalse(by_model["2D"]["covariance_separable"])
+
     def test_include_models_filters_candidate_list(self):
         lc = _make_multiband_lightcurve()
 

--- a/tests/test_wavelength_hypotheses.py
+++ b/tests/test_wavelength_hypotheses.py
@@ -1,0 +1,161 @@
+"""Tests for explicit wavelength-model scientific-hypothesis metadata."""
+
+import json
+import unittest
+
+from pgmuvi.wavelength_hypotheses import (
+    LPV_WAVELENGTH_MODEL_PRIORITY,
+    WAVELENGTH_HYPOTHESIS_SCHEMA_VERSION,
+    WavelengthCovarianceStructure,
+    WavelengthHypothesisRole,
+    WavelengthMeanStructure,
+    WavelengthModelHypothesis,
+    describe_wavelength_model_hypothesis,
+)
+
+
+class TestWavelengthModelHypothesisTaxonomy(unittest.TestCase):
+    def test_lpv_priority_is_explicit_and_excludes_achromatic_control(self):
+        self.assertEqual(
+            LPV_WAVELENGTH_MODEL_PRIORITY,
+            (
+                "2DWavelengthDependent",
+                "2DDustMean",
+                "2DPowerLawMean",
+                "2DSeparable",
+                "2D",
+            ),
+        )
+        self.assertNotIn("2DAchromatic", LPV_WAVELENGTH_MODEL_PRIORITY)
+
+    def test_2d_is_joint_nonseparable_baseline(self):
+        hypothesis = describe_wavelength_model_hypothesis("2D")
+        self.assertEqual(hypothesis.role, WavelengthHypothesisRole.JOINT_BASELINE)
+        self.assertEqual(
+            hypothesis.covariance_structure,
+            WavelengthCovarianceStructure.JOINT_2D_SPECTRAL_MIXTURE,
+        )
+        self.assertEqual(hypothesis.mean_structure, WavelengthMeanStructure.CONSTANT)
+        self.assertFalse(hypothesis.covariance_separable)
+        self.assertTrue(hypothesis.baseline)
+
+    def test_dust_and_power_law_are_not_mean_only_hypotheses(self):
+        expected = {
+            "2DDustMean": WavelengthMeanStructure.DUST_ATTENUATION,
+            "2DPowerLawMean": WavelengthMeanStructure.POWER_LAW,
+        }
+        for model, mean_structure in expected.items():
+            with self.subTest(model=model):
+                hypothesis = describe_wavelength_model_hypothesis(model)
+                self.assertEqual(
+                    hypothesis.role,
+                    WavelengthHypothesisRole.MEAN_AND_COVARIANCE,
+                )
+                self.assertEqual(hypothesis.mean_structure, mean_structure)
+                self.assertEqual(
+                    hypothesis.covariance_structure,
+                    WavelengthCovarianceStructure.SEPARABLE_SMOOTH_WAVELENGTH,
+                )
+                self.assertTrue(hypothesis.mean_wavelength_dependent)
+                self.assertTrue(hypothesis.covariance_wavelength_dependent)
+                self.assertTrue(
+                    any(
+                        "not a mean-only hypothesis" in caution.lower()
+                        for caution in hypothesis.comparison_cautions
+                    )
+                )
+
+    def test_wavelength_dependent_model_records_both_axes(self):
+        hypothesis = describe_wavelength_model_hypothesis(
+            "2DWavelengthDependent"
+        )
+        self.assertEqual(hypothesis.mean_structure, WavelengthMeanStructure.QUADRATIC)
+        self.assertEqual(
+            hypothesis.covariance_structure,
+            WavelengthCovarianceStructure.SEPARABLE_SMOOTH_WAVELENGTH,
+        )
+        self.assertTrue(hypothesis.mean_wavelength_dependent)
+        self.assertTrue(hypothesis.covariance_wavelength_dependent)
+
+    def test_mean_override_refines_configurable_model_without_mutating_input(self):
+        fit_kwargs = {"mean_module": "constant", "training_iter": 20}
+        hypothesis = describe_wavelength_model_hypothesis(
+            "2DWavelengthDependent", fit_kwargs=fit_kwargs
+        )
+        self.assertEqual(hypothesis.mean_structure, WavelengthMeanStructure.CONSTANT)
+        self.assertFalse(hypothesis.mean_wavelength_dependent)
+        self.assertEqual(fit_kwargs, {"mean_module": "constant", "training_iter": 20})
+        self.assertEqual(hypothesis.metadata["mean_module_override"], "constant")
+
+    def test_fixed_model_means_are_not_overridden_by_generic_fit_metadata(self):
+        expected = {
+            "2DAchromatic": WavelengthMeanStructure.CONSTANT,
+            "2DDustMean": WavelengthMeanStructure.DUST_ATTENUATION,
+            "2DPowerLawMean": WavelengthMeanStructure.POWER_LAW,
+        }
+        for model, mean_structure in expected.items():
+            with self.subTest(model=model):
+                hypothesis = describe_wavelength_model_hypothesis(
+                    model, fit_kwargs={"mean_module": "linear"}
+                )
+                self.assertEqual(hypothesis.mean_structure, mean_structure)
+
+    def test_achromatic_is_control_without_lpv_priority(self):
+        hypothesis = describe_wavelength_model_hypothesis("2DAchromatic")
+        self.assertEqual(
+            hypothesis.role,
+            WavelengthHypothesisRole.ACHROMATIC_CONTROL,
+        )
+        self.assertFalse(hypothesis.covariance_wavelength_dependent)
+        self.assertIsNone(hypothesis.lpv_advisory_priority)
+
+    def test_unknown_model_is_explicitly_unknown(self):
+        hypothesis = describe_wavelength_model_hypothesis("FutureModel")
+        self.assertEqual(hypothesis.role, WavelengthHypothesisRole.UNKNOWN)
+        self.assertEqual(
+            hypothesis.mean_structure,
+            WavelengthMeanStructure.UNKNOWN,
+        )
+        self.assertIsNone(hypothesis.mean_wavelength_dependent)
+        self.assertIn("unknown", hypothesis.comparison_cautions[0].lower())
+
+    def test_mapping_round_trip_is_versioned_and_json_safe(self):
+        source = describe_wavelength_model_hypothesis("2DDustMean")
+        payload = source.to_dict()
+        self.assertEqual(
+            payload["schema_version"], WAVELENGTH_HYPOTHESIS_SCHEMA_VERSION
+        )
+        restored = WavelengthModelHypothesis.from_mapping(payload)
+        self.assertEqual(restored, source)
+        json.dumps(payload)
+
+    def test_arbitrary_metadata_is_sanitized_for_json(self):
+        source = WavelengthModelHypothesis(
+            model="FutureModel",
+            role=WavelengthHypothesisRole.UNKNOWN,
+            mean_structure=WavelengthMeanStructure.UNKNOWN,
+            covariance_structure=WavelengthCovarianceStructure.UNKNOWN,
+            mean_wavelength_dependent=None,
+            covariance_wavelength_dependent=None,
+            covariance_separable=None,
+            temporal_kernel_configurable=None,
+            metadata={
+                "enum": WavelengthMeanStructure.LINEAR,
+                "nonfinite": float("nan"),
+                "nested": (1, object()),
+            },
+        )
+        payload = source.to_dict()
+        self.assertEqual(payload["metadata"]["enum"], "linear")
+        self.assertIsNone(payload["metadata"]["nonfinite"])
+        self.assertIsInstance(payload["metadata"]["nested"], list)
+        json.dumps(payload, allow_nan=False)
+
+    def test_blank_model_name_uses_explicit_unknown_label(self):
+        hypothesis = describe_wavelength_model_hypothesis("")
+        self.assertEqual(hypothesis.model, "unknown")
+        self.assertEqual(hypothesis.role, WavelengthHypothesisRole.UNKNOWN)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wavelength_result_primitives.py
+++ b/tests/test_wavelength_result_primitives.py
@@ -125,6 +125,13 @@ class TestAttemptResultAdapter(unittest.TestCase):
             ComparisonEligibility.ELIGIBLE,
         )
         self.assertEqual(result.fit_kwargs["training_iter"], 20)
+        self.assertIsNotNone(result.hypothesis)
+        self.assertEqual(result.hypothesis.model, "2DDustMean")
+        self.assertEqual(result.hypothesis.role.value, "mean_and_covariance")
+        self.assertEqual(
+            result.hypothesis.covariance_structure.value,
+            "separable_smooth_wavelength",
+        )
         self.assertEqual(
             result.to_legacy_dict()["unknown_legacy_field"], {"kept": True}
         )
@@ -134,6 +141,7 @@ class TestAttemptResultAdapter(unittest.TestCase):
             "completed_with_warnings",
         )
         self.assertEqual(typed["warnings"][0]["message"], "synthetic warning")
+        self.assertEqual(typed["hypothesis"]["mean_structure"], "dust_attenuation")
         self.assertEqual(typed["diagnostics"]["consensus"]["consensus_period"], 600.0)
         json.dumps(typed)
 


### PR DESCRIPTION
## Summary

- introduce a versioned wavelength-model hypothesis taxonomy
- classify mean structure and covariance structure independently
- record wavelength dependence in the mean and covariance separately
- record covariance separability, baseline status, and interpretive role
- identify `2D` as the joint non-separable baseline
- identify `2DSeparable` as a separable covariance-focused configuration
- identify `2DWavelengthDependent` as wavelength-dependent mean plus covariance
- classify `2DDustMean` and `2DPowerLawMean` as mean-and-covariance configurations rather than mean-only hypotheses
- preserve the LPV model priority order while excluding `2DAchromatic` from it
- propagate hypothesis metadata through generated and legacy configurations, fit outcomes, quality rows, and typed result adapters
- add focused regression tests and documentation
- leave fitting, scoring, ranking, and eligibility behavior unchanged

## Validation

- targeted B3 tests passed
- Ruff CI-equivalent check passed
- strict Sphinx documentation build passed
- full test suite passed
