### PR TITLE
Synthesize wavelength advisory conclusions explicitly

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -57,6 +57,7 @@ Data, diagnostics, and validation
    pgmuvi.dtypes
    pgmuvi.preprocess
    pgmuvi.multiband_ls_significance
+   pgmuvi.wavelength_conclusions
    pgmuvi.wavelength_diagnostics
    pgmuvi.wavelength_hypotheses
    pgmuvi.wavelength_results

--- a/docs/source/future_work.rst
+++ b/docs/source/future_work.rst
@@ -39,6 +39,28 @@ Validation and model-selection boundaries
     model. The current advisory contract intentionally leaves
     ``selected_model`` as ``None``.
 
+Wavelength-derived fitting constraints and validation
+-----------------------------------------------------
+
+**TBD[wavelength-derived-constraints]**
+    Implement the dedicated scientific fitting tranche for data-derived
+    wavelength-kernel and wavelength-mean initialization and constraints.  The
+    tranche must summarize usable wavelength sampling, apply independent mean
+    and covariance estimates to ``2DWavelengthDependent``, ``2DDustMean``,
+    ``2DPowerLawMean``, and ``2DSeparable``, and redesign the full ``2D``
+    spectral-mixture parameterization so temporal and wavelength ARD dimensions
+    can receive genuinely independent bounds.  It must also preserve
+    constraint-before-value ordering and record the origin of every estimate and
+    bound.
+
+**TBD[wavelength-constraint-validation]**
+    Validate the wavelength-derived initialization and constraint tranche with
+    synthetic recovery, sparse and uneven band coverage, missing bands, large
+    wavelength gaps, weak and strong wavelength dependence, supported
+    non-monotonic cases, seed stability, constraint-ceiling diagnostics,
+    consensus periodic or quasi-periodic time kernels, and real LPV sources.
+    Successful optimization alone is not sufficient validation.
+
 Wavelength-model extensions
 ---------------------------
 

--- a/docs/source/howto/interpreting_results.rst
+++ b/docs/source/howto/interpreting_results.rst
@@ -512,3 +512,27 @@ See also
 * :doc:`wavelength_advisory`
 * :doc:`wavelength_advisory_batch`
 * :doc:`preprocessing`
+
+Advisory conclusions are scoped, not selections
+------------------------------------------------
+
+For the period-independent wavelength workflow, inspect
+``advisory_conclusions`` together with ``unresolved_ambiguities``.  A conclusion
+about a ``complete_configuration`` applies to the full GP configuration.  It
+must not be reinterpreted as isolated evidence for its wavelength mean or its
+wavelength covariance.
+
+The disposition ``remains_plausible`` means only that the available diagnostics
+do not exclude the hypothesis.  ``weakened`` records explicit adverse advisory
+evidence without claiming formal rejection.  ``technically_unevaluable`` means
+that technical execution did not yield usable scientific evidence.
+``scientifically_ambiguous`` means that the required same-mean or
+same-covariance contrast is absent.  ``incomparable`` means that the result is
+not eligible for the current like-for-like comparison.
+
+The current scalar ranking remains a training-residual heuristic, not a formal
+model-comparison statistic.  Consequently, neither ``top_ranked_model`` nor a
+``remains_plausible`` conclusion performs automatic model selection.  Use the
+ambiguity records to identify whether stronger interpretation requires another
+successful candidate, an isolated mean/covariance contrast, held-out prediction,
+seed-stability checks, or resolution of a recorded technical failure.

--- a/docs/source/howto/wavelength_advisory.rst
+++ b/docs/source/howto/wavelength_advisory.rst
@@ -555,3 +555,59 @@ Use these fields to decide whether to inspect the input data, restore missing
 diagnostics, relax consensus requirements, increase numerical safeguards, or
 rerun only a subset of model/kernel configs.  They are not a substitute for a
 valid comparison, and ``only_valid_model`` is not a comparative winner.
+
+Structured advisory conclusions and unresolved ambiguities
+-----------------------------------------------------------
+
+The one-shot period-independent advisory workflow now adds versioned
+``advisory_conclusions`` and ``unresolved_ambiguities`` records.  These records
+summarize the existing attempt statuses, fit-quality availability, and
+``model_hypothesis`` metadata.  They do not rerun fits, change scores, alter
+comparison eligibility, or perform automatic model selection.
+
+Each conclusion has an explicit scope:
+
+``complete_configuration``
+   The fitted model string as a complete mean-plus-covariance GP
+   configuration.
+
+``mean_structure``
+   A wavelength-mean family such as ``dust_attenuation`` or ``power_law``.
+
+``covariance_structure``
+   A joint or separable wavelength-covariance family.
+
+The conservative conclusion dispositions are ``remains_plausible``,
+``weakened``, ``technically_unevaluable``, ``scientifically_ambiguous``, and
+``incomparable``.  ``remains_plausible`` is not a selection or endorsement.
+``technically_unevaluable`` records that a fit did not produce usable evidence.
+``scientifically_ambiguous`` records that the candidate set does not isolate a
+mean or covariance mechanism.  ``incomparable`` records usable but non-equivalent
+or diagnostically incomplete results.
+
+The ``unresolved_ambiguities`` list makes limitations explicit.  In particular,
+the current training-residual fit-quality ranking is heuristic: it is not a
+formal, held-out, or cross-validated model comparison.  A top-ranked model is
+therefore still not selected automatically.  Failures, a single valid
+candidate, and missing same-mean or same-covariance contrasts are reported as
+separate ambiguities rather than being collapsed into one success/failure flag.
+
+The schema version is available as
+``advisory_conclusion_schema_version``.  The text report includes the same
+conclusion and ambiguity summaries, while the existing legacy ranking and
+fallback fields remain unchanged.
+
+
+Remaining wavelength-constraint tranche
+---------------------------------------
+
+The conclusion synthesis does not improve the fitted wavelength parameters.
+That separate implementation roadmap is explicitly tracked by
+``TBD[wavelength-derived-constraints]`` and
+``TBD[wavelength-constraint-validation]``.  It covers data-derived wavelength
+sampling summaries, independent wavelength-kernel and wavelength-mean
+initialization, dimension-aware temporal versus wavelength ARD bounds for the
+full ``2D`` spectral-mixture baseline, saturation provenance, synthetic
+recovery, consensus compatibility, and real-LPV validation.  The current B4
+conclusion records must not be presented as a substitute for that scientific
+fitting work.

--- a/docs/source/pgmuvi.wavelength_conclusions.rst
+++ b/docs/source/pgmuvi.wavelength_conclusions.rst
@@ -1,0 +1,7 @@
+Wavelength-advisory conclusions
+===============================
+
+.. automodule:: pgmuvi.wavelength_conclusions
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/pgmuvi/__init__.py
+++ b/pgmuvi/__init__.py
@@ -21,6 +21,7 @@ __all__ = [
     "priors",
     "synthetic",
     "trainers",
+    "wavelength_conclusions",
     "wavelength_diagnostics",
     "wavelength_hypotheses",
     "wavelength_results",

--- a/pgmuvi/wavelength_conclusions.py
+++ b/pgmuvi/wavelength_conclusions.py
@@ -1,0 +1,733 @@
+"""Structured, conservative conclusions for wavelength-advisory workflows.
+
+The wavelength-advisory workflow compares complete Gaussian-process
+configurations.  Its current training-residual score is heuristic rather than a
+formal model-comparison statistic.  This module converts existing attempt
+statuses, hypothesis metadata, and ranking availability into explicit
+conclusions without selecting a model or attributing a score difference to a
+mean or covariance mechanism that was not isolated by the compared configs.
+
+The synthesis is report-only.  It does not fit models, change scores, alter
+comparison eligibility, apply constraints, or mutate a light curve.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from enum import Enum
+import math
+from typing import Any
+
+from .wavelength_hypotheses import (
+    WavelengthCovarianceStructure,
+    WavelengthMeanStructure,
+)
+from .wavelength_results import WavelengthModelAttemptResult
+from .wavelength_status import (
+    AttemptDisposition,
+    ComparisonEligibility,
+    ScientificUsability,
+    TechnicalOutcome,
+)
+
+WAVELENGTH_ADVISORY_CONCLUSION_SCHEMA_VERSION = (
+    "pgmuvi-wavelength-advisory-conclusions-v1"
+)
+
+__all__ = [
+    "WAVELENGTH_ADVISORY_CONCLUSION_SCHEMA_VERSION",
+    "WavelengthAdvisoryConclusion",
+    "WavelengthConclusionDisposition",
+    "WavelengthConclusionScope",
+    "WavelengthUnresolvedAmbiguity",
+    "synthesize_wavelength_advisory_conclusions",
+]
+
+
+class _StringEnum(str, Enum):
+    """Enum whose values serialize and display as stable public strings."""
+
+    def __str__(self) -> str:
+        return self.value
+
+
+class WavelengthConclusionScope(_StringEnum):
+    """Scientific level addressed by one advisory conclusion."""
+
+    COMPLETE_CONFIGURATION = "complete_configuration"
+    MEAN_STRUCTURE = "mean_structure"
+    COVARIANCE_STRUCTURE = "covariance_structure"
+    WORKFLOW = "workflow"
+
+
+class WavelengthConclusionDisposition(_StringEnum):
+    """Conservative state assigned by the advisory synthesis."""
+
+    REMAINS_PLAUSIBLE = "remains_plausible"
+    WEAKENED = "weakened"
+    TECHNICALLY_UNEVALUABLE = "technically_unevaluable"
+    SCIENTIFICALLY_AMBIGUOUS = "scientifically_ambiguous"
+    INCOMPARABLE = "incomparable"
+
+
+def _json_safe(value: Any) -> Any:
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, Mapping):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, Sequence) and not isinstance(
+        value, (str, bytes, bytearray)
+    ):
+        return [_json_safe(item) for item in value]
+    item_method = getattr(value, "item", None)
+    if callable(item_method):
+        try:
+            return _json_safe(item_method())
+        except (TypeError, ValueError, RuntimeError):
+            pass
+    return str(value)
+
+
+def _string_tuple(value: Any) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return (value,)
+    if isinstance(value, Sequence):
+        return tuple(str(item) for item in value)
+    return (str(value),)
+
+
+@dataclass(frozen=True)
+class WavelengthAdvisoryConclusion:
+    """One explicit, JSON-safe advisory conclusion."""
+
+    conclusion_id: str
+    scope: WavelengthConclusionScope
+    subject: str
+    disposition: WavelengthConclusionDisposition
+    summary: str
+    models: tuple[str, ...] = ()
+    model_kernel_config_ids: tuple[str, ...] = ()
+    mean_structures: tuple[str, ...] = ()
+    covariance_structures: tuple[str, ...] = ()
+    evidence_basis: Mapping[str, Any] = field(default_factory=dict)
+    limitations: tuple[str, ...] = ()
+    schema_version: str = WAVELENGTH_ADVISORY_CONCLUSION_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        for field_name in ("conclusion_id", "subject", "summary"):
+            if not str(getattr(self, field_name)).strip():
+                raise ValueError(f"{field_name} must be non-empty.")
+        object.__setattr__(self, "conclusion_id", str(self.conclusion_id))
+        object.__setattr__(self, "subject", str(self.subject))
+        object.__setattr__(self, "summary", str(self.summary))
+        object.__setattr__(self, "models", _string_tuple(self.models))
+        object.__setattr__(
+            self,
+            "model_kernel_config_ids",
+            _string_tuple(self.model_kernel_config_ids),
+        )
+        object.__setattr__(
+            self, "mean_structures", _string_tuple(self.mean_structures)
+        )
+        object.__setattr__(
+            self,
+            "covariance_structures",
+            _string_tuple(self.covariance_structures),
+        )
+        object.__setattr__(
+            self, "evidence_basis", _json_safe(dict(self.evidence_basis))
+        )
+        object.__setattr__(self, "limitations", _string_tuple(self.limitations))
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the stable public mapping representation."""
+        return {
+            "schema_version": self.schema_version,
+            "kind": "wavelength_advisory_conclusion",
+            "conclusion_id": self.conclusion_id,
+            "scope": self.scope.value,
+            "subject": self.subject,
+            "disposition": self.disposition.value,
+            "summary": self.summary,
+            "models": list(self.models),
+            "model_kernel_config_ids": list(self.model_kernel_config_ids),
+            "mean_structures": list(self.mean_structures),
+            "covariance_structures": list(self.covariance_structures),
+            "evidence_basis": _json_safe(self.evidence_basis),
+            "limitations": list(self.limitations),
+        }
+
+
+@dataclass(frozen=True)
+class WavelengthUnresolvedAmbiguity:
+    """One unresolved limitation that prevents a stronger interpretation."""
+
+    code: str
+    summary: str
+    affected_scopes: tuple[WavelengthConclusionScope, ...]
+    models: tuple[str, ...] = ()
+    resolution_requirements: tuple[str, ...] = ()
+    details: Mapping[str, Any] = field(default_factory=dict)
+    schema_version: str = WAVELENGTH_ADVISORY_CONCLUSION_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if not str(self.code).strip():
+            raise ValueError("code must be non-empty.")
+        if not str(self.summary).strip():
+            raise ValueError("summary must be non-empty.")
+        object.__setattr__(self, "code", str(self.code))
+        object.__setattr__(self, "summary", str(self.summary))
+        object.__setattr__(self, "affected_scopes", tuple(self.affected_scopes))
+        object.__setattr__(self, "models", _string_tuple(self.models))
+        object.__setattr__(
+            self,
+            "resolution_requirements",
+            _string_tuple(self.resolution_requirements),
+        )
+        object.__setattr__(self, "details", _json_safe(dict(self.details)))
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the stable public mapping representation."""
+        return {
+            "schema_version": self.schema_version,
+            "kind": "wavelength_unresolved_ambiguity",
+            "code": self.code,
+            "summary": self.summary,
+            "affected_scopes": [scope.value for scope in self.affected_scopes],
+            "models": list(self.models),
+            "resolution_requirements": list(self.resolution_requirements),
+            "details": _json_safe(self.details),
+        }
+
+
+def _outcomes_from_workflow(workflow: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    run_report = workflow.get("run_report")
+    run_report = run_report if isinstance(run_report, Mapping) else {}
+    outcomes = (
+        run_report.get("model_kernel_config_results")
+        or run_report.get("outcomes")
+        or workflow.get("model_kernel_config_results")
+        or workflow.get("outcomes")
+        or []
+    )
+    if not isinstance(outcomes, Sequence) or isinstance(outcomes, str):
+        return []
+    return [item for item in outcomes if isinstance(item, Mapping)]
+
+
+def _quality_rows_from_workflow(
+    workflow: Mapping[str, Any],
+) -> list[Mapping[str, Any]]:
+    quality_report = workflow.get("quality_report")
+    quality_report = quality_report if isinstance(quality_report, Mapping) else {}
+    rows = quality_report.get("ranked_results") or quality_report.get("results") or []
+    if not isinstance(rows, Sequence) or isinstance(rows, str):
+        return []
+    return [item for item in rows if isinstance(item, Mapping)]
+
+
+def _quality_row_for_attempt(
+    attempt: WavelengthModelAttemptResult,
+    rows: Sequence[Mapping[str, Any]],
+) -> Mapping[str, Any]:
+    for row in rows:
+        if (
+            attempt.model_kernel_config_id is not None
+            and row.get("model_kernel_config_id") == attempt.model_kernel_config_id
+        ):
+            return row
+    matching = [row for row in rows if row.get("model") == attempt.model]
+    if len(matching) == 1:
+        return matching[0]
+    if attempt.rank is not None:
+        for row in matching:
+            if row.get("rank") == attempt.rank:
+                return row
+    return {}
+
+
+def _configuration_disposition(
+    attempt: WavelengthModelAttemptResult,
+) -> WavelengthConclusionDisposition:
+    status = attempt.status
+    if status.disposition in {
+        AttemptDisposition.NOT_ATTEMPTED,
+        AttemptDisposition.SKIPPED,
+    }:
+        return WavelengthConclusionDisposition.TECHNICALLY_UNEVALUABLE
+    if status.technical_outcome is TechnicalOutcome.FAILED:
+        return WavelengthConclusionDisposition.TECHNICALLY_UNEVALUABLE
+    if status.scientific_usability is ScientificUsability.UNUSABLE:
+        return WavelengthConclusionDisposition.TECHNICALLY_UNEVALUABLE
+    if attempt.legacy_payload.get("hard_exclusion") is True:
+        return WavelengthConclusionDisposition.WEAKENED
+    if status.comparison_eligibility is not ComparisonEligibility.ELIGIBLE:
+        return WavelengthConclusionDisposition.INCOMPARABLE
+    return WavelengthConclusionDisposition.REMAINS_PLAUSIBLE
+
+
+def _configuration_summary(
+    attempt: WavelengthModelAttemptResult,
+    disposition: WavelengthConclusionDisposition,
+    ranking_status: str,
+    top_ranked_model: str | None,
+) -> str:
+    model = attempt.model or attempt.model_kernel_config_id or "unknown configuration"
+    if disposition is WavelengthConclusionDisposition.TECHNICALLY_UNEVALUABLE:
+        return (
+            f"{model} could not be scientifically evaluated because the attempt "
+            "did not produce a usable completed fit."
+        )
+    if disposition is WavelengthConclusionDisposition.WEAKENED:
+        return (
+            f"{model} is weakened by an explicit advisory exclusion, but this "
+            "does not constitute a formal model rejection."
+        )
+    if disposition is WavelengthConclusionDisposition.INCOMPARABLE:
+        return (
+            f"{model} produced some usable information but is not eligible for "
+            "the current like-for-like fit-quality comparison."
+        )
+    if ranking_status == "available" and model == top_ranked_model:
+        return (
+            f"{model} remains plausible and is top ranked by the current "
+            "training-residual heuristic; it is not selected automatically."
+        )
+    if ranking_status == "available":
+        return (
+            f"{model} remains plausible despite not being top ranked by the "
+            "current training-residual heuristic."
+        )
+    return (
+        f"{model} remains plausible as a completed comparable configuration, "
+        "but no comparative ranking is available."
+    )
+
+
+def _has_isolating_contrast(
+    attempt: WavelengthModelAttemptResult,
+    eligible_attempts: Sequence[WavelengthModelAttemptResult],
+    *,
+    scope: WavelengthConclusionScope,
+) -> bool:
+    hypothesis = attempt.hypothesis
+    if hypothesis is None:
+        return False
+    for other in eligible_attempts:
+        if other is attempt or other.hypothesis is None:
+            continue
+        if scope is WavelengthConclusionScope.MEAN_STRUCTURE:
+            if (
+                other.hypothesis.covariance_structure
+                is hypothesis.covariance_structure
+                and other.hypothesis.mean_structure is not hypothesis.mean_structure
+            ):
+                return True
+        elif scope is WavelengthConclusionScope.COVARIANCE_STRUCTURE:
+            if (
+                other.hypothesis.mean_structure is hypothesis.mean_structure
+                and other.hypothesis.covariance_structure
+                is not hypothesis.covariance_structure
+            ):
+                return True
+    return False
+
+
+def _aggregate_structure_conclusions(
+    attempts: Sequence[WavelengthModelAttemptResult],
+    configuration_dispositions: Mapping[str, WavelengthConclusionDisposition],
+    *,
+    scope: WavelengthConclusionScope,
+) -> list[WavelengthAdvisoryConclusion]:
+    eligible = [
+        attempt
+        for attempt in attempts
+        if attempt.status.comparison_eligibility is ComparisonEligibility.ELIGIBLE
+    ]
+    grouped: dict[str, list[WavelengthModelAttemptResult]] = {}
+    for attempt in attempts:
+        if attempt.hypothesis is None:
+            structure = "unknown"
+        elif scope is WavelengthConclusionScope.MEAN_STRUCTURE:
+            structure = attempt.hypothesis.mean_structure.value
+        else:
+            structure = attempt.hypothesis.covariance_structure.value
+        grouped.setdefault(structure, []).append(attempt)
+
+    conclusions = []
+    for structure, members in grouped.items():
+        member_keys = [
+            member.model_kernel_config_id or member.model or "unknown" for member in members
+        ]
+        member_dispositions = [
+            configuration_dispositions[key] for key in member_keys
+        ]
+        comparable = [
+            member
+            for member in members
+            if member.status.comparison_eligibility is ComparisonEligibility.ELIGIBLE
+        ]
+        isolating = any(
+            _has_isolating_contrast(member, eligible, scope=scope)
+            for member in comparable
+        )
+
+        if not comparable and all(
+            item is WavelengthConclusionDisposition.TECHNICALLY_UNEVALUABLE
+            for item in member_dispositions
+        ):
+            disposition = WavelengthConclusionDisposition.TECHNICALLY_UNEVALUABLE
+            summary = (
+                f"The {structure} hypothesis could not be evaluated because no "
+                "configuration representing it produced a usable comparable fit."
+            )
+        elif not comparable:
+            disposition = WavelengthConclusionDisposition.INCOMPARABLE
+            summary = (
+                f"The {structure} hypothesis is represented, but none of its "
+                "configurations is eligible for the current comparison."
+            )
+        elif not isolating:
+            disposition = WavelengthConclusionDisposition.SCIENTIFICALLY_AMBIGUOUS
+            mechanism = "mean" if scope is WavelengthConclusionScope.MEAN_STRUCTURE else "covariance"
+            summary = (
+                f"The {structure} {mechanism} hypothesis is represented by a "
+                "comparable fit, but the current candidate set does not isolate "
+                f"that {mechanism} mechanism from the other GP components."
+            )
+        else:
+            disposition = WavelengthConclusionDisposition.REMAINS_PLAUSIBLE
+            mechanism = "mean" if scope is WavelengthConclusionScope.MEAN_STRUCTURE else "covariance"
+            summary = (
+                f"The {structure} {mechanism} hypothesis remains plausible and "
+                f"has at least one same-other-axis contrast in the candidate set."
+            )
+
+        conclusions.append(
+            WavelengthAdvisoryConclusion(
+                conclusion_id=f"{scope.value}:{structure}",
+                scope=scope,
+                subject=structure,
+                disposition=disposition,
+                summary=summary,
+                models=tuple(
+                    member.model or member.model_kernel_config_id or "unknown"
+                    for member in members
+                ),
+                model_kernel_config_ids=tuple(
+                    member.model_kernel_config_id
+                    or member.model
+                    or "unknown"
+                    for member in members
+                ),
+                mean_structures=(structure,)
+                if scope is WavelengthConclusionScope.MEAN_STRUCTURE
+                else tuple(
+                    sorted(
+                        {
+                            member.hypothesis.mean_structure.value
+                            if member.hypothesis is not None
+                            else WavelengthMeanStructure.UNKNOWN.value
+                            for member in members
+                        }
+                    )
+                ),
+                covariance_structures=(structure,)
+                if scope is WavelengthConclusionScope.COVARIANCE_STRUCTURE
+                else tuple(
+                    sorted(
+                        {
+                            member.hypothesis.covariance_structure.value
+                            if member.hypothesis is not None
+                            else WavelengthCovarianceStructure.UNKNOWN.value
+                            for member in members
+                        }
+                    )
+                ),
+                evidence_basis={
+                    "n_configurations": len(members),
+                    "n_comparison_eligible": len(comparable),
+                    "isolating_contrast_available": isolating,
+                },
+                limitations=(
+                    "The workflow compares complete GP configurations.",
+                    "The current score is a training-residual heuristic, not a formal comparison statistic.",
+                ),
+            )
+        )
+    return conclusions
+
+
+def _build_ambiguities(
+    attempts: Sequence[WavelengthModelAttemptResult],
+    conclusions: Sequence[WavelengthAdvisoryConclusion],
+    *,
+    ranking_status: str,
+    top_ranked_model: str | None,
+) -> list[WavelengthUnresolvedAmbiguity]:
+    ambiguities: list[WavelengthUnresolvedAmbiguity] = []
+    models = tuple(
+        attempt.model or attempt.model_kernel_config_id or "unknown"
+        for attempt in attempts
+    )
+    failed = [
+        attempt
+        for attempt in attempts
+        if attempt.status.technical_outcome is TechnicalOutcome.FAILED
+    ]
+
+    if not attempts:
+        ambiguities.append(
+            WavelengthUnresolvedAmbiguity(
+                code="no_candidate_attempts",
+                summary="No model/kernel configuration attempts are available.",
+                affected_scopes=(WavelengthConclusionScope.WORKFLOW,),
+                resolution_requirements=(
+                    "Run at least one wavelength-model configuration.",
+                ),
+            )
+        )
+    if ranking_status == "available":
+        ambiguities.append(
+            WavelengthUnresolvedAmbiguity(
+                code="training_residual_ranking_is_heuristic",
+                summary=(
+                    "The available ranking is based on training-residual fit quality "
+                    "and is not a formal or held-out model comparison."
+                ),
+                affected_scopes=(
+                    WavelengthConclusionScope.COMPLETE_CONFIGURATION,
+                    WavelengthConclusionScope.MEAN_STRUCTURE,
+                    WavelengthConclusionScope.COVARIANCE_STRUCTURE,
+                ),
+                models=models,
+                resolution_requirements=(
+                    "Add held-out or cross-validated predictive comparison.",
+                    "Assess seed and subsampling stability.",
+                ),
+                details={"top_ranked_model": top_ranked_model},
+            )
+        )
+    elif ranking_status == "single_valid_candidate":
+        ambiguities.append(
+            WavelengthUnresolvedAmbiguity(
+                code="single_valid_candidate_not_comparative",
+                summary=(
+                    "Only one candidate has valid fit-quality diagnostics, so it "
+                    "cannot establish a comparative preference."
+                ),
+                affected_scopes=(WavelengthConclusionScope.WORKFLOW,),
+                models=models,
+                resolution_requirements=(
+                    "Obtain valid fit-quality diagnostics for another candidate.",
+                ),
+            )
+        )
+    else:
+        ambiguities.append(
+            WavelengthUnresolvedAmbiguity(
+                code="comparative_ranking_unavailable",
+                summary="No comparative fit-quality ranking is available.",
+                affected_scopes=(WavelengthConclusionScope.WORKFLOW,),
+                models=models,
+                resolution_requirements=(
+                    "Resolve fit failures or missing diagnostics before comparison.",
+                ),
+            )
+        )
+
+    if failed:
+        ambiguities.append(
+            WavelengthUnresolvedAmbiguity(
+                code="technical_failures_limit_hypothesis_coverage",
+                summary=(
+                    "Technical failures prevent some configured hypotheses from "
+                    "contributing comparable evidence."
+                ),
+                affected_scopes=(
+                    WavelengthConclusionScope.COMPLETE_CONFIGURATION,
+                    WavelengthConclusionScope.MEAN_STRUCTURE,
+                    WavelengthConclusionScope.COVARIANCE_STRUCTURE,
+                ),
+                models=tuple(
+                    attempt.model or attempt.model_kernel_config_id or "unknown"
+                    for attempt in failed
+                ),
+                resolution_requirements=(
+                    "Resolve the recorded failure stages and rerun affected candidates.",
+                ),
+            )
+        )
+
+    ambiguous_scopes = {
+        conclusion.scope
+        for conclusion in conclusions
+        if conclusion.disposition
+        is WavelengthConclusionDisposition.SCIENTIFICALLY_AMBIGUOUS
+    }
+    if WavelengthConclusionScope.MEAN_STRUCTURE in ambiguous_scopes:
+        ambiguities.append(
+            WavelengthUnresolvedAmbiguity(
+                code="mean_effect_not_isolated",
+                summary=(
+                    "At least one wavelength-mean hypothesis lacks a same-covariance "
+                    "contrast, so its separate contribution cannot be attributed."
+                ),
+                affected_scopes=(WavelengthConclusionScope.MEAN_STRUCTURE,),
+                models=models,
+                resolution_requirements=(
+                    "Compare alternative means under the same covariance parameterization.",
+                ),
+            )
+        )
+    if WavelengthConclusionScope.COVARIANCE_STRUCTURE in ambiguous_scopes:
+        ambiguities.append(
+            WavelengthUnresolvedAmbiguity(
+                code="covariance_effect_not_isolated",
+                summary=(
+                    "At least one wavelength-covariance hypothesis lacks a same-mean "
+                    "contrast, so its separate contribution cannot be attributed."
+                ),
+                affected_scopes=(WavelengthConclusionScope.COVARIANCE_STRUCTURE,),
+                models=models,
+                resolution_requirements=(
+                    "Compare alternative covariances under the same mean structure.",
+                ),
+            )
+        )
+    return ambiguities
+
+
+def synthesize_wavelength_advisory_conclusions(
+    workflow_report: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Synthesize explicit conclusions and ambiguities from an advisory report.
+
+    The returned mapping is additive and non-selecting.  It may be attached to
+    an existing workflow under ``advisory_conclusions`` and
+    ``unresolved_ambiguities`` without changing the legacy fields.
+    """
+    if not isinstance(workflow_report, Mapping):
+        raise TypeError("workflow_report must be a mapping")
+
+    raw_attempts = _outcomes_from_workflow(workflow_report)
+    attempts = [
+        WavelengthModelAttemptResult.from_mapping(payload)
+        for payload in raw_attempts
+    ]
+    quality_rows = _quality_rows_from_workflow(workflow_report)
+    quality_report = workflow_report.get("quality_report")
+    quality_report = quality_report if isinstance(quality_report, Mapping) else {}
+    ranking_status = str(
+        workflow_report.get("fit_quality_ranking_status")
+        or quality_report.get("ranking_status")
+        or quality_report.get("fit_quality_ranking_status")
+        or "unavailable"
+    )
+    top_ranked_value = workflow_report.get("top_ranked_model")
+    if top_ranked_value is None:
+        top_ranked_value = quality_report.get("top_ranked_model")
+    top_ranked_model = (
+        str(top_ranked_value) if top_ranked_value is not None else None
+    )
+
+    configuration_conclusions: list[WavelengthAdvisoryConclusion] = []
+    dispositions: dict[str, WavelengthConclusionDisposition] = {}
+    for attempt in attempts:
+        key = attempt.model_kernel_config_id or attempt.model or "unknown"
+        disposition = _configuration_disposition(attempt)
+        dispositions[key] = disposition
+        quality_row = _quality_row_for_attempt(attempt, quality_rows)
+        hypothesis = attempt.hypothesis
+        configuration_conclusions.append(
+            WavelengthAdvisoryConclusion(
+                conclusion_id=f"complete_configuration:{key}",
+                scope=WavelengthConclusionScope.COMPLETE_CONFIGURATION,
+                subject=attempt.model or key,
+                disposition=disposition,
+                summary=_configuration_summary(
+                    attempt,
+                    disposition,
+                    ranking_status,
+                    top_ranked_model,
+                ),
+                models=(attempt.model or key,),
+                model_kernel_config_ids=(key,),
+                mean_structures=(
+                    hypothesis.mean_structure.value if hypothesis is not None else "unknown",
+                ),
+                covariance_structures=(
+                    hypothesis.covariance_structure.value
+                    if hypothesis is not None
+                    else "unknown",
+                ),
+                evidence_basis={
+                    **attempt.status.to_dict(),
+                    "quality_rank": quality_row.get("quality_rank"),
+                    "fit_quality_score": quality_row.get("fit_quality_score"),
+                    "score_kind": quality_report.get("score_kind"),
+                    "is_top_ranked": quality_row.get("is_top_ranked"),
+                },
+                limitations=tuple(
+                    dict.fromkeys(
+                        (
+                            "The configuration contains both a mean and a covariance model.",
+                            "The current score is a training-residual heuristic, not a formal comparison statistic.",
+                            *(hypothesis.comparison_cautions if hypothesis is not None else ()),
+                        )
+                    )
+                ),
+            )
+        )
+
+    mean_conclusions = _aggregate_structure_conclusions(
+        attempts,
+        dispositions,
+        scope=WavelengthConclusionScope.MEAN_STRUCTURE,
+    )
+    covariance_conclusions = _aggregate_structure_conclusions(
+        attempts,
+        dispositions,
+        scope=WavelengthConclusionScope.COVARIANCE_STRUCTURE,
+    )
+    conclusions = [
+        *configuration_conclusions,
+        *mean_conclusions,
+        *covariance_conclusions,
+    ]
+    ambiguities = _build_ambiguities(
+        attempts,
+        conclusions,
+        ranking_status=ranking_status,
+        top_ranked_model=top_ranked_model,
+    )
+
+    disposition_counts: dict[str, int] = {}
+    for conclusion in conclusions:
+        name = conclusion.disposition.value
+        disposition_counts[name] = disposition_counts.get(name, 0) + 1
+
+    return {
+        "schema_version": WAVELENGTH_ADVISORY_CONCLUSION_SCHEMA_VERSION,
+        "kind": "wavelength_advisory_conclusion_synthesis",
+        "advisory_only": True,
+        "automatic_model_selection_applied": False,
+        "selected_model": None,
+        "fit_quality_ranking_status": ranking_status,
+        "top_ranked_model": top_ranked_model,
+        "conclusions": [item.to_dict() for item in conclusions],
+        "unresolved_ambiguities": [item.to_dict() for item in ambiguities],
+        "summary": {
+            "n_attempts": len(attempts),
+            "n_conclusions": len(conclusions),
+            "n_unresolved_ambiguities": len(ambiguities),
+            "conclusion_disposition_counts": disposition_counts,
+        },
+    }

--- a/pgmuvi/wavelength_diagnostics.py
+++ b/pgmuvi/wavelength_diagnostics.py
@@ -23,6 +23,9 @@ except ImportError:  # pragma: no cover - pgmuvi normally depends on torch
 
 from pgmuvi.preprocess.quality import assess_sampling_quality, robust_scale
 from pgmuvi.preprocess.variability import is_variable
+from pgmuvi.wavelength_conclusions import (
+    synthesize_wavelength_advisory_conclusions,
+)
 from pgmuvi.wavelength_hypotheses import (
     WAVELENGTH_HYPOTHESIS_SCHEMA_VERSION,
     WavelengthModelHypothesis,
@@ -5796,6 +5799,36 @@ def _piwd_format_advisory_workflow_text_report(
         "it is expected to be False because scoring summarizes already-completed fits.",
     ]
 
+    conclusions = workflow_report.get("advisory_conclusions") or []
+    ambiguities = workflow_report.get("unresolved_ambiguities") or []
+    if conclusions or ambiguities:
+        lines.extend(
+            [
+                "",
+                "Advisory conclusions",
+                "=" * 60,
+                f"conclusion_schema_version: {workflow_report.get('advisory_conclusion_schema_version')}",
+                f"n_conclusions: {len(conclusions)}",
+                f"n_unresolved_ambiguities: {len(ambiguities)}",
+            ]
+        )
+        for conclusion in conclusions:
+            if not isinstance(conclusion, dict):
+                continue
+            lines.append(
+                "- "
+                f"[{conclusion.get('scope')}] {conclusion.get('subject')}: "
+                f"{conclusion.get('disposition')} — {conclusion.get('summary')}"
+            )
+        if ambiguities:
+            lines.append("unresolved_ambiguities:")
+            for ambiguity in ambiguities:
+                if not isinstance(ambiguity, dict):
+                    continue
+                lines.append(
+                    f"- {ambiguity.get('code')}: {ambiguity.get('summary')}"
+                )
+
     if fallback_report.get("available"):
         lines.extend(
             [
@@ -5962,12 +5995,31 @@ def run_period_independent_wavelength_advisory_workflow(
         ),
         "fallback_diagnostics_available": fallback_report.get("available"),
         "fallback_report": fallback_report,
+        "advisory_conclusion_schema_version": None,
+        "advisory_conclusions": [],
+        "unresolved_ambiguities": [],
+        "advisory_conclusion_summary": {},
         "model_kernel_config_report": model_kernel_config_report,
         "run_report": run_report,
         "quality_report": quality_report,
         "comparison_text_report": comparison_text_report,
         "text_report": None,
     }
+    conclusion_synthesis = synthesize_wavelength_advisory_conclusions(
+        workflow_report
+    )
+    workflow_report["advisory_conclusion_schema_version"] = (
+        conclusion_synthesis.get("schema_version")
+    )
+    workflow_report["advisory_conclusions"] = conclusion_synthesis.get(
+        "conclusions", []
+    )
+    workflow_report["unresolved_ambiguities"] = conclusion_synthesis.get(
+        "unresolved_ambiguities", []
+    )
+    workflow_report["advisory_conclusion_summary"] = conclusion_synthesis.get(
+        "summary", {}
+    )
     if make_text_report:
         workflow_report["text_report"] = _piwd_format_advisory_workflow_text_report(
             workflow_report,
@@ -6541,6 +6593,26 @@ def _piwd_batch_extract_model_kernel_config_rows(*, source_row, workflow):
     ranked_rows = quality_report.get("ranked_results") or workflow.get("ranked_results") or []
     rows = _piwd_batch_merge_model_kernel_config_rows(run_rows, ranked_rows)
 
+    conclusion_rows = [
+        item
+        for item in workflow.get("advisory_conclusions") or []
+        if isinstance(item, dict)
+        and item.get("scope") == "complete_configuration"
+    ]
+    conclusions_by_id = {}
+    conclusions_by_model = {}
+    for conclusion in conclusion_rows:
+        for config_id in conclusion.get("model_kernel_config_ids") or []:
+            if _piwd_batch_nonempty(config_id):
+                conclusions_by_id[config_id] = conclusion
+        models = conclusion.get("models") or []
+        if len(models) == 1 and _piwd_batch_nonempty(models[0]):
+            model = models[0]
+            if model in conclusions_by_model:
+                conclusions_by_model[model] = None
+            else:
+                conclusions_by_model[model] = conclusion
+
     ranking_status, _ = _piwd_resolve_fit_quality_ranking_state(
         quality_report if quality_report else workflow
     )
@@ -6548,6 +6620,10 @@ def _piwd_batch_extract_model_kernel_config_rows(*, source_row, workflow):
     out = []
     for item in rows:
         fit_kwargs = item.get("fit_kwargs") if isinstance(item.get("fit_kwargs"), dict) else {}
+        conclusion = conclusions_by_id.get(item.get("model_kernel_config_id"))
+        if conclusion is None:
+            conclusion = conclusions_by_model.get(item.get("model"))
+        conclusion = conclusion if isinstance(conclusion, dict) else {}
         flattened = {
             "source_index": source_row.get("source_index"),
             "source_id": source_row.get("source_id"),
@@ -6561,6 +6637,11 @@ def _piwd_batch_extract_model_kernel_config_rows(*, source_row, workflow):
             "quality_rank": item.get("quality_rank"),
             "is_top_ranked": item.get("is_top_ranked"),
             "model": item.get("model"),
+            "advisory_conclusion_schema_version": workflow.get(
+                "advisory_conclusion_schema_version"
+            ),
+            "advisory_conclusion_disposition": conclusion.get("disposition"),
+            "advisory_conclusion_summary": conclusion.get("summary"),
             "status": item.get("status"),
             "attempt_disposition": item.get("attempt_disposition"),
             "execution_stage": item.get("execution_stage"),
@@ -6663,6 +6744,9 @@ def _piwd_batch_model_kernel_config_csv_fields():
         "quality_rank",
         "is_top_ranked",
         "model",
+        "advisory_conclusion_schema_version",
+        "advisory_conclusion_disposition",
+        "advisory_conclusion_summary",
         "status",
         "attempt_disposition",
         "execution_stage",
@@ -7332,6 +7416,15 @@ def run_period_independent_wavelength_advisory_workflow_batch(
                 ),
                 warning_count=candidate_warning_count,
             )
+            advisory_conclusion_summary = (
+                workflow.get("advisory_conclusion_summary") or {}
+            )
+            unresolved_ambiguities = workflow.get("unresolved_ambiguities") or []
+            unresolved_ambiguity_codes = [
+                item.get("code")
+                for item in unresolved_ambiguities
+                if isinstance(item, dict) and item.get("code")
+            ]
             row.update(
                 {
                     "status": "passed",
@@ -7343,6 +7436,21 @@ def run_period_independent_wavelength_advisory_workflow_batch(
                     "top_ranked_model": workflow_top_ranked_model,
                     "top_ranked_fit_quality_score": workflow_top_ranked_score,
                     "score_kind": workflow.get("score_kind"),
+                    "advisory_conclusion_schema_version": workflow.get(
+                        "advisory_conclusion_schema_version"
+                    ),
+                    "n_advisory_conclusions": advisory_conclusion_summary.get(
+                        "n_conclusions", 0
+                    ),
+                    "n_unresolved_ambiguities": advisory_conclusion_summary.get(
+                        "n_unresolved_ambiguities", 0
+                    ),
+                    "advisory_conclusion_disposition_counts": (
+                        advisory_conclusion_summary.get(
+                            "conclusion_disposition_counts", {}
+                        )
+                    ),
+                    "unresolved_ambiguity_codes": unresolved_ambiguity_codes,
                     "warning_count": candidate_warning_count,
                     "training_recovered_from_failure": candidate_recovery,
                     "n_model_kernel_configs": n_model_kernel_configs,
@@ -7356,6 +7464,16 @@ def run_period_independent_wavelength_advisory_workflow_batch(
                         "top_ranked_model": workflow_top_ranked_model,
                         "top_ranked_fit_quality_score": workflow_top_ranked_score,
                         "score_kind": workflow.get("score_kind"),
+                        "advisory_conclusion_schema_version": workflow.get(
+                            "advisory_conclusion_schema_version"
+                        ),
+                        "n_advisory_conclusions": advisory_conclusion_summary.get(
+                            "n_conclusions", 0
+                        ),
+                        "n_unresolved_ambiguities": advisory_conclusion_summary.get(
+                            "n_unresolved_ambiguities", 0
+                        ),
+                        "unresolved_ambiguity_codes": unresolved_ambiguity_codes,
                         "automatic_model_selection_applied": workflow.get(
                             "automatic_model_selection_applied"
                         ),

--- a/pgmuvi/wavelength_results.py
+++ b/pgmuvi/wavelength_results.py
@@ -748,6 +748,7 @@ class WavelengthAdvisoryResult:
                 "interpretation",
                 "advisory_conclusions",
                 "unresolved_ambiguities",
+                "advisory_conclusion_summary",
             )
             if name in payload
         }

--- a/tests/test_docs_wavelength_conclusions.py
+++ b/tests/test_docs_wavelength_conclusions.py
@@ -1,0 +1,55 @@
+"""Documentation contracts for wavelength-advisory conclusions."""
+
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class TestWavelengthConclusionDocumentation(unittest.TestCase):
+    def test_api_reference_includes_conclusion_module(self):
+        api = (ROOT / "docs/source/api.rst").read_text()
+        module_page = ROOT / "docs/source/pgmuvi.wavelength_conclusions.rst"
+        self.assertIn("pgmuvi.wavelength_conclusions", api)
+        self.assertTrue(module_page.exists())
+        self.assertIn(
+            "automodule:: pgmuvi.wavelength_conclusions",
+            module_page.read_text(),
+        )
+
+
+    def test_future_work_tracks_constraint_and_validation_tranche(self):
+        future_work = (ROOT / "docs/source/future_work.rst").read_text()
+        advisory = (ROOT / "docs/source/howto/wavelength_advisory.rst").read_text()
+        for marker in (
+            "TBD[wavelength-derived-constraints]",
+            "TBD[wavelength-constraint-validation]",
+        ):
+            self.assertIn(marker, future_work)
+            self.assertIn(marker, advisory)
+        self.assertIn("2DWavelengthDependent", future_work)
+        self.assertIn("2DDustMean", future_work)
+        self.assertIn("2DPowerLawMean", future_work)
+        self.assertIn("2DSeparable", future_work)
+        self.assertIn("temporal and wavelength ARD dimensions", future_work)
+
+    def test_advisory_docs_define_conclusions_and_ambiguities(self):
+        advisory = (ROOT / "docs/source/howto/wavelength_advisory.rst").read_text()
+        interpretation = (
+            ROOT / "docs/source/howto/interpreting_results.rst"
+        ).read_text()
+        for text in (advisory, interpretation):
+            self.assertIn("advisory_conclusions", text)
+            self.assertIn("unresolved_ambiguities", text)
+            self.assertIn("remains_plausible", text)
+            self.assertIn("technically_unevaluable", text)
+            self.assertIn("scientifically_ambiguous", text)
+            self.assertIn("incomparable", text)
+            self.assertIn("training-residual", text)
+            self.assertIn("not", text)
+            self.assertIn("automatic model selection", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wavelength_advisory_conclusions.py
+++ b/tests/test_wavelength_advisory_conclusions.py
@@ -1,0 +1,283 @@
+"""Tests for structured wavelength-advisory conclusions."""
+
+import json
+import unittest
+
+from pgmuvi.wavelength_conclusions import (
+    WAVELENGTH_ADVISORY_CONCLUSION_SCHEMA_VERSION,
+    WavelengthAdvisoryConclusion,
+    WavelengthConclusionDisposition,
+    WavelengthConclusionScope,
+    WavelengthUnresolvedAmbiguity,
+    synthesize_wavelength_advisory_conclusions,
+)
+from pgmuvi.wavelength_results import WavelengthAdvisoryResult
+from pgmuvi.wavelength_diagnostics import (
+    _piwd_batch_extract_model_kernel_config_rows,
+    _piwd_batch_model_kernel_config_csv_fields,
+    run_period_independent_wavelength_advisory_workflow,
+)
+
+
+def _outcome(model, *, fit_quality=True, failed=False):
+    if failed:
+        return {
+            "model_kernel_config_id": f"config_{model}",
+            "model": model,
+            "status": "failed",
+            "attempt_disposition": "attempted",
+            "execution_stage": "optimization",
+            "technical_outcome": "failed",
+            "diagnostic_validity": "unavailable",
+            "scientific_usability": "unusable",
+            "comparison_eligibility": "ineligible",
+            "warning_severity": "error",
+            "failure_code": "numerical_stability_failed",
+            "failure_stage": "optimization",
+            "exception_type": "RuntimeError",
+            "exception_message": "synthetic failure",
+            "fit_kwargs": {"training_iter": 20},
+        }
+    return {
+        "model_kernel_config_id": f"config_{model}",
+        "model": model,
+        "status": "passed",
+        "attempt_disposition": "attempted",
+        "execution_stage": "completed",
+        "technical_outcome": "completed",
+        "diagnostic_validity": "valid" if fit_quality else "unavailable",
+        "scientific_usability": "usable" if fit_quality else "limited",
+        "comparison_eligibility": "eligible" if fit_quality else "ineligible",
+        "warning_severity": None,
+        "fit_kwargs": {"training_iter": 20},
+        "fit_quality": {"available": fit_quality},
+        "fit_quality_available": fit_quality,
+    }
+
+
+def _workflow(outcomes, *, ranking_status="available", top="2DDustMean"):
+    ranked = []
+    for rank, outcome in enumerate(outcomes, start=1):
+        if outcome.get("comparison_eligibility") != "eligible":
+            continue
+        ranked.append(
+            {
+                "model_kernel_config_id": outcome["model_kernel_config_id"],
+                "model": outcome["model"],
+                "quality_rank": rank,
+                "fit_quality_available": True,
+                "fit_quality_score": 10.0 - rank,
+                "is_top_ranked": outcome["model"] == top,
+            }
+        )
+    return {
+        "kind": "period_independent_wavelength_advisory_workflow",
+        "advisory_only": True,
+        "automatic_model_selection_applied": False,
+        "selected_model": None,
+        "fit_quality_ranking_status": ranking_status,
+        "top_ranked_model": top if ranking_status == "available" else None,
+        "run_report": {
+            "kind": "period_independent_wavelength_model_kernel_config_results",
+            "outcomes": outcomes,
+        },
+        "quality_report": {
+            "kind": "period_independent_wavelength_model_kernel_config_quality_scores",
+            "ranking_status": ranking_status,
+            "score_kind": "training_residual_fit_quality",
+            "ranked_results": ranked,
+        },
+    }
+
+
+class TestConclusionPrimitives(unittest.TestCase):
+    def test_records_are_json_safe_and_require_explicit_scope(self):
+        conclusion = WavelengthAdvisoryConclusion(
+            conclusion_id="complete_configuration:2D",
+            scope=WavelengthConclusionScope.COMPLETE_CONFIGURATION,
+            subject="2D",
+            disposition=WavelengthConclusionDisposition.REMAINS_PLAUSIBLE,
+            summary="The baseline remains plausible.",
+            models=("2D",),
+            evidence_basis={"fit_quality_score": 3.0},
+        )
+        ambiguity = WavelengthUnresolvedAmbiguity(
+            code="training_residual_ranking_is_heuristic",
+            summary="The score is heuristic.",
+            affected_scopes=(WavelengthConclusionScope.COMPLETE_CONFIGURATION,),
+        )
+        self.assertEqual(
+            conclusion.to_dict()["disposition"], "remains_plausible"
+        )
+        self.assertEqual(
+            ambiguity.to_dict()["affected_scopes"], ["complete_configuration"]
+        )
+        json.dumps(conclusion.to_dict())
+        json.dumps(ambiguity.to_dict())
+
+    def test_required_dispositions_are_stable(self):
+        self.assertEqual(
+            {item.value for item in WavelengthConclusionDisposition},
+            {
+                "remains_plausible",
+                "weakened",
+                "technically_unevaluable",
+                "scientifically_ambiguous",
+                "incomparable",
+            },
+        )
+
+
+class TestConclusionSynthesis(unittest.TestCase):
+    def test_synthesis_separates_configuration_mean_and_covariance_scopes(self):
+        outcomes = [
+            _outcome("2DDustMean"),
+            _outcome("2DPowerLawMean"),
+            _outcome("2DSeparable"),
+            _outcome("2D"),
+        ]
+        synthesis = synthesize_wavelength_advisory_conclusions(
+            _workflow(outcomes)
+        )
+
+        self.assertEqual(
+            synthesis["schema_version"],
+            WAVELENGTH_ADVISORY_CONCLUSION_SCHEMA_VERSION,
+        )
+        self.assertFalse(synthesis["automatic_model_selection_applied"])
+        self.assertIsNone(synthesis["selected_model"])
+        scopes = {item["scope"] for item in synthesis["conclusions"]}
+        self.assertEqual(
+            scopes,
+            {
+                "complete_configuration",
+                "mean_structure",
+                "covariance_structure",
+            },
+        )
+        dust = next(
+            item
+            for item in synthesis["conclusions"]
+            if item["conclusion_id"] == "mean_structure:dust_attenuation"
+        )
+        self.assertEqual(dust["disposition"], "remains_plausible")
+        self.assertTrue(dust["evidence_basis"]["isolating_contrast_available"])
+        codes = {
+            item["code"] for item in synthesis["unresolved_ambiguities"]
+        }
+        self.assertIn("training_residual_ranking_is_heuristic", codes)
+        json.dumps(synthesis)
+
+    def test_failed_attempt_is_technically_unevaluable(self):
+        synthesis = synthesize_wavelength_advisory_conclusions(
+            _workflow(
+                [_outcome("2DDustMean"), _outcome("2DWavelengthDependent", failed=True)],
+                ranking_status="single_valid_candidate",
+                top=None,
+            )
+        )
+        failed = next(
+            item
+            for item in synthesis["conclusions"]
+            if item["conclusion_id"]
+            == "complete_configuration:config_2DWavelengthDependent"
+        )
+        self.assertEqual(failed["disposition"], "technically_unevaluable")
+        codes = {
+            item["code"] for item in synthesis["unresolved_ambiguities"]
+        }
+        self.assertIn("single_valid_candidate_not_comparative", codes)
+        self.assertIn("technical_failures_limit_hypothesis_coverage", codes)
+
+    def test_unisolated_mechanism_is_scientifically_ambiguous(self):
+        synthesis = synthesize_wavelength_advisory_conclusions(
+            _workflow(
+                [_outcome("2DDustMean")],
+                ranking_status="single_valid_candidate",
+                top=None,
+            )
+        )
+        mean = next(
+            item
+            for item in synthesis["conclusions"]
+            if item["scope"] == "mean_structure"
+        )
+        covariance = next(
+            item
+            for item in synthesis["conclusions"]
+            if item["scope"] == "covariance_structure"
+        )
+        self.assertEqual(mean["disposition"], "scientifically_ambiguous")
+        self.assertEqual(
+            covariance["disposition"], "scientifically_ambiguous"
+        )
+
+
+
+    def test_typed_result_preserves_conclusion_sections(self):
+        outcomes = [_outcome("2DDustMean"), _outcome("2DPowerLawMean")]
+        workflow = _workflow(outcomes)
+        synthesis = synthesize_wavelength_advisory_conclusions(workflow)
+        workflow["advisory_conclusions"] = synthesis["conclusions"]
+        workflow["unresolved_ambiguities"] = synthesis[
+            "unresolved_ambiguities"
+        ]
+        workflow["advisory_conclusion_summary"] = synthesis["summary"]
+        typed = WavelengthAdvisoryResult.from_mapping(workflow)
+        self.assertEqual(
+            typed.sections["advisory_conclusions"], synthesis["conclusions"]
+        )
+        self.assertEqual(
+            typed.sections["advisory_conclusion_summary"], synthesis["summary"]
+        )
+
+    def test_batch_rows_receive_complete_configuration_conclusion(self):
+        outcomes = [_outcome("2DDustMean"), _outcome("2DPowerLawMean")]
+        workflow = _workflow(outcomes)
+        synthesis = synthesize_wavelength_advisory_conclusions(workflow)
+        workflow["advisory_conclusion_schema_version"] = synthesis[
+            "schema_version"
+        ]
+        workflow["advisory_conclusions"] = synthesis["conclusions"]
+        rows = _piwd_batch_extract_model_kernel_config_rows(
+            source_row={"source_index": 0, "source_id": "source", "status": "passed"},
+            workflow=workflow,
+        )
+        dust = next(row for row in rows if row["model"] == "2DDustMean")
+        self.assertEqual(
+            dust["advisory_conclusion_disposition"], "remains_plausible"
+        )
+        self.assertEqual(
+            dust["advisory_conclusion_schema_version"],
+            WAVELENGTH_ADVISORY_CONCLUSION_SCHEMA_VERSION,
+        )
+        fields = _piwd_batch_model_kernel_config_csv_fields()
+        self.assertIn("advisory_conclusion_disposition", fields)
+        self.assertIn("advisory_conclusion_summary", fields)
+
+    def test_workflow_adds_synthesis_without_selecting(self):
+        outcomes = [_outcome("2DDustMean"), _outcome("2DPowerLawMean")]
+        workflow = _workflow(outcomes)
+        report = run_period_independent_wavelength_advisory_workflow(
+            object(),
+            model_kernel_config_report={
+                "kind": "period_independent_wavelength_model_kernel_configs",
+                "model_kernel_configs": [],
+            },
+            run_report=workflow["run_report"],
+            quality_report=workflow["quality_report"],
+            make_text_report=True,
+        )
+        self.assertEqual(
+            report["advisory_conclusion_schema_version"],
+            WAVELENGTH_ADVISORY_CONCLUSION_SCHEMA_VERSION,
+        )
+        self.assertTrue(report["advisory_conclusions"])
+        self.assertTrue(report["unresolved_ambiguities"])
+        self.assertFalse(report["automatic_model_selection_applied"])
+        self.assertIsNone(report["selected_model"])
+        self.assertIn("Advisory conclusions", report["text_report"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR adds a structured synthesis layer for wavelength-model advisory results.

It introduces explicit advisory conclusions for:

- complete model/kernel configurations;
- mean-structure hypotheses;
- covariance-structure hypotheses.

The conclusions distinguish configurations or hypotheses that:

- remain plausible;
- are weakened by available evidence;
- are technically unevaluable;
- remain scientifically ambiguous;
- cannot be compared with the available evidence.

It also adds structured unresolved-ambiguity records and propagates the new information through typed wavelength-result adapters, legacy advisory dictionaries, text reports, batch summaries, long-form rows, and exported outputs.

## Scientific contract

This PR does not claim automatic model selection.

It does not change:

- fitting;
- optimization;
- scoring;
- ranking;
- comparison eligibility;
- candidate generation;
- failure classification.

The synthesis layer interprets the existing evidence while keeping mean and covariance hypotheses separate.

## Roadmap clarification

The documentation now records a dedicated remaining implementation tranche for:

- wavelength-derived kernel initialization and constraints;
- wavelength-derived mean initialization and constraints;
- independent temporal and wavelength ARD parameterization;
- ARD saturation and bound-proximity diagnostics;
- synthetic recovery, consensus, and real-LPV validation.

## Validation

- targeted unit tests passed;
- CI-equivalent Ruff check passed;
- strict Sphinx documentation build passed;
- complete unittest suite passed.