### PR TITLE
Build wavelength estimation context

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -59,6 +59,7 @@ Data, diagnostics, and validation
    pgmuvi.multiband_ls_significance
    pgmuvi.wavelength_conclusions
    pgmuvi.wavelength_diagnostics
+   pgmuvi.wavelength_estimation
    pgmuvi.wavelength_hypotheses
    pgmuvi.wavelength_results
    pgmuvi.wavelength_status

--- a/docs/source/future_work.rst
+++ b/docs/source/future_work.rst
@@ -43,9 +43,13 @@ Wavelength-derived fitting constraints and validation
 -----------------------------------------------------
 
 **TBD[wavelength-derived-constraints]**
-    Implement the dedicated scientific fitting tranche for data-derived
-    wavelength-kernel and wavelength-mean initialization and constraints.  The
-    tranche must summarize usable wavelength sampling, apply independent mean
+    The shared raw-coordinate wavelength-sampling context and the dormant
+    ``WAVELENGTH_RANGE`` guess/constraint strategies are implemented.  The
+    remaining scientific fitting tranche must apply data-derived wavelength-
+    kernel and wavelength-mean initialization and constraints.  It must use the
+    recorded usable-band, adjacent-spacing, gap, uncertainty, robust mean, and
+    robust amplitude summaries; transform raw-coordinate estimates into the
+    actual model-input coordinate where required; and apply independent mean
     and covariance estimates to ``2DWavelengthDependent``, ``2DDustMean``,
     ``2DPowerLawMean``, and ``2DSeparable``, and redesign the full ``2D``
     spectral-mixture parameterization so temporal and wavelength ARD dimensions

--- a/docs/source/pgmuvi.wavelength_estimation.rst
+++ b/docs/source/pgmuvi.wavelength_estimation.rst
@@ -1,0 +1,27 @@
+pgmuvi.wavelength_estimation
+============================
+
+This module builds the shared wavelength-estimation context used by the
+parameter workflow.  It records:
+
+* usable and excluded bands;
+* total wavelength span and adjacent wavelength spacings;
+* the largest wavelength gap and spacing irregularity;
+* robust per-band median, scatter, and multiple quantile amplitudes;
+* fractional and uncertainty-corrected amplitude summaries;
+* monotonicity indicators for median flux, amplitude, and scatter; and
+* an auditable wavelength-length-scale value and interval.
+
+The length-scale recommendation is expressed in the **raw wavelength
+coordinate**.  It is not transformed into the model-input coordinate and is
+not applied to any GP model by this package.  The
+``GuessStrategy.WAVELENGTH_RANGE`` and
+``ConstraintStrategy.WAVELENGTH_RANGE`` builders only make the recommendation
+available to later model-specific work.
+
+No logarithmic flux transformation is used when constructing these summaries.
+
+.. automodule:: pgmuvi.wavelength_estimation
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/pgmuvi/__init__.py
+++ b/pgmuvi/__init__.py
@@ -23,6 +23,7 @@ __all__ = [
     "trainers",
     "wavelength_conclusions",
     "wavelength_diagnostics",
+    "wavelength_estimation",
     "wavelength_hypotheses",
     "wavelength_results",
     "wavelength_status",

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -68,6 +68,7 @@ from pgmuvi.parameter_workflow import (
     build_and_apply_parameter_estimates,
     model_supports_parameter_workflow,
 )
+from pgmuvi.wavelength_estimation import build_wavelength_estimation_context
 from pgmuvi.constraint_utils import clamp_to_constraint_interior
 from pgmuvi.constraint_utils import register_constraint_preserving_value
 
@@ -9899,24 +9900,23 @@ class Lightcurve(InputHelpers, gpytorch.Module):
 
     def _build_parameter_estimation_context(self):
         """Construct a parameter-estimation context from this light curve."""
-        flux_values = self._ydata_raw
-        if isinstance(flux_values, torch.Tensor):
-            flux_values = flux_values.detach().cpu().numpy()
+        flux_values_all = self._ydata_raw
+        if isinstance(flux_values_all, torch.Tensor):
+            flux_values_all = flux_values_all.detach().cpu().numpy()
+        flux_values_all = np.asarray(flux_values_all, dtype=float).reshape(-1)
+        finite_flux_values = flux_values_all[np.isfinite(flux_values_all)]
 
-        flux_values = np.asarray(flux_values, dtype=float)
-        flux_values = flux_values[np.isfinite(flux_values)]
-
-        time_values = self._xdata_raw
-        if isinstance(time_values, torch.Tensor):
-            time_values = time_values.detach().cpu().numpy()
-
-        time_values = np.asarray(time_values, dtype=float)
+        input_values = self._xdata_raw
+        if isinstance(input_values, torch.Tensor):
+            input_values = input_values.detach().cpu().numpy()
+        input_values = np.asarray(input_values, dtype=float)
 
         if self.ndim > 1:
-            times = np.sort(time_values[:, 0])
+            times = np.sort(input_values[:, 0])
         else:
-            times = np.sort(time_values)
+            times = np.sort(input_values.reshape(-1))
 
+        times = times[np.isfinite(times)]
         baseline_duration = None
         median_cadence = None
 
@@ -9929,29 +9929,55 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             if gaps.size:
                 median_cadence = float(np.median(gaps))
 
-        if flux_values.size == 0:
-            return ParameterEstimationContext(
-                is_multiband=self.ndim > 1,
-                global_diagnostics=LightcurveDiagnostics(
-                    baseline_duration=baseline_duration,
-                    median_cadence=median_cadence,
-                ),
+        wavelength_diagnostics = None
+        band_diagnostics = {}
+        if self.ndim > 1:
+            uncertainty_values = None
+            if hasattr(self, "_yerr_raw") and self._yerr_raw is not None:
+                uncertainty_values = self._yerr_raw
+                if isinstance(uncertainty_values, torch.Tensor):
+                    uncertainty_values = uncertainty_values.detach().cpu().numpy()
+
+            band_labels = None
+            if self.band is not None and len(self.band) == flux_values_all.size:
+                band_labels = np.asarray(self.band, dtype=str)
+
+            wavelength_diagnostics, band_diagnostics = (
+                build_wavelength_estimation_context(
+                    wavelengths=input_values[:, 1],
+                    fluxes=flux_values_all,
+                    uncertainties=uncertainty_values,
+                    band_labels=band_labels,
+                )
             )
 
-        p025, p50, p975 = np.percentile(flux_values, [2.5, 50.0, 97.5])
-        return ParameterEstimationContext(
-            is_multiband=self.ndim > 1,
-            global_diagnostics=LightcurveDiagnostics(
+        if finite_flux_values.size == 0:
+            global_diagnostics = LightcurveDiagnostics(
+                baseline_duration=baseline_duration,
+                median_cadence=median_cadence,
+            )
+        else:
+            p025, p50, p975 = np.percentile(
+                finite_flux_values,
+                [2.5, 50.0, 97.5],
+            )
+            global_diagnostics = LightcurveDiagnostics(
                 median_flux=float(p50),
                 flux_percentiles={
                     2.5: float(p025),
                     50.0: float(p50),
                     97.5: float(p975),
                 },
-                n_points=int(flux_values.size),
+                n_points=int(finite_flux_values.size),
                 baseline_duration=baseline_duration,
                 median_cadence=median_cadence,
-            ),
+            )
+
+        return ParameterEstimationContext(
+            is_multiband=self.ndim > 1,
+            global_diagnostics=global_diagnostics,
+            band_diagnostics=band_diagnostics,
+            wavelength_diagnostics=wavelength_diagnostics,
         )
 
     def _apply_parameter_workflow_estimates(self):

--- a/pgmuvi/parameter_builders.py
+++ b/pgmuvi/parameter_builders.py
@@ -57,6 +57,51 @@ class ParameterEstimateBuilder:
         metadata = {
             "value_reason": value_reason,
         }
+        diagnostics = {}
+
+        if (
+            spec.guess_strategy is GuessStrategy.WAVELENGTH_RANGE
+            or spec.constraint_strategy is ConstraintStrategy.WAVELENGTH_RANGE
+        ):
+            wavelength_diagnostics = context.wavelength_diagnostics
+            if wavelength_diagnostics is not None:
+                diagnostics = {
+                    "schema_version": getattr(
+                        wavelength_diagnostics,
+                        "schema_version",
+                        None,
+                    ),
+                    "coordinate_space": getattr(
+                        wavelength_diagnostics,
+                        "coordinate_space",
+                        None,
+                    ),
+                    "n_usable_bands": getattr(
+                        wavelength_diagnostics,
+                        "n_usable_bands",
+                        None,
+                    ),
+                    "wavelength_span": getattr(
+                        wavelength_diagnostics,
+                        "wavelength_span",
+                        None,
+                    ),
+                    "median_adjacent_spacing": getattr(
+                        wavelength_diagnostics,
+                        "median_adjacent_spacing",
+                        None,
+                    ),
+                    "largest_gap": getattr(
+                        wavelength_diagnostics,
+                        "largest_gap",
+                        None,
+                    ),
+                    "recommendation_method": getattr(
+                        wavelength_diagnostics,
+                        "recommendation_method",
+                        None,
+                    ),
+                }
 
         if spec.name.startswith("mean_module.") and constraint is not None:
             metadata["constraint_reason"] = (
@@ -72,6 +117,7 @@ class ParameterEstimateBuilder:
             constraint_source=(
                 spec.constraint_strategy.value if spec.constraint_strategy else None
             ),
+            diagnostics=diagnostics,
             metadata=metadata,
         )
 
@@ -101,6 +147,12 @@ class ParameterEstimateBuilder:
                 return "global_diagnostics_unavailable"
 
             return "robust_flux_span_unavailable"
+
+        if spec.guess_strategy is GuessStrategy.WAVELENGTH_RANGE:
+            if context.wavelength_diagnostics is None:
+                return "wavelength_diagnostics_unavailable"
+
+            return "wavelength_lengthscale_recommendation_unavailable"
 
         return None
 
@@ -176,6 +228,9 @@ class ParameterEstimateBuilder:
 
         if spec.guess_strategy is GuessStrategy.CONSENSUS_MULTICOMP_PERIOD:
             return self._estimate_consensus_multicomp_period(spec, context)
+
+        if spec.guess_strategy is GuessStrategy.WAVELENGTH_RANGE:
+            return self._estimate_wavelength_range_value(spec, context)
 
         return None
 
@@ -324,7 +379,61 @@ class ParameterEstimateBuilder:
         if spec.constraint_strategy is ConstraintStrategy.ROBUST_POSITIVE_FLUX_SPAN:
             return self._estimate_robust_positive_flux_span_constraint(context)
 
+        if spec.constraint_strategy is ConstraintStrategy.WAVELENGTH_RANGE:
+            return self._estimate_wavelength_range_constraint(spec, context)
+
         return None
+
+    def _estimate_wavelength_range_value(
+        self,
+        spec: ParameterSpec,
+        context: ParameterEstimationContext,
+    ):
+        """Return the raw-coordinate wavelength length-scale recommendation."""
+        diagnostics = context.wavelength_diagnostics
+        if diagnostics is None:
+            return None
+
+        value = getattr(
+            diagnostics,
+            "recommended_lengthscale_initial",
+            None,
+        )
+        return self._reshape_initial_value(value, spec.shape)
+
+    def _estimate_wavelength_range_constraint(
+        self,
+        spec: ParameterSpec,
+        context: ParameterEstimationContext,
+    ):
+        """Return raw-coordinate wavelength length-scale bounds."""
+        diagnostics = context.wavelength_diagnostics
+        if diagnostics is None:
+            return None
+
+        bounds = getattr(
+            diagnostics,
+            "recommended_lengthscale_bounds",
+            None,
+        )
+        if bounds is None:
+            return None
+
+        lower, upper = bounds
+        if spec.shape is None:
+            return (lower, upper)
+
+        lower_tensor = torch.full(
+            spec.shape,
+            float(lower),
+            dtype=DEFAULT_DTYPE,
+        )
+        upper_tensor = torch.full(
+            spec.shape,
+            float(upper),
+            dtype=DEFAULT_DTYPE,
+        )
+        return (lower_tensor, upper_tensor)
 
     def _estimate_default_constraint(
         self,

--- a/pgmuvi/parameter_context.py
+++ b/pgmuvi/parameter_context.py
@@ -7,7 +7,7 @@ constraints. It does not compute diagnostics or apply values to models.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from typing import Any
 
 
@@ -38,7 +38,69 @@ class BandDiagnostics:
     mad_flux: float | None = None
     flux_percentiles: dict[float, float] = field(default_factory=dict)
     n_points: int | None = None
+    median_uncertainty: float | None = None
+    uncertainty_percentiles: dict[float, float] = field(default_factory=dict)
+    robust_scatter: float | None = None
+    raw_half_amplitude_q02_5_q97_5: float | None = None
+    raw_half_amplitude_q05_q95: float | None = None
+    raw_half_amplitude_q10_q90: float | None = None
+    fractional_half_amplitude_q02_5_q97_5: float | None = None
+    fractional_half_amplitude_q05_q95: float | None = None
+    fractional_half_amplitude_q10_q90: float | None = None
+    noise_corrected_robust_scatter: float | None = None
+    noise_corrected_half_amplitude_q02_5_q97_5: float | None = None
+    noise_corrected_half_amplitude_q05_q95: float | None = None
+    noise_corrected_half_amplitude_q10_q90: float | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
+
+
+WAVELENGTH_ESTIMATION_SCHEMA_VERSION = "pgmuvi-wavelength-estimation-v1"
+
+
+@dataclass(frozen=True)
+class WavelengthEstimationDiagnostics:
+    """Data-derived wavelength sampling and trend diagnostics.
+
+    All wavelength scales are expressed in the same raw coordinate units as
+    the second column of the input light curve.  The recommended length scale
+    and bounds are advisory physical-space quantities only; this object does
+    not account for a later input transformation applied by a GP model.
+    """
+
+    schema_version: str = WAVELENGTH_ESTIMATION_SCHEMA_VERSION
+    available: bool = False
+    coordinate_space: str = "raw_input"
+    n_observations: int = 0
+    n_distinct_wavelengths: int = 0
+    n_usable_bands: int = 0
+    min_points_per_band: int = 3
+    wavelengths: tuple[float, ...] = ()
+    wavelength_min: float | None = None
+    wavelength_max: float | None = None
+    wavelength_span: float | None = None
+    adjacent_spacings: tuple[float, ...] = ()
+    minimum_adjacent_spacing: float | None = None
+    median_adjacent_spacing: float | None = None
+    maximum_adjacent_spacing: float | None = None
+    largest_gap: float | None = None
+    largest_gap_ratio_to_median_spacing: float | None = None
+    spacing_ratio_max_to_min: float | None = None
+    coverage_class: str = "unavailable"
+    median_flux_monotonicity_class: str = "unavailable"
+    amplitude_monotonicity_class: str = "unavailable"
+    scatter_monotonicity_class: str = "unavailable"
+    median_flux_ratio_max_to_min_abs: float | None = None
+    amplitude_ratio_max_to_min: float | None = None
+    scatter_ratio_max_to_min: float | None = None
+    recommended_lengthscale_initial: float | None = None
+    recommended_lengthscale_bounds: tuple[float, float] | None = None
+    recommendation_method: str | None = None
+    excluded_bands: tuple[str, ...] = ()
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-safe dictionary representation."""
+        return asdict(self)
 
 
 @dataclass(frozen=True)
@@ -63,6 +125,7 @@ class ParameterEstimationContext:
     global_diagnostics: LightcurveDiagnostics | None = None
     band_diagnostics: dict[str, BandDiagnostics] = field(default_factory=dict)
     consensus_diagnostics: ConsensusDiagnostics | None = None
+    wavelength_diagnostics: WavelengthEstimationDiagnostics | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
 
     def bands(self) -> list[str]:

--- a/pgmuvi/wavelength_estimation.py
+++ b/pgmuvi/wavelength_estimation.py
@@ -1,0 +1,474 @@
+"""Wavelength-domain summaries for parameter estimation.
+
+The routines in this module summarize the wavelength sampling and robust
+per-band flux distributions of a multiband light curve.  They do not mutate a
+GP model and they do not claim that a particular wavelength model is selected.
+The resulting diagnostics are intended to provide a shared, auditable input to
+later wavelength-kernel and wavelength-mean initialization work.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import numpy as np
+
+from pgmuvi.parameter_context import (
+    BandDiagnostics,
+    WAVELENGTH_ESTIMATION_SCHEMA_VERSION,
+    WavelengthEstimationDiagnostics,
+)
+from pgmuvi.preprocess.quality import robust_scale
+
+
+def _finite_array(values: Any) -> np.ndarray:
+    """Return a flattened float array without changing its length."""
+    return np.asarray(values, dtype=float).reshape(-1)
+
+
+def _band_label_for_wavelength(wavelength: float) -> str:
+    """Return a stable fallback label for one numeric wavelength."""
+    return f"wavelength={wavelength:.17g}"
+
+
+def _safe_ratio(values: list[float], *, absolute: bool = False) -> float | None:
+    """Return max/min for finite positive values."""
+    arr = np.asarray(values, dtype=float)
+    arr = arr[np.isfinite(arr)]
+
+    if absolute:
+        arr = np.abs(arr)
+
+    arr = arr[arr > 0.0]
+    if arr.size < 2:
+        return None
+
+    return float(np.max(arr) / np.min(arr))
+
+
+def _monotonicity_class(values: list[float]) -> str:
+    """Classify a finite sequence without fitting a wavelength model."""
+    arr = np.asarray(values, dtype=float)
+    arr = arr[np.isfinite(arr)]
+
+    if arr.size < 2:
+        return "unavailable"
+
+    scale = max(float(np.max(np.abs(arr))), 1.0)
+    tolerance = 1.0e-10 * scale
+    differences = np.diff(arr)
+    positive = differences > tolerance
+    negative = differences < -tolerance
+
+    if not np.any(positive) and not np.any(negative):
+        return "approximately_constant"
+    if np.all(~negative) and np.any(positive):
+        return "non_decreasing"
+    if np.all(~positive) and np.any(negative):
+        return "non_increasing"
+    return "non_monotonic"
+
+
+def _noise_corrected_scale(scale: float, median_uncertainty: float | None) -> float:
+    """Subtract a representative measurement-noise variance in quadrature."""
+    if median_uncertainty is None or not math.isfinite(median_uncertainty):
+        return scale
+
+    return float(math.sqrt(max(scale * scale - median_uncertainty**2, 0.0)))
+
+
+def _build_band_diagnostics(
+    *,
+    band: str,
+    wavelengths: np.ndarray,
+    fluxes: np.ndarray,
+    uncertainties: np.ndarray | None,
+    min_points_per_band: int,
+) -> BandDiagnostics:
+    """Build robust physical-space summaries for one band."""
+    finite = np.isfinite(wavelengths) & np.isfinite(fluxes)
+    wavelength_values = wavelengths[finite]
+    flux_values = fluxes[finite]
+
+    n_points = int(flux_values.size)
+    representative_wavelength = (
+        float(np.median(wavelength_values)) if wavelength_values.size else None
+    )
+    wavelength_spread = (
+        float(np.max(wavelength_values) - np.min(wavelength_values))
+        if wavelength_values.size
+        else None
+    )
+
+    if uncertainties is not None:
+        uncertainty_values = uncertainties[finite]
+        uncertainty_values = uncertainty_values[
+            np.isfinite(uncertainty_values) & (uncertainty_values > 0.0)
+        ]
+    else:
+        uncertainty_values = np.asarray([], dtype=float)
+
+    median_uncertainty = (
+        float(np.median(uncertainty_values)) if uncertainty_values.size else None
+    )
+    uncertainty_percentiles: dict[float, float] = {}
+    if uncertainty_values.size:
+        uq = np.percentile(uncertainty_values, [5.0, 50.0, 95.0])
+        uncertainty_percentiles = {
+            5.0: float(uq[0]),
+            50.0: float(uq[1]),
+            95.0: float(uq[2]),
+        }
+
+    if flux_values.size:
+        quantile_levels = [2.5, 5.0, 10.0, 50.0, 90.0, 95.0, 97.5]
+        q = np.percentile(flux_values, quantile_levels)
+        flux_percentiles = {
+            level: float(value)
+            for level, value in zip(quantile_levels, q, strict=True)
+        }
+        median_flux = flux_percentiles[50.0]
+        mad_flux = float(np.median(np.abs(flux_values - median_flux)))
+        robust_scatter = float(robust_scale(flux_values))
+        amplitude_02_97 = 0.5 * (
+            flux_percentiles[97.5] - flux_percentiles[2.5]
+        )
+        amplitude_05_95 = 0.5 * (
+            flux_percentiles[95.0] - flux_percentiles[5.0]
+        )
+        amplitude_10_90 = 0.5 * (
+            flux_percentiles[90.0] - flux_percentiles[10.0]
+        )
+    else:
+        flux_percentiles = {}
+        median_flux = None
+        mad_flux = None
+        robust_scatter = None
+        amplitude_02_97 = None
+        amplitude_05_95 = None
+        amplitude_10_90 = None
+
+    fractional_denominator = (
+        abs(median_flux)
+        if median_flux is not None and math.isfinite(median_flux) and median_flux != 0.0
+        else None
+    )
+
+    def fractional(value: float | None) -> float | None:
+        if value is None or fractional_denominator is None:
+            return None
+        return float(value / fractional_denominator)
+
+    def corrected(value: float | None) -> float | None:
+        if value is None:
+            return None
+        return _noise_corrected_scale(value, median_uncertainty)
+
+    wavelength_consistent = False
+    if representative_wavelength is not None and wavelength_spread is not None:
+        wavelength_tolerance = 1.0e-10 * max(
+            abs(representative_wavelength),
+            1.0,
+        )
+        wavelength_consistent = wavelength_spread <= wavelength_tolerance
+
+    usable = (
+        n_points >= min_points_per_band
+        and representative_wavelength is not None
+        and math.isfinite(representative_wavelength)
+        and wavelength_consistent
+    )
+
+    exclusion_reason = None
+    if not usable:
+        if representative_wavelength is None:
+            exclusion_reason = "finite_wavelength_unavailable"
+        elif not wavelength_consistent:
+            exclusion_reason = "inconsistent_wavelength_within_band"
+        elif n_points < min_points_per_band:
+            exclusion_reason = "insufficient_finite_flux_points"
+
+    return BandDiagnostics(
+        band=band,
+        wavelength=representative_wavelength,
+        median_flux=median_flux,
+        mad_flux=mad_flux,
+        flux_percentiles=flux_percentiles,
+        n_points=n_points,
+        median_uncertainty=median_uncertainty,
+        uncertainty_percentiles=uncertainty_percentiles,
+        robust_scatter=robust_scatter,
+        raw_half_amplitude_q02_5_q97_5=amplitude_02_97,
+        raw_half_amplitude_q05_q95=amplitude_05_95,
+        raw_half_amplitude_q10_q90=amplitude_10_90,
+        fractional_half_amplitude_q02_5_q97_5=fractional(amplitude_02_97),
+        fractional_half_amplitude_q05_q95=fractional(amplitude_05_95),
+        fractional_half_amplitude_q10_q90=fractional(amplitude_10_90),
+        noise_corrected_robust_scatter=corrected(robust_scatter),
+        noise_corrected_half_amplitude_q02_5_q97_5=corrected(amplitude_02_97),
+        noise_corrected_half_amplitude_q05_q95=corrected(amplitude_05_95),
+        noise_corrected_half_amplitude_q10_q90=corrected(amplitude_10_90),
+        metadata={
+            "usable_for_wavelength_estimation": usable,
+            "exclusion_reason": exclusion_reason,
+            "wavelength_spread_within_band": wavelength_spread,
+            "wavelength_consistent_within_band": wavelength_consistent,
+            "n_positive_finite_uncertainties": int(uncertainty_values.size),
+        },
+    )
+
+
+def _coverage_class(n_bands: int) -> str:
+    """Return a descriptive sampling class based only on usable band count."""
+    if n_bands < 2:
+        return "unresolved"
+    if n_bands == 2:
+        return "two_band"
+    if n_bands <= 4:
+        return "sparse"
+    if n_bands <= 8:
+        return "moderate"
+    return "dense"
+
+
+def _lengthscale_recommendation(
+    wavelengths: np.ndarray,
+) -> tuple[float | None, tuple[float, float] | None, str | None]:
+    """Derive an auditable raw-coordinate length-scale recommendation."""
+    if wavelengths.size < 2:
+        return None, None, None
+
+    spacings = np.diff(wavelengths)
+    spacings = spacings[np.isfinite(spacings) & (spacings > 0.0)]
+    if spacings.size == 0:
+        return None, None, None
+
+    span = float(wavelengths[-1] - wavelengths[0])
+    if not math.isfinite(span) or span <= 0.0:
+        return None, None, None
+
+    minimum_spacing = float(np.min(spacings))
+    median_spacing = float(np.median(spacings))
+    largest_gap = float(np.max(spacings))
+
+    lower = max(
+        0.25 * minimum_spacing,
+        np.finfo(float).eps * max(float(np.max(np.abs(wavelengths))), 1.0),
+    )
+    initial = float(math.sqrt(median_spacing * span))
+    upper = max(5.0 * span, 4.0 * largest_gap, 2.0 * initial)
+    initial = min(max(initial, lower), upper)
+
+    return (
+        initial,
+        (float(lower), float(upper)),
+        "geometric_mean_of_median_spacing_and_total_span",
+    )
+
+
+def build_wavelength_estimation_context(
+    wavelengths: Any,
+    fluxes: Any,
+    uncertainties: Any | None = None,
+    band_labels: Any | None = None,
+    *,
+    min_points_per_band: int = 3,
+) -> tuple[WavelengthEstimationDiagnostics, dict[str, BandDiagnostics]]:
+    """Build wavelength sampling and robust per-band diagnostics.
+
+    Parameters
+    ----------
+    wavelengths
+        Numeric wavelength coordinate for each observation.
+    fluxes
+        Flux or magnitude value for each observation.  The values are summarized
+        in their supplied linear coordinate; no log-flux transformation is used.
+    uncertainties
+        Optional measurement uncertainties.  Only finite positive values enter
+        the uncertainty and noise-corrected summaries.
+    band_labels
+        Optional row-wise labels.  When absent, exact numeric wavelengths define
+        the groups.
+    min_points_per_band
+        Minimum number of finite wavelength/flux pairs required for a band to
+        enter cross-wavelength trend and length-scale summaries.
+
+    Returns
+    -------
+    diagnostics, band_diagnostics
+        An immutable wavelength-level summary and per-band diagnostics keyed by
+        label.
+    """
+    if min_points_per_band < 1:
+        raise ValueError("min_points_per_band must be at least 1.")
+
+    wavelength_values = _finite_array(wavelengths)
+    flux_values = _finite_array(fluxes)
+    if wavelength_values.size != flux_values.size:
+        raise ValueError("wavelengths and fluxes must have the same length.")
+
+    if uncertainties is not None:
+        uncertainty_values = _finite_array(uncertainties)
+        if uncertainty_values.size != flux_values.size:
+            raise ValueError(
+                "uncertainties must have the same length as wavelengths and fluxes."
+            )
+    else:
+        uncertainty_values = None
+
+    if band_labels is None:
+        labels = np.asarray(
+            [
+                _band_label_for_wavelength(value)
+                if math.isfinite(value)
+                else "wavelength=nonfinite"
+                for value in wavelength_values
+            ],
+            dtype=str,
+        )
+    else:
+        labels = np.asarray(band_labels, dtype=str).reshape(-1)
+        if labels.size != flux_values.size:
+            raise ValueError(
+                "band_labels must have the same length as wavelengths and fluxes."
+            )
+
+    band_diagnostics: dict[str, BandDiagnostics] = {}
+    for label in dict.fromkeys(labels.tolist()):
+        mask = labels == label
+        band_diagnostics[label] = _build_band_diagnostics(
+            band=label,
+            wavelengths=wavelength_values[mask],
+            fluxes=flux_values[mask],
+            uncertainties=(
+                uncertainty_values[mask]
+                if uncertainty_values is not None
+                else None
+            ),
+            min_points_per_band=min_points_per_band,
+        )
+
+    usable = [
+        item
+        for item in band_diagnostics.values()
+        if item.metadata.get("usable_for_wavelength_estimation")
+    ]
+    usable.sort(key=lambda item: float(item.wavelength))
+
+    usable_wavelengths = np.asarray(
+        [float(item.wavelength) for item in usable],
+        dtype=float,
+    )
+    distinct_wavelengths = np.unique(usable_wavelengths)
+    spacings = np.diff(distinct_wavelengths)
+    positive_spacings = spacings[
+        np.isfinite(spacings) & (spacings > 0.0)
+    ]
+
+    span = (
+        float(distinct_wavelengths[-1] - distinct_wavelengths[0])
+        if distinct_wavelengths.size >= 2
+        else None
+    )
+    minimum_spacing = (
+        float(np.min(positive_spacings)) if positive_spacings.size else None
+    )
+    median_spacing = (
+        float(np.median(positive_spacings)) if positive_spacings.size else None
+    )
+    maximum_spacing = (
+        float(np.max(positive_spacings)) if positive_spacings.size else None
+    )
+    gap_ratio = (
+        float(maximum_spacing / median_spacing)
+        if maximum_spacing is not None
+        and median_spacing is not None
+        and median_spacing > 0.0
+        else None
+    )
+    spacing_ratio = (
+        float(maximum_spacing / minimum_spacing)
+        if maximum_spacing is not None
+        and minimum_spacing is not None
+        and minimum_spacing > 0.0
+        else None
+    )
+
+    median_fluxes = [
+        float(item.median_flux)
+        for item in usable
+        if item.median_flux is not None and math.isfinite(item.median_flux)
+    ]
+    amplitudes = [
+        float(item.raw_half_amplitude_q05_q95)
+        for item in usable
+        if item.raw_half_amplitude_q05_q95 is not None
+        and math.isfinite(item.raw_half_amplitude_q05_q95)
+    ]
+    scatters = [
+        float(item.robust_scatter)
+        for item in usable
+        if item.robust_scatter is not None and math.isfinite(item.robust_scatter)
+    ]
+
+    initial, bounds, method = _lengthscale_recommendation(distinct_wavelengths)
+    excluded = tuple(
+        label
+        for label, item in band_diagnostics.items()
+        if not item.metadata.get("usable_for_wavelength_estimation")
+    )
+
+    diagnostics = WavelengthEstimationDiagnostics(
+        available=bool(distinct_wavelengths.size >= 2 and span is not None),
+        n_observations=int(
+            np.sum(np.isfinite(wavelength_values) & np.isfinite(flux_values))
+        ),
+        n_distinct_wavelengths=int(distinct_wavelengths.size),
+        n_usable_bands=len(usable),
+        min_points_per_band=min_points_per_band,
+        wavelengths=tuple(float(value) for value in distinct_wavelengths),
+        wavelength_min=(
+            float(distinct_wavelengths[0]) if distinct_wavelengths.size else None
+        ),
+        wavelength_max=(
+            float(distinct_wavelengths[-1]) if distinct_wavelengths.size else None
+        ),
+        wavelength_span=span,
+        adjacent_spacings=tuple(float(value) for value in positive_spacings),
+        minimum_adjacent_spacing=minimum_spacing,
+        median_adjacent_spacing=median_spacing,
+        maximum_adjacent_spacing=maximum_spacing,
+        largest_gap=maximum_spacing,
+        largest_gap_ratio_to_median_spacing=gap_ratio,
+        spacing_ratio_max_to_min=spacing_ratio,
+        coverage_class=_coverage_class(int(distinct_wavelengths.size)),
+        median_flux_monotonicity_class=_monotonicity_class(median_fluxes),
+        amplitude_monotonicity_class=_monotonicity_class(amplitudes),
+        scatter_monotonicity_class=_monotonicity_class(scatters),
+        median_flux_ratio_max_to_min_abs=_safe_ratio(
+            median_fluxes,
+            absolute=True,
+        ),
+        amplitude_ratio_max_to_min=_safe_ratio(amplitudes),
+        scatter_ratio_max_to_min=_safe_ratio(scatters),
+        recommended_lengthscale_initial=initial,
+        recommended_lengthscale_bounds=bounds,
+        recommendation_method=method,
+        excluded_bands=excluded,
+        metadata={
+            "uses_log_flux": False,
+            "lengthscale_units": "raw_wavelength_coordinate",
+            "lengthscale_applied_to_models": False,
+            "trend_order": "ascending_wavelength",
+        },
+    )
+
+    return diagnostics, band_diagnostics
+
+
+__all__ = [
+    "WAVELENGTH_ESTIMATION_SCHEMA_VERSION",
+    "WavelengthEstimationDiagnostics",
+    "build_wavelength_estimation_context",
+]

--- a/tests/test_docs_wavelength_estimation.py
+++ b/tests/test_docs_wavelength_estimation.py
@@ -1,0 +1,34 @@
+import unittest
+from pathlib import Path
+
+
+class TestWavelengthEstimationDocumentation(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        root = Path(__file__).resolve().parents[1]
+        cls.api_text = (root / "docs/source/api.rst").read_text(
+            encoding="utf-8"
+        )
+        cls.module_text = (
+            root / "docs/source/pgmuvi.wavelength_estimation.rst"
+        ).read_text(encoding="utf-8")
+        cls.future_work_text = (
+            root / "docs/source/future_work.rst"
+        ).read_text(encoding="utf-8")
+
+    def test_api_reference_includes_wavelength_estimation_module(self):
+        self.assertIn("pgmuvi.wavelength_estimation", self.api_text)
+
+    def test_module_page_states_raw_coordinate_and_no_application(self):
+        self.assertIn("raw wavelength", self.module_text)
+        self.assertIn("not applied to any GP model", self.module_text)
+        self.assertIn("No logarithmic flux transformation", self.module_text)
+
+    def test_future_work_retains_model_application_and_validation(self):
+        self.assertIn("actual model-input coordinate", self.future_work_text)
+        self.assertIn("2DWavelengthDependent", self.future_work_text)
+        self.assertIn("wavelength-constraint-validation", self.future_work_text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_lightcurve_wavelength_estimation_context.py
+++ b/tests/test_lightcurve_wavelength_estimation_context.py
@@ -1,0 +1,62 @@
+import unittest
+
+import torch
+
+from pgmuvi.lightcurve import Lightcurve
+from pgmuvi.wavelength_estimation import WAVELENGTH_ESTIMATION_SCHEMA_VERSION
+
+
+class TestLightcurveWavelengthEstimationContext(unittest.TestCase):
+    def test_multiband_context_contains_wavelength_and_band_diagnostics(self):
+        xdata = torch.tensor(
+            [
+                [0.0, 0.5],
+                [1.0, 0.5],
+                [2.0, 0.5],
+                [0.0, 1.0],
+                [1.0, 1.0],
+                [2.0, 1.0],
+                [0.0, 2.0],
+                [1.0, 2.0],
+                [2.0, 2.0],
+            ]
+        )
+        ydata = torch.tensor(
+            [8.0, 10.0, 12.0, 18.0, 20.0, 22.0, 28.0, 30.0, 32.0]
+        )
+        yerr = torch.full((9,), 0.5)
+        bands = ["g"] * 3 + ["r"] * 3 + ["j"] * 3
+        lc = Lightcurve(xdata, ydata, yerr=yerr, band=bands)
+
+        context = lc._build_parameter_estimation_context()
+
+        self.assertEqual(
+            context.wavelength_diagnostics.schema_version,
+            WAVELENGTH_ESTIMATION_SCHEMA_VERSION,
+        )
+        self.assertTrue(context.wavelength_diagnostics.available)
+        self.assertEqual(context.wavelength_diagnostics.n_usable_bands, 3)
+        self.assertEqual(set(context.band_diagnostics), {"g", "r", "j"})
+        self.assertAlmostEqual(
+            context.band_diagnostics["r"].median_flux,
+            20.0,
+        )
+        self.assertAlmostEqual(
+            context.band_diagnostics["r"].median_uncertainty,
+            0.5,
+        )
+
+    def test_one_dimensional_context_has_no_wavelength_diagnostics(self):
+        lc = Lightcurve(
+            torch.tensor([0.0, 1.0, 2.0]),
+            torch.tensor([1.0, 2.0, 3.0]),
+        )
+
+        context = lc._build_parameter_estimation_context()
+
+        self.assertIsNone(context.wavelength_diagnostics)
+        self.assertEqual(context.band_diagnostics, {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wavelength_estimation.py
+++ b/tests/test_wavelength_estimation.py
@@ -1,0 +1,191 @@
+import math
+import unittest
+
+import numpy as np
+
+from pgmuvi.wavelength_estimation import (
+    WAVELENGTH_ESTIMATION_SCHEMA_VERSION,
+    build_wavelength_estimation_context,
+)
+
+
+class TestWavelengthEstimationContext(unittest.TestCase):
+    def test_builds_sampling_and_robust_band_summaries(self):
+        wavelengths = np.repeat([0.5, 1.0, 2.0, 5.0], 5)
+        bands = np.repeat(["g", "r", "j", "m"], 5)
+        fluxes = np.concatenate(
+            [
+                [8.0, 9.0, 10.0, 11.0, 12.0],
+                [18.0, 19.0, 20.0, 21.0, 22.0],
+                [28.0, 29.0, 30.0, 31.0, 32.0],
+                [38.0, 39.0, 40.0, 41.0, 42.0],
+            ]
+        )
+        uncertainties = np.full(fluxes.shape, 0.5)
+
+        diagnostics, band_diagnostics = build_wavelength_estimation_context(
+            wavelengths,
+            fluxes,
+            uncertainties,
+            bands,
+        )
+
+        self.assertEqual(
+            diagnostics.schema_version,
+            WAVELENGTH_ESTIMATION_SCHEMA_VERSION,
+        )
+        self.assertTrue(diagnostics.available)
+        self.assertEqual(diagnostics.coordinate_space, "raw_input")
+        self.assertEqual(diagnostics.n_observations, 20)
+        self.assertEqual(diagnostics.n_distinct_wavelengths, 4)
+        self.assertEqual(diagnostics.n_usable_bands, 4)
+        self.assertEqual(diagnostics.wavelengths, (0.5, 1.0, 2.0, 5.0))
+        self.assertAlmostEqual(diagnostics.wavelength_span, 4.5)
+        self.assertEqual(diagnostics.adjacent_spacings, (0.5, 1.0, 3.0))
+        self.assertAlmostEqual(diagnostics.minimum_adjacent_spacing, 0.5)
+        self.assertAlmostEqual(diagnostics.median_adjacent_spacing, 1.0)
+        self.assertAlmostEqual(diagnostics.largest_gap, 3.0)
+        self.assertAlmostEqual(
+            diagnostics.largest_gap_ratio_to_median_spacing,
+            3.0,
+        )
+        self.assertAlmostEqual(diagnostics.spacing_ratio_max_to_min, 6.0)
+        self.assertEqual(diagnostics.coverage_class, "sparse")
+        self.assertEqual(
+            diagnostics.median_flux_monotonicity_class,
+            "non_decreasing",
+        )
+        self.assertEqual(
+            diagnostics.amplitude_monotonicity_class,
+            "approximately_constant",
+        )
+        self.assertAlmostEqual(
+            diagnostics.recommended_lengthscale_initial,
+            math.sqrt(4.5),
+        )
+        self.assertEqual(
+            diagnostics.recommended_lengthscale_bounds,
+            (0.125, 22.5),
+        )
+        self.assertFalse(diagnostics.metadata["uses_log_flux"])
+        self.assertFalse(
+            diagnostics.metadata["lengthscale_applied_to_models"]
+        )
+
+        self.assertEqual(set(band_diagnostics), {"g", "r", "j", "m"})
+        self.assertAlmostEqual(band_diagnostics["g"].median_flux, 10.0)
+        self.assertAlmostEqual(band_diagnostics["g"].median_uncertainty, 0.5)
+        self.assertAlmostEqual(
+            band_diagnostics["g"].raw_half_amplitude_q05_q95,
+            1.8,
+        )
+        self.assertAlmostEqual(
+            band_diagnostics["g"].fractional_half_amplitude_q05_q95,
+            0.18,
+        )
+        self.assertTrue(
+            band_diagnostics["g"].metadata[
+                "usable_for_wavelength_estimation"
+            ]
+        )
+
+    def test_excludes_underpopulated_band_from_cross_wavelength_context(self):
+        wavelengths = np.asarray([1.0, 1.0, 1.0, 2.0, 2.0])
+        fluxes = np.asarray([10.0, 11.0, 12.0, 20.0, 21.0])
+        bands = np.asarray(["a", "a", "a", "b", "b"])
+
+        diagnostics, band_diagnostics = build_wavelength_estimation_context(
+            wavelengths,
+            fluxes,
+            band_labels=bands,
+            min_points_per_band=3,
+        )
+
+        self.assertFalse(diagnostics.available)
+        self.assertEqual(diagnostics.n_usable_bands, 1)
+        self.assertEqual(diagnostics.n_distinct_wavelengths, 1)
+        self.assertEqual(diagnostics.coverage_class, "unresolved")
+        self.assertEqual(diagnostics.excluded_bands, ("b",))
+        self.assertIsNone(diagnostics.recommended_lengthscale_initial)
+        self.assertEqual(
+            band_diagnostics["b"].metadata["exclusion_reason"],
+            "insufficient_finite_flux_points",
+        )
+
+
+    def test_excludes_band_label_with_inconsistent_wavelengths(self):
+        diagnostics, band_diagnostics = build_wavelength_estimation_context(
+            wavelengths=[1.0, 1.1, 1.0, 2.0, 2.0, 2.0],
+            fluxes=[1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+            band_labels=["a", "a", "a", "b", "b", "b"],
+        )
+
+        self.assertFalse(diagnostics.available)
+        self.assertEqual(diagnostics.excluded_bands, ("a",))
+        self.assertEqual(
+            band_diagnostics["a"].metadata["exclusion_reason"],
+            "inconsistent_wavelength_within_band",
+        )
+        self.assertFalse(
+            band_diagnostics["a"].metadata[
+                "wavelength_consistent_within_band"
+            ]
+        )
+
+    def test_noise_correction_uses_only_positive_finite_uncertainties(self):
+        diagnostics, band_diagnostics = build_wavelength_estimation_context(
+            wavelengths=[1.0, 1.0, 1.0, 2.0, 2.0, 2.0],
+            fluxes=[9.0, 10.0, 11.0, 18.0, 20.0, 22.0],
+            uncertainties=[0.5, -1.0, np.nan, 1.0, 1.0, 1.0],
+            band_labels=["a", "a", "a", "b", "b", "b"],
+        )
+
+        self.assertTrue(diagnostics.available)
+        self.assertAlmostEqual(band_diagnostics["a"].median_uncertainty, 0.5)
+        self.assertEqual(
+            band_diagnostics["a"].metadata[
+                "n_positive_finite_uncertainties"
+            ],
+            1,
+        )
+        self.assertLessEqual(
+            band_diagnostics["a"].noise_corrected_robust_scatter,
+            band_diagnostics["a"].robust_scatter,
+        )
+
+    def test_fallback_labels_group_exact_numeric_wavelengths(self):
+        diagnostics, band_diagnostics = build_wavelength_estimation_context(
+            wavelengths=[1.0, 1.0, 1.0, 2.0, 2.0, 2.0],
+            fluxes=[1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+        )
+
+        self.assertTrue(diagnostics.available)
+        self.assertEqual(len(band_diagnostics), 2)
+        self.assertIn("wavelength=1", band_diagnostics)
+        self.assertIn("wavelength=2", band_diagnostics)
+
+    def test_rejects_mismatched_lengths(self):
+        with self.assertRaisesRegex(ValueError, "same length"):
+            build_wavelength_estimation_context(
+                wavelengths=[1.0, 2.0],
+                fluxes=[1.0],
+            )
+
+        with self.assertRaisesRegex(ValueError, "same length"):
+            build_wavelength_estimation_context(
+                wavelengths=[1.0, 2.0],
+                fluxes=[1.0, 2.0],
+                uncertainties=[0.1],
+            )
+
+    def test_rejects_nonpositive_minimum_band_count(self):
+        with self.assertRaisesRegex(ValueError, "at least 1"):
+            build_wavelength_estimation_context(
+                wavelengths=[1.0],
+                fluxes=[1.0],
+                min_points_per_band=0,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wavelength_range_parameter_builders.py
+++ b/tests/test_wavelength_range_parameter_builders.py
@@ -1,0 +1,124 @@
+import math
+import unittest
+
+import torch
+
+from pgmuvi.parameter_builders import ParameterEstimateBuilder
+from pgmuvi.parameter_context import ParameterEstimationContext
+from pgmuvi.parameter_specs import (
+    ConstraintStrategy,
+    GuessStrategy,
+    ParameterDomain,
+    ParameterRole,
+    ParameterScale,
+    ParameterSpec,
+)
+from pgmuvi.wavelength_estimation import build_wavelength_estimation_context
+
+
+class TestWavelengthRangeParameterBuilder(unittest.TestCase):
+    @staticmethod
+    def _context():
+        diagnostics, band_diagnostics = build_wavelength_estimation_context(
+            wavelengths=[1.0] * 3 + [2.0] * 3 + [5.0] * 3,
+            fluxes=[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
+            band_labels=["a"] * 3 + ["b"] * 3 + ["c"] * 3,
+        )
+        return ParameterEstimationContext(
+            is_multiband=True,
+            band_diagnostics=band_diagnostics,
+            wavelength_diagnostics=diagnostics,
+        )
+
+    @staticmethod
+    def _spec(shape=None):
+        return ParameterSpec(
+            name="covar_module.wavelength_kernel.lengthscale",
+            role=ParameterRole.WAVELENGTH_SCALE,
+            domain=ParameterDomain.WAVELENGTH,
+            scale=ParameterScale.LINEAR,
+            shape=shape,
+            guess_strategy=GuessStrategy.WAVELENGTH_RANGE,
+            constraint_strategy=ConstraintStrategy.WAVELENGTH_RANGE,
+        )
+
+    def test_builds_scalar_value_and_constraint_from_wavelength_context(self):
+        estimate = ParameterEstimateBuilder().build_one(
+            self._spec(),
+            self._context(),
+        )
+
+        self.assertAlmostEqual(estimate.value, math.sqrt(8.0))
+        self.assertEqual(estimate.constraint, (0.25, 20.0))
+        self.assertEqual(estimate.value_source, "wavelength_range")
+        self.assertEqual(estimate.constraint_source, "wavelength_range")
+        self.assertIsNone(estimate.metadata["value_reason"])
+        self.assertEqual(estimate.diagnostics["coordinate_space"], "raw_input")
+        self.assertEqual(estimate.diagnostics["n_usable_bands"], 3)
+        self.assertAlmostEqual(estimate.diagnostics["wavelength_span"], 4.0)
+        self.assertAlmostEqual(
+            estimate.diagnostics["median_adjacent_spacing"],
+            2.0,
+        )
+        self.assertAlmostEqual(estimate.diagnostics["largest_gap"], 3.0)
+
+    def test_expands_value_and_bounds_to_declared_shape(self):
+        estimate = ParameterEstimateBuilder().build_one(
+            self._spec(shape=(2, 1, 1)),
+            self._context(),
+        )
+
+        self.assertEqual(tuple(estimate.value.shape), (2, 1, 1))
+        self.assertTrue(
+            torch.allclose(
+                estimate.value,
+                torch.full((2, 1, 1), math.sqrt(8.0)),
+            )
+        )
+        lower, upper = estimate.constraint
+        self.assertEqual(tuple(lower.shape), (2, 1, 1))
+        self.assertEqual(tuple(upper.shape), (2, 1, 1))
+        self.assertTrue(torch.all(lower == 0.25))
+        self.assertTrue(torch.all(upper == 20.0))
+
+    def test_reports_unavailable_wavelength_context(self):
+        estimate = ParameterEstimateBuilder().build_one(
+            self._spec(),
+            ParameterEstimationContext(is_multiband=True),
+        )
+
+        self.assertIsNone(estimate.value)
+        self.assertIsNone(estimate.constraint)
+        self.assertEqual(
+            estimate.metadata["value_reason"],
+            "wavelength_diagnostics_unavailable",
+        )
+        self.assertEqual(estimate.diagnostics, {})
+
+    def test_reports_context_without_two_usable_wavelengths(self):
+        diagnostics, band_diagnostics = build_wavelength_estimation_context(
+            wavelengths=[1.0, 1.0, 1.0],
+            fluxes=[1.0, 2.0, 3.0],
+        )
+        context = ParameterEstimationContext(
+            is_multiband=True,
+            band_diagnostics=band_diagnostics,
+            wavelength_diagnostics=diagnostics,
+        )
+
+        estimate = ParameterEstimateBuilder().build_one(
+            self._spec(),
+            context,
+        )
+
+        self.assertIsNone(estimate.value)
+        self.assertIsNone(estimate.constraint)
+        self.assertEqual(
+            estimate.metadata["value_reason"],
+            "wavelength_lengthscale_recommendation_unavailable",
+        )
+        self.assertEqual(estimate.diagnostics["n_usable_bands"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR adds the shared wavelength-estimation context required for later scientifically motivated model initialization and constraints.

It summarizes:

- usable and excluded wavelength bands;
- raw-coordinate wavelength span;
- adjacent-band spacing;
- large wavelength gaps;
- robust per-band median flux;
- quantile-based amplitudes;
- fractional amplitudes;
- uncertainty-corrected scatter;
- robust wavelength-trend diagnostics;
- per-band uncertainty summaries.

It also implements the previously dormant `WAVELENGTH_RANGE` guess and constraint strategies in the parameter-estimation builders.

## Scientific contract

This PR does not yet apply the resulting wavelength estimates to GP kernel or mean parameters.

The generated values are explicitly recorded as:

- heuristic candidates;
- expressed in raw wavelength coordinates;
- not yet transformed into model coordinates;
- not formal comparison evidence;
- not proof that wavelength dependence is resolved.

This separation allows the next packages to apply and validate the estimates without silently changing fitting behavior in this foundational package.

## Integrity and provenance

The implementation:

- rejects inconsistent band-to-wavelength mappings;
- distinguishes present bands from usable bands;
- records excluded bands and reasons;
- preserves coordinate-system provenance;
- integrates the context into `Lightcurve` parameter estimation;
- exposes a versioned public diagnostics object.

## Remaining constraint tranche

Follow-up packages will:

- apply wavelength-derived covariance initialization and bounds to separable models;
- initialize and constrain wavelength-dependent mean parameters;
- separate temporal and wavelength ARD parameterization in the full `2D` baseline;
- extend component- and dimension-specific saturation diagnostics;
- perform synthetic, consensus, and real-LPV recovery validation.

## Validation

- targeted unit tests passed;
- CI-equivalent Ruff check passed;
- strict Sphinx documentation build passed;
- complete unittest suite passed.