### PR TITLE
Apply wavelength-derived mean estimates

### DIFF
--- a/docs/source/future_work.rst
+++ b/docs/source/future_work.rst
@@ -51,10 +51,17 @@ Wavelength-derived fitting constraints and validation
     value ordering is preserved, and raw/model-coordinate plus effective-bound
     provenance is recorded.
 
-    The remaining scientific fitting tranche must initialize and constrain the
-    wavelength-dependent mean parameters independently, redesign the full
-    ``2D`` spectral-mixture parameterization so temporal and wavelength ARD
-    dimensions can receive genuinely independent bounds, and extend explicit
+    Data-derived wavelength-mean initialization and enforceable constraints are
+    now implemented independently for ``2DWavelengthDependent``,
+    ``2DDustMean``, and ``2DPowerLawMean``.  Dust and power-law means reconstruct
+    physical positive wavelength under affine input transforms, while the
+    quadratic mean uses the GP input coordinate.  Parameter-level provenance
+    records the robust-band fit, proposed interval, effective interval, and
+    coordinate basis.
+
+    The remaining scientific fitting tranche must redesign the full ``2D``
+    spectral-mixture parameterization so temporal and wavelength ARD dimensions
+    can receive genuinely independent bounds, and extend explicit
     component/dimension saturation diagnostics.  It must continue to use the
     recorded usable-band, adjacent-spacing, gap, uncertainty, robust mean, and
     robust amplitude summaries rather than reverting to generic constants.

--- a/docs/source/howto/priors_constraints.rst
+++ b/docs/source/howto/priors_constraints.rst
@@ -100,6 +100,15 @@ For the noise variance::
    the GP input coordinate and intersected with any existing registered bounds,
    so an existing tighter user interval is not loosened or replaced.
 
+   The wavelength-dependent mean parameters in
+   ``"2DWavelengthDependent"``, ``"2DDustMean"``, and
+   ``"2DPowerLawMean"`` also use registered GPyTorch raw-parameter
+   constraints.  Their data-derived intervals are therefore enforced during
+   optimization rather than merely reported for plain ``nn.Parameter``
+   objects.  Dust and power-law wavelength formulas are evaluated in the
+   reconstructed physical wavelength coordinate when an affine input transform
+   is active.
+
    For the **non-separable ``model="2D"``**, GPyTorch applies constraints
    element-wise to the entire ``mixture_means`` tensor (which spans both time
    and wavelength dimensions), so temporal and wavelength constraints cannot be

--- a/docs/source/howto/wavelength_advisory.rst
+++ b/docs/source/howto/wavelength_advisory.rst
@@ -601,13 +601,15 @@ fallback fields remain unchanged.
 Remaining wavelength-constraint tranche
 ---------------------------------------
 
-The conclusion synthesis does not improve the fitted wavelength parameters.
-That separate implementation roadmap is explicitly tracked by
-``TBD[wavelength-derived-constraints]`` and
-``TBD[wavelength-constraint-validation]``.  It covers data-derived wavelength
-sampling summaries, independent wavelength-kernel and wavelength-mean
-initialization, dimension-aware temporal versus wavelength ARD bounds for the
-full ``2D`` spectral-mixture baseline, saturation provenance, synthetic
-recovery, consensus compatibility, and real-LPV validation.  The current B4
-conclusion records must not be presented as a substitute for that scientific
-fitting work.
+The conclusion synthesis is separate from parameter fitting.  Subsequent
+packages now provide data-derived wavelength sampling summaries, separable
+wavelength-kernel initialization, and independent wavelength-mean
+initialization with enforceable constraints for ``2DWavelengthDependent``,
+``2DDustMean``, and ``2DPowerLawMean``.  Those fitting changes do not turn the
+conclusion records into automatic selection evidence.
+
+The remaining roadmap is tracked by ``TBD[wavelength-derived-constraints]`` and
+``TBD[wavelength-constraint-validation]``.  It covers dimension-aware temporal
+versus wavelength ARD bounds for the full ``2D`` spectral-mixture baseline,
+saturation provenance, synthetic recovery, consensus compatibility, and
+real-LPV validation.

--- a/docs/source/howto/wavelength_models.rst
+++ b/docs/source/howto/wavelength_models.rst
@@ -283,8 +283,38 @@ records both the proposed and effective bounds under
 This is an initialization and optimization-domain improvement, not evidence
 that a source has resolved wavelength dependence.  It does not apply to the
 full non-separable ``2D`` spectral-mixture kernel, whose temporal and wavelength
-ARD entries still share tensor-wide constraints, and it does not yet initialize
-the dust, power-law, or quadratic wavelength-mean shape parameters.
+ARD entries still share tensor-wide constraints.
+
+Data-derived wavelength mean initialization
+-------------------------------------------
+
+The three wavelength-dependent mean families now use robust per-band median
+fluxes to construct initial values and finite optimization intervals.  The
+parameter workflow records these under
+``wavelength_mean_estimate_provenance``.
+
+``2DWavelengthDependent``
+   Fits the quadratic bias and two coefficients in the transformed wavelength
+   coordinate actually supplied to the GP.  The coefficient intervals scale
+   with the robust target range and transformed wavelength span.
+
+``2DDustMean``
+   Fits a coarse positive dust-attenuation profile using physical wavelength
+   and the transformed training target.  Positive amplitude, optical depth,
+   and extinction-index estimates are converted to the model's explicit
+   ``log_*`` parameters only when applied.
+
+``2DPowerLawMean``
+   Fits ``offset + weight * wavelength**exponent`` using physical wavelength
+   and the transformed training target.  The signed weight is retained and the
+   exponent is constrained to a finite physical search domain.
+
+For dust and power-law means, an affine wavelength transform is inverted inside
+the mean module.  MinMax, Z-score, robust Z-score, and pure coordinate shifts
+therefore do not turn physical wavelength into a zero, negative, or otherwise
+misinterpreted base.  A custom non-affine wavelength transform is rejected for
+these physical means.  The intervals are registered on raw GPyTorch parameters
+and remain active throughout optimization.
 
 Interpreting model-specific diagnostics
 ---------------------------------------

--- a/docs/source/pgmuvi.gps.rst
+++ b/docs/source/pgmuvi.gps.rst
@@ -10,3 +10,4 @@ workflow based on physical-space parameter estimates.
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: offset, weight, exponent, log_amplitude, log_tau, log_alpha

--- a/docs/source/pgmuvi.wavelength_estimation.rst
+++ b/docs/source/pgmuvi.wavelength_estimation.rst
@@ -27,10 +27,35 @@ the effective registered interval.
 
 This applies to the wavelength covariance in ``2DWavelengthDependent``,
 ``2DDustMean``, ``2DPowerLawMean``, and ``2DSeparable``.  It does not change the
-full non-separable ``2D`` spectral-mixture ARD parameterization, and it does not
-yet initialize wavelength-dependent mean parameters.
+full non-separable ``2D`` spectral-mixture ARD parameterization.
 
-No logarithmic flux transformation is used when constructing these summaries.
+The same module now builds model-ready wavelength-mean recommendations from
+robust per-band median fluxes.  ``GuessStrategy.WAVELENGTH_MEAN`` and
+``ConstraintStrategy.WAVELENGTH_MEAN`` initialize and constrain:
+
+* the quadratic bias and coefficients in ``2DWavelengthDependent``;
+* the offset, amplitude, optical depth, and extinction index in
+  ``2DDustMean``; and
+* the offset, signed amplitude, and exponent in ``2DPowerLawMean``.
+
+The quadratic coefficients are fitted in the wavelength coordinate seen by the
+GP.  Dust and power-law means instead evaluate on reconstructed physical,
+strictly positive wavelength while their flux parameters remain in the actual
+training-target coordinate.  Affine input transforms are supported and recorded;
+a non-affine wavelength transform is rejected rather than silently changing the
+physical interpretation.  Every affected mean parameter uses a registered
+GPyTorch raw-parameter interval, so the reported bounds remain active during
+optimization.
+
+With only two usable bands, the power-law exponent is not identifiable jointly
+with its offset and amplitude.  The estimator therefore keeps the documented
+``-2`` default and fits only the linear coefficients instead of selecting an
+arbitrary grid endpoint.  An exactly flat band-median trend is not promoted to
+a dust-shape estimate.
+
+No logarithmic flux fitting is introduced by this workflow.  Explicit
+``log_*`` mean parameters receive positive physical estimates and are converted
+to their stored log parameterization only at application time.
 
 .. automodule:: pgmuvi.wavelength_estimation
     :members:

--- a/pgmuvi/gps.py
+++ b/pgmuvi/gps.py
@@ -22,6 +22,11 @@ from gpytorch.models import ExactGP, ApproximateGP
 from gpytorch.variational import CholeskyVariationalDistribution
 from gpytorch.variational import VariationalStrategy
 
+from pgmuvi.constraint_utils import (
+    make_interval_constraint,
+    register_constraint_preserving_value,
+)
+
 from pgmuvi.parameter_specs import (
     ConstraintStrategy,
     GuessStrategy,
@@ -325,7 +330,58 @@ def _kernel_parameter_schema(
 # ---------------------------------------------------------------------
 # Mean functions
 # ---------------------------------------------------------------------
-class PowerLawMean(gpt.means.Mean):
+class _IntervalConstrainedMeanMixin:
+    """Utilities for GPyTorch-constrained mean-function parameters."""
+
+    def _register_interval_parameter(self, name, initial_value, lower, upper):
+        initial = t.as_tensor(initial_value, dtype=t.get_default_dtype())
+        lower_tensor = t.full_like(initial, float(lower))
+        upper_tensor = t.full_like(initial, float(upper))
+        constraint = gpt.constraints.Interval(lower_tensor, upper_tensor)
+        raw_name = f"raw_{name}"
+        self.register_parameter(
+            raw_name,
+            t.nn.Parameter(constraint.inverse_transform(initial.clone())),
+        )
+        self.register_constraint(raw_name, constraint)
+
+    def _constrained_parameter(self, name):
+        raw = getattr(self, f"raw_{name}")
+        constraint = getattr(self, f"raw_{name}_constraint")
+        return constraint.transform(raw)
+
+    def _set_constrained_parameter(self, name, value):
+        raw = getattr(self, f"raw_{name}")
+        constraint = getattr(self, f"raw_{name}_constraint")
+        value_tensor = t.as_tensor(value, dtype=raw.dtype, device=raw.device)
+        value_tensor = value_tensor.reshape_as(raw)
+        with t.no_grad():
+            raw.copy_(constraint.inverse_transform(value_tensor))
+
+    def configure_default_flux_bounds(self, train_y):
+        """Set broad finite flux bounds scaled to the training target."""
+        values = t.as_tensor(train_y).detach()
+        values = values[t.isfinite(values)]
+        if values.numel() == 0:
+            return
+        span = float(values.max() - values.min())
+        maximum = float(values.abs().max())
+        bound = max(10.0 * max(span, maximum, 1.0), 100.0)
+        for name in ("offset", "weight", "bias", "weights"):
+            raw_name = f"raw_{name}"
+            if not hasattr(self, raw_name):
+                continue
+            raw = getattr(self, raw_name)
+            lower = t.full_like(raw, -bound)
+            upper = t.full_like(raw, bound)
+            register_constraint_preserving_value(
+                self,
+                raw_name,
+                make_interval_constraint(lower, upper),
+            )
+
+
+class PowerLawMean(_IntervalConstrainedMeanMixin, gpt.means.Mean):
     """Mean function with power-law wavelength dependence for 2D GP models.
 
     Computes the mean flux as a power law in the second input dimension
@@ -346,38 +402,87 @@ class PowerLawMean(gpt.means.Mean):
 
     Attributes
     ----------
-    offset : torch.nn.Parameter
-        Constant offset term.
-    weight : torch.nn.Parameter
-        Amplitude scaling factor (unconstrained; sign determines whether
-        flux increases or decreases with wavelength).
-    exponent : torch.nn.Parameter
-        Power-law exponent for the wavelength dependence. Defaults to
+    offset : torch.Tensor
+        Constrained constant offset term.
+    weight : torch.Tensor
+        Constrained signed amplitude scaling factor; its sign determines
+        whether flux increases or decreases with wavelength.
+    exponent : torch.Tensor
+        Constrained power-law exponent for the wavelength dependence. Defaults to
         ``-2.0``, which gives a steep decline from optical to infrared
         (i.e., high optical amplitude).
 
     Notes
     -----
-    The ``exponent`` parameter is unconstrained and can be learned to any
-    real value during optimisation. Initialising it to a physically
-    motivated value (e.g. ``-1.7`` for a typical dust-extinction law, or
-    ``2.0`` for a Rayleigh-Jeans tail) can help convergence.
+    The parameters use registered finite GPyTorch intervals. The parameter
+    workflow replaces the broad constructor bounds with data-derived intervals
+    before optimization when wavelength-mean diagnostics are available.
     """
 
     def __init__(self, batch_shape=None):
         super().__init__()
         if batch_shape is None:
             batch_shape = t.Size()
-        self.register_parameter(
-            "offset", t.nn.Parameter(t.zeros(*batch_shape, 1))
+        shape = (*batch_shape, 1)
+        self._register_interval_parameter(
+            "offset", t.zeros(shape), -100.0, 100.0
         )
-        self.register_parameter(
-            "weight", t.nn.Parameter(t.ones(*batch_shape, 1))
+        self._register_interval_parameter(
+            "weight", t.ones(shape), -100.0, 100.0
         )
-        # Default exponent of -2 gives a steep optical-to-IR decline
-        self.register_parameter(
-            "exponent", t.nn.Parameter(t.full((*batch_shape, 1), -2.0))
+        self._register_interval_parameter(
+            "exponent", t.full(shape, -2.0), -10.0, 10.0
         )
+        self.register_buffer("wavelength_origin", t.tensor(0.0))
+        self.register_buffer("wavelength_scale", t.tensor(1.0))
+
+    @property
+    def offset(self):
+        return self._constrained_parameter("offset")
+
+    @offset.setter
+    def offset(self, value):
+        self._set_constrained_parameter("offset", value)
+
+    @property
+    def weight(self):
+        return self._constrained_parameter("weight")
+
+    @weight.setter
+    def weight(self, value):
+        self._set_constrained_parameter("weight", value)
+
+    @property
+    def exponent(self):
+        return self._constrained_parameter("exponent")
+
+    @exponent.setter
+    def exponent(self, value):
+        self._set_constrained_parameter("exponent", value)
+
+    def configure_wavelength_coordinate(self, origin, scale):
+        """Configure ``physical = origin + scale * model_wavelength``."""
+        origin_value = t.as_tensor(
+            origin,
+            dtype=self.wavelength_origin.dtype,
+            device=self.wavelength_origin.device,
+        )
+        scale_value = t.as_tensor(
+            scale,
+            dtype=self.wavelength_scale.dtype,
+            device=self.wavelength_scale.device,
+        )
+        if (
+            scale_value.numel() != 1
+            or not t.isfinite(scale_value)
+            or scale_value <= 0
+        ):
+            raise ValueError("Physical-wavelength scale must be finite and positive.")
+        self.wavelength_origin.copy_(origin_value.reshape_as(self.wavelength_origin))
+        self.wavelength_scale.copy_(scale_value.reshape_as(self.wavelength_scale))
+
+    def physical_wavelength(self, x):
+        return self.wavelength_origin + self.wavelength_scale * x[..., 1]
 
     def parameter_schema(self, prefix="mean_module"):
         """Return model-independent parameter specifications for PowerLawMean."""
@@ -392,8 +497,14 @@ class PowerLawMean(gpt.means.Mean):
                     role=ParameterRole.OFFSET,
                     domain=ParameterDomain.FLUX,
                     scale=ParameterScale.LINEAR,
-                    guess_strategy=GuessStrategy.MEDIAN_FLUX,
-                    constraint_strategy=ConstraintStrategy.ROBUST_FLUX_RANGE,
+                    guess_strategy=GuessStrategy.WAVELENGTH_MEAN,
+                    constraint_strategy=ConstraintStrategy.WAVELENGTH_MEAN,
+                    guess_source="wavelength_mean_estimation_context",
+                    constraint_source="wavelength_mean_estimation_context",
+                    metadata={
+                        "wavelength_mean_model": "2DPowerLawMean",
+                        "wavelength_mean_parameter": "mean_module.offset",
+                    },
                     description=(
                         "Constant additive flux offset of the wavelength "
                         "power-law mean function."
@@ -404,8 +515,14 @@ class PowerLawMean(gpt.means.Mean):
                     role=ParameterRole.AMPLITUDE,
                     domain=ParameterDomain.FLUX,
                     scale=ParameterScale.LINEAR,
-                    guess_strategy=GuessStrategy.ROBUST_FLUX_SPAN,
-                    constraint_strategy=ConstraintStrategy.ROBUST_FLUX_RANGE,
+                    guess_strategy=GuessStrategy.WAVELENGTH_MEAN,
+                    constraint_strategy=ConstraintStrategy.WAVELENGTH_MEAN,
+                    guess_source="wavelength_mean_estimation_context",
+                    constraint_source="wavelength_mean_estimation_context",
+                    metadata={
+                        "wavelength_mean_model": "2DPowerLawMean",
+                        "wavelength_mean_parameter": "mean_module.weight",
+                    },
                     description=(
                         "Linear flux-domain amplitude multiplying the wavelength "
                         "power-law term. The sign controls whether the mean flux "
@@ -419,8 +536,14 @@ class PowerLawMean(gpt.means.Mean):
                     scale=ParameterScale.LINEAR,
                     initial_value=-2.0,
                     constraint=(-10.0, 10.0),
-                    guess_strategy=GuessStrategy.DEFAULT,
-                    constraint_strategy=ConstraintStrategy.DEFAULT,
+                    guess_strategy=GuessStrategy.WAVELENGTH_MEAN,
+                    constraint_strategy=ConstraintStrategy.WAVELENGTH_MEAN,
+                    guess_source="wavelength_mean_estimation_context",
+                    constraint_source="wavelength_mean_estimation_context",
+                    metadata={
+                        "wavelength_mean_model": "2DPowerLawMean",
+                        "wavelength_mean_parameter": "mean_module.exponent",
+                    },
                     description=(
                         "Dimensionless power-law index controlling the wavelength "
                         "dependence of the mean flux."
@@ -430,14 +553,14 @@ class PowerLawMean(gpt.means.Mean):
         )
 
     def forward(self, x):
-        wavelength = x[..., 1]  # second column is wavelength
+        wavelength = self.physical_wavelength(x).clamp(min=1.0e-12)
         return (
             self.offset.squeeze(-1)
             + self.weight.squeeze(-1) * wavelength.pow(self.exponent.squeeze(-1))
         )
 
 
-class DustMean(gpt.means.Mean):
+class DustMean(_IntervalConstrainedMeanMixin, gpt.means.Mean):
     """Mean function with dust-extinction wavelength dependence for 2D GP
     models.
 
@@ -461,15 +584,15 @@ class DustMean(gpt.means.Mean):
 
     Attributes
     ----------
-    offset : torch.nn.Parameter
-        Constant offset (background) term.
-    log_amplitude : torch.nn.Parameter
+    offset : torch.Tensor
+        Constrained constant offset (background) term.
+    log_amplitude : torch.Tensor
         Log of the amplitude; the amplitude itself is ``exp(log_amplitude)``,
         ensuring it is always positive.
-    log_tau : torch.nn.Parameter
+    log_tau : torch.Tensor
         Log of the dust optical depth ``tau``; the optical depth itself is
         ``exp(log_tau)``, ensuring it is always positive.
-    log_alpha : torch.nn.Parameter
+    log_alpha : torch.Tensor
         Log of the extinction power-law index ``alpha``; the index itself is
         ``exp(log_alpha)``, ensuring it is always positive.  Defaults to
         ``log(1.7)`` ≈ 0.53, corresponding to a typical interstellar
@@ -478,33 +601,88 @@ class DustMean(gpt.means.Mean):
     Notes
     -----
     The wavelength axis is expected to be the second column of the input
-    tensor ``x``.  It should be strictly positive (as is the case for
-    physical wavelengths in microns).  Wavelength values below ``1e-6``
-    (microns) are clamped to ``1e-6`` to avoid numerical overflow in
-    ``λ^(-alpha)``; in practice any physically meaningful wavelength
-    (optical ~0.4 μm or longer) is well above this threshold.  Applying a
-    wavelength transform (e.g. ``MinMax``) before fitting is still
-    recommended to keep wavelength values in a numerically convenient range.
+    tensor ``x``.  When the GP input is affinely transformed, the physical
+    positive wavelength is reconstructed before evaluating this law. Values
+    below ``1e-6`` microns are clamped to avoid numerical overflow in
+    ``λ^(-alpha)``; physically meaningful optical and infrared wavelengths are
+    well above this numerical guard.
     """
 
     def __init__(self, batch_shape=None):
         super().__init__()
         if batch_shape is None:
             batch_shape = t.Size()
-        self.register_parameter(
-            "offset", t.nn.Parameter(t.zeros(*batch_shape, 1))
+        shape = (*batch_shape, 1)
+        self._register_interval_parameter(
+            "offset", t.zeros(shape), -100.0, 100.0
         )
-        self.register_parameter(
-            "log_amplitude", t.nn.Parameter(t.zeros(*batch_shape, 1))
+        self._register_interval_parameter(
+            "log_amplitude", t.zeros(shape), -40.0, 40.0
         )
-        self.register_parameter(
-            "log_tau", t.nn.Parameter(t.zeros(*batch_shape, 1))
+        self._register_interval_parameter(
+            "log_tau", t.zeros(shape), -40.0, math.log(1.0e3)
         )
-        # Default alpha ≈ 1.7, consistent with a typical dust-extinction law
-        self.register_parameter(
-            "log_alpha",
-            t.nn.Parameter(t.full((*batch_shape, 1), _LOG_1_7)),
+        self._register_interval_parameter(
+            "log_alpha", t.full(shape, _LOG_1_7), math.log(0.1), math.log(10.0)
         )
+        self.register_buffer("wavelength_origin", t.tensor(0.0))
+        self.register_buffer("wavelength_scale", t.tensor(1.0))
+
+    @property
+    def offset(self):
+        return self._constrained_parameter("offset")
+
+    @offset.setter
+    def offset(self, value):
+        self._set_constrained_parameter("offset", value)
+
+    @property
+    def log_amplitude(self):
+        return self._constrained_parameter("log_amplitude")
+
+    @log_amplitude.setter
+    def log_amplitude(self, value):
+        self._set_constrained_parameter("log_amplitude", value)
+
+    @property
+    def log_tau(self):
+        return self._constrained_parameter("log_tau")
+
+    @log_tau.setter
+    def log_tau(self, value):
+        self._set_constrained_parameter("log_tau", value)
+
+    @property
+    def log_alpha(self):
+        return self._constrained_parameter("log_alpha")
+
+    @log_alpha.setter
+    def log_alpha(self, value):
+        self._set_constrained_parameter("log_alpha", value)
+
+    def configure_wavelength_coordinate(self, origin, scale):
+        """Configure ``physical = origin + scale * model_wavelength``."""
+        origin_value = t.as_tensor(
+            origin,
+            dtype=self.wavelength_origin.dtype,
+            device=self.wavelength_origin.device,
+        )
+        scale_value = t.as_tensor(
+            scale,
+            dtype=self.wavelength_scale.dtype,
+            device=self.wavelength_scale.device,
+        )
+        if (
+            scale_value.numel() != 1
+            or not t.isfinite(scale_value)
+            or scale_value <= 0
+        ):
+            raise ValueError("Physical-wavelength scale must be finite and positive.")
+        self.wavelength_origin.copy_(origin_value.reshape_as(self.wavelength_origin))
+        self.wavelength_scale.copy_(scale_value.reshape_as(self.wavelength_scale))
+
+    def physical_wavelength(self, x):
+        return self.wavelength_origin + self.wavelength_scale * x[..., 1]
 
     def parameter_schema(self, prefix="mean_module"):
         """Return model-independent parameter specifications for DustMean."""
@@ -518,8 +696,14 @@ class DustMean(gpt.means.Mean):
                     role=ParameterRole.OFFSET,
                     domain=ParameterDomain.FLUX,
                     scale=ParameterScale.LINEAR,
-                    guess_strategy=GuessStrategy.MEDIAN_FLUX,
-                    constraint_strategy=ConstraintStrategy.ROBUST_FLUX_RANGE,
+                    guess_strategy=GuessStrategy.WAVELENGTH_MEAN,
+                    constraint_strategy=ConstraintStrategy.WAVELENGTH_MEAN,
+                    guess_source="wavelength_mean_estimation_context",
+                    constraint_source="wavelength_mean_estimation_context",
+                    metadata={
+                        "wavelength_mean_model": "2DDustMean",
+                        "wavelength_mean_parameter": "mean_module.offset",
+                    },
                     description=(
                         "Constant additive flux offset shared across "
                         "wavelengths."
@@ -530,8 +714,14 @@ class DustMean(gpt.means.Mean):
                     role=ParameterRole.AMPLITUDE,
                     domain=ParameterDomain.FLUX,
                     scale=ParameterScale.LOG,
-                    guess_strategy=GuessStrategy.ROBUST_FLUX_SPAN,
-                    constraint_strategy=ConstraintStrategy.ROBUST_POSITIVE_FLUX_SPAN,
+                    guess_strategy=GuessStrategy.WAVELENGTH_MEAN,
+                    constraint_strategy=ConstraintStrategy.WAVELENGTH_MEAN,
+                    guess_source="wavelength_mean_estimation_context",
+                    constraint_source="wavelength_mean_estimation_context",
+                    metadata={
+                        "wavelength_mean_model": "2DDustMean",
+                        "wavelength_mean_parameter": "mean_module.log_amplitude",
+                    },
                     description=(
                         "Positive amplitude of the dust-attenuated "
                         "wavelength-dependent mean function, represented in "
@@ -545,8 +735,14 @@ class DustMean(gpt.means.Mean):
                     scale=ParameterScale.LOG,
                     initial_value=1.0,
                     constraint=(1.0e-3, 1.0e3),
-                    guess_strategy=GuessStrategy.DEFAULT,
-                    constraint_strategy=ConstraintStrategy.DEFAULT,
+                    guess_strategy=GuessStrategy.WAVELENGTH_MEAN,
+                    constraint_strategy=ConstraintStrategy.WAVELENGTH_MEAN,
+                    guess_source="wavelength_mean_estimation_context",
+                    constraint_source="wavelength_mean_estimation_context",
+                    metadata={
+                        "wavelength_mean_model": "2DDustMean",
+                        "wavelength_mean_parameter": "mean_module.log_tau",
+                    },
                     description=(
                         "Positive effective dust optical-depth parameter "
                         "controlling the "
@@ -560,8 +756,14 @@ class DustMean(gpt.means.Mean):
                     scale=ParameterScale.LOG,
                     initial_value=1.7,
                     constraint=(0.1, 10.0),
-                    guess_strategy=GuessStrategy.DEFAULT,
-                    constraint_strategy=ConstraintStrategy.DEFAULT,
+                    guess_strategy=GuessStrategy.WAVELENGTH_MEAN,
+                    constraint_strategy=ConstraintStrategy.WAVELENGTH_MEAN,
+                    guess_source="wavelength_mean_estimation_context",
+                    constraint_source="wavelength_mean_estimation_context",
+                    metadata={
+                        "wavelength_mean_model": "2DDustMean",
+                        "wavelength_mean_parameter": "mean_module.log_alpha",
+                    },
                     description=(
                         "Positive power-law index of the "
                         "wavelength-dependent attenuation law."
@@ -574,7 +776,7 @@ class DustMean(gpt.means.Mean):
         # Clamp wavelength to avoid overflow in λ^(-alpha): any physical
         # wavelength in microns is far above 1e-6, so this guard is only
         # triggered for pathological inputs.
-        wavelength = x[..., 1].clamp(min=1e-6)
+        wavelength = self.physical_wavelength(x).clamp(min=1e-6)
         amplitude = self.log_amplitude.squeeze(-1).exp()
         tau = self.log_tau.squeeze(-1).exp()
         alpha = self.log_alpha.squeeze(-1).exp()
@@ -2146,7 +2348,7 @@ class CustomLinearConstantMean(Mean):
         return self.bias + self.wavelength_slope * x[:, 1]
 
 
-class CustomQuadConstantMean(Mean):
+class CustomQuadConstantMean(_IntervalConstrainedMeanMixin, Mean):
     """ Custom mean function that is quadratic in wavelength and constant in time.
 
     This is useful for modelling stars whose mean flux changes with wavelength but not
@@ -2156,14 +2358,28 @@ class CustomQuadConstantMean(Mean):
 
     def __init__(self):
         super().__init__()
-        self.register_parameter(
-            name="weights",
-            parameter=t.nn.Parameter(t.tensor([0.0, 0.0])),
+        self._register_interval_parameter(
+            "weights", t.tensor([0.0, 0.0]), -100.0, 100.0
         )
-        self.register_parameter(
-            name="bias",
-            parameter=t.nn.Parameter(t.tensor(0.0)),
+        self._register_interval_parameter(
+            "bias", t.tensor(0.0), -100.0, 100.0
         )
+
+    @property
+    def weights(self):
+        return self._constrained_parameter("weights")
+
+    @weights.setter
+    def weights(self, value):
+        self._set_constrained_parameter("weights", value)
+
+    @property
+    def bias(self):
+        return self._constrained_parameter("bias")
+
+    @bias.setter
+    def bias(self, value):
+        self._set_constrained_parameter("bias", value)
 
     def parameter_schema(self, prefix="mean_module"):
         """Return model-independent parameter specifications for this mean."""
@@ -2178,6 +2394,14 @@ class CustomQuadConstantMean(Mean):
                     domain=ParameterDomain.FLUX,
                     scale=ParameterScale.LINEAR,
                     shape=(2,),
+                    guess_strategy=GuessStrategy.WAVELENGTH_MEAN,
+                    constraint_strategy=ConstraintStrategy.WAVELENGTH_MEAN,
+                    guess_source="wavelength_mean_estimation_context",
+                    constraint_source="wavelength_mean_estimation_context",
+                    metadata={
+                        "wavelength_mean_model": "2DWavelengthDependent",
+                        "wavelength_mean_parameter": "mean_module.weights",
+                    },
                     description=(
                         "Linear and quadratic coefficients describing how the mean "
                         "flux changes with wavelength in the transformed "
@@ -2189,6 +2413,14 @@ class CustomQuadConstantMean(Mean):
                     role=ParameterRole.OFFSET,
                     domain=ParameterDomain.FLUX,
                     scale=ParameterScale.LINEAR,
+                    guess_strategy=GuessStrategy.WAVELENGTH_MEAN,
+                    constraint_strategy=ConstraintStrategy.WAVELENGTH_MEAN,
+                    guess_source="wavelength_mean_estimation_context",
+                    constraint_source="wavelength_mean_estimation_context",
+                    metadata={
+                        "wavelength_mean_model": "2DWavelengthDependent",
+                        "wavelength_mean_parameter": "mean_module.bias",
+                    },
                     description=(
                         "Constant flux offset of the wavelength-quadratic "
                         "mean function."
@@ -2342,6 +2574,11 @@ class WavelengthDependentGPModel(SeparableGPModel):
                 f"Expected one of: {accepted}."
             )
 
+        configure_flux_bounds = getattr(
+            mean_module, "configure_default_flux_bounds", None
+        )
+        if configure_flux_bounds is not None:
+            configure_flux_bounds(train_y)
 
         time_kernel = _build_time_kernel(
             time_kernel_type, period, num_mixtures, add_flicker=add_flicker

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -68,7 +68,10 @@ from pgmuvi.parameter_workflow import (
     build_and_apply_parameter_estimates,
     model_supports_parameter_workflow,
 )
-from pgmuvi.wavelength_estimation import build_wavelength_estimation_context
+from pgmuvi.wavelength_estimation import (
+    build_wavelength_estimation_context,
+    build_wavelength_mean_estimation_context,
+)
 from pgmuvi.constraint_utils import clamp_to_constraint_interior
 from pgmuvi.constraint_utils import register_constraint_preserving_value
 
@@ -6792,11 +6795,80 @@ class Lightcurve(InputHelpers, gpytorch.Module):
 
         self._move_module_to_data_dtype(self.model)
         self._move_module_to_data_dtype(self.likelihood)
+        self._configure_physical_wavelength_mean_coordinate()
 
         # now we've got a model set up, we're going to make some handy lookups
         # for the parameters and modules that we'll need to access later
         self._make_parameter_dict()
         # self.set_default_constraints()
+
+    def _configure_physical_wavelength_mean_coordinate(self):
+        """Map transformed GP wavelengths back to raw positive wavelengths.
+
+        Dust and power-law means have physical wavelength parameters.  When an
+        affine input transform is active, they must evaluate on the inverse
+        wavelength coordinate rather than on centered or standardized values.
+        """
+        self._wavelength_mean_coordinate_provenance = {
+            "status": "not_required",
+            "origin": 0.0,
+            "scale": 1.0,
+        }
+        mean_module = getattr(self.model, "mean_module", None)
+        configure = getattr(mean_module, "configure_wavelength_coordinate", None)
+        if configure is None:
+            return
+        if self.ndim < 2:
+            raise ValueError(
+                "Physical wavelength mean modules require a two-dimensional "
+                "input with wavelength in coordinate 1."
+            )
+
+        raw = torch.as_tensor(self._xdata_raw)[:, 1].detach().cpu().numpy()
+        model = (
+            torch.as_tensor(self._xdata_transformed)[:, 1]
+            .detach()
+            .cpu()
+            .numpy()
+        )
+        finite = np.isfinite(raw) & np.isfinite(model)
+        raw = np.asarray(raw[finite], dtype=float)
+        model = np.asarray(model[finite], dtype=float)
+        if raw.size < 2 or np.unique(raw).size < 2:
+            raise ValueError(
+                "Physical wavelength mean modules require at least two finite "
+                "distinct wavelengths."
+            )
+
+        design = np.column_stack([np.ones_like(model), model])
+        origin, scale = np.linalg.lstsq(design, raw, rcond=None)[0]
+        reconstructed = origin + scale * model
+        tolerance = 1.0e-8 * max(float(np.max(np.abs(raw))), 1.0)
+        max_error = float(np.max(np.abs(reconstructed - raw)))
+        if (
+            not math.isfinite(float(origin))
+            or not math.isfinite(float(scale))
+            or float(scale) <= 0.0
+            or max_error > tolerance
+        ):
+            raise ValueError(
+                "DustMean and PowerLawMean require an affine wavelength input "
+                "transform so physical wavelength can be reconstructed exactly."
+            )
+
+        with torch.no_grad():
+            configure(float(origin), float(scale))
+        self._wavelength_mean_coordinate_provenance = {
+            "status": "configured",
+            "origin": float(origin),
+            "scale": float(scale),
+            "maximum_reconstruction_error": max_error,
+            "raw_coordinate": "physical_wavelength",
+            "model_coordinate": "gp_input_dimension_1",
+            "transform_name": (
+                None if self.xtransform is None else type(self.xtransform).__name__
+            ),
+        }
 
     def _make_parameter_dict(self):
         """Make a dictionary of the model parameters
@@ -6822,15 +6894,15 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             if "raw" in param_name:
                 # This is a constrained parameter, so we need to get the
                 # unconstrained value
-                pn_const = comps[-1].lstrip("raw_")
+                pn_const = comps[-1].removeprefix("raw_")
                 param_dict["constrained"] = True
                 param_dict["constrained_name"] = pn_const
-                pn = ".".join([c.lstrip("raw_") for c in comps])
+                pn = ".".join([c.removeprefix("raw_") for c in comps])
                 param_dict["constrained_full_name"] = pn
             tmp = self.model.__getattr__(comps[0])
             param_dict["chain"].append(tmp)
             for i in range(1, len(comps)):
-                c = comps[i] if "raw" not in comps[i] else comps[i].lstrip("raw_")
+                c = comps[i].removeprefix("raw_")
                 try:
                     tmp = tmp.__getattr__(c)
                 except AttributeError:
@@ -10056,6 +10128,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 median_cadence = float(np.median(gaps))
 
         wavelength_diagnostics = None
+        wavelength_mean_diagnostics = None
         band_diagnostics = {}
         if self.ndim > 1:
             uncertainty_values = None
@@ -10080,6 +10153,35 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 self._prepare_wavelength_estimation_for_model(
                     wavelength_diagnostics
                 )
+            )
+            model_wavelengths = (
+                self._xdata_transformed[:, 1]
+                .detach()
+                .cpu()
+                .numpy()
+            )
+            model_fluxes = (
+                self._ydata_transformed.detach().cpu().numpy()
+            )
+            wavelength_mean_diagnostics = (
+                build_wavelength_mean_estimation_context(
+                    raw_wavelengths=input_values[:, 1],
+                    model_wavelengths=model_wavelengths,
+                    model_fluxes=model_fluxes,
+                    band_labels=band_labels,
+                )
+            )
+            mean_metadata = dict(wavelength_mean_diagnostics.metadata)
+            mean_metadata["wavelength_coordinate_configuration"] = dict(
+                getattr(
+                    self,
+                    "_wavelength_mean_coordinate_provenance",
+                    {"status": "not_configured"},
+                )
+            )
+            wavelength_mean_diagnostics = dataclasses.replace(
+                wavelength_mean_diagnostics,
+                metadata=mean_metadata,
             )
 
         if finite_flux_values.size == 0:
@@ -10109,6 +10211,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             global_diagnostics=global_diagnostics,
             band_diagnostics=band_diagnostics,
             wavelength_diagnostics=wavelength_diagnostics,
+            wavelength_mean_diagnostics=wavelength_mean_diagnostics,
         )
 
     def _apply_parameter_workflow_estimates(self):
@@ -10220,6 +10323,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             for optional_key in (
                 "constraint_action",
                 "wavelength_estimate_provenance",
+                "wavelength_mean_estimate_provenance",
             ):
                 if optional_key in info:
                     entry[optional_key] = copy.deepcopy(info[optional_key])
@@ -22173,10 +22277,10 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             if not raw and "raw" in param_name:
                 # This is a constrained parameter, so we need to get the
                 # unconstrained value
-                pn = ".".join([c.lstrip("raw_") for c in comps])
+                pn = ".".join([c.removeprefix("raw_") for c in comps])
                 tmp = self.model.__getattr__(comps[0])
                 for i in range(1, len(comps)):
-                    c = comps[i] if "raw" not in comps[i] else comps[i].lstrip("raw_")
+                    c = comps[i].removeprefix("raw_")
                     try:
                         tmp = tmp.__getattr__(c)
                     except AttributeError:

--- a/pgmuvi/parameter_application.py
+++ b/pgmuvi/parameter_application.py
@@ -95,6 +95,23 @@ class ParameterEstimateApplicator:
                     "diagnostics": self._to_python(estimate.diagnostics),
                 }
 
+            if self._is_wavelength_mean_estimate(estimate):
+                result["wavelength_mean_estimate_provenance"] = {
+                    "value_source": estimate.value_source,
+                    "constraint_source": estimate.constraint_source,
+                    "estimated_value": self._to_python(estimate.value),
+                    "estimated_constraint": self._to_python(
+                        estimate.constraint
+                    ),
+                    "effective_constraint": self._to_python(
+                        self._effective_constraint_bounds(
+                            target_module,
+                            parameter_name,
+                        )
+                    ),
+                    "diagnostics": self._to_python(estimate.diagnostics),
+                }
+
             results[estimate.name] = result
 
         return results
@@ -106,6 +123,15 @@ class ParameterEstimateApplicator:
             estimate.spec.guess_strategy is GuessStrategy.WAVELENGTH_RANGE
             or estimate.spec.constraint_strategy
             is ConstraintStrategy.WAVELENGTH_RANGE
+        )
+
+    @staticmethod
+    def _is_wavelength_mean_estimate(estimate) -> bool:
+        """Return whether an estimate comes from wavelength-mean diagnostics."""
+        return (
+            estimate.spec.guess_strategy is GuessStrategy.WAVELENGTH_MEAN
+            or estimate.spec.constraint_strategy
+            is ConstraintStrategy.WAVELENGTH_MEAN
         )
 
     @staticmethod
@@ -311,6 +337,7 @@ class ParameterEstimateApplicator:
                 in {
                     ConstraintStrategy.DEFAULT,
                     ConstraintStrategy.WAVELENGTH_RANGE,
+                    ConstraintStrategy.WAVELENGTH_MEAN,
                 }
                 and existing_constraint is not None
             ):

--- a/pgmuvi/parameter_builders.py
+++ b/pgmuvi/parameter_builders.py
@@ -158,7 +158,40 @@ class ParameterEstimateBuilder:
                     ),
                 }
 
-        if spec.name.startswith("mean_module.") and constraint is not None:
+        if (
+            spec.guess_strategy is GuessStrategy.WAVELENGTH_MEAN
+            or spec.constraint_strategy is ConstraintStrategy.WAVELENGTH_MEAN
+        ):
+            mean_diagnostics = context.wavelength_mean_diagnostics
+            if mean_diagnostics is not None:
+                model_name = spec.metadata.get("wavelength_mean_model")
+                record = mean_diagnostics.recommendations.get(model_name, {})
+                diagnostics = {
+                    "schema_version": mean_diagnostics.schema_version,
+                    "model": model_name,
+                    "parameter": spec.metadata.get(
+                        "wavelength_mean_parameter", spec.name
+                    ),
+                    "coordinate_basis": record.get("coordinate_basis"),
+                    "n_usable_bands": mean_diagnostics.n_usable_bands,
+                    "raw_wavelengths": list(mean_diagnostics.raw_wavelengths),
+                    "model_wavelengths": list(mean_diagnostics.model_wavelengths),
+                    "model_median_fluxes": list(
+                        mean_diagnostics.model_median_fluxes
+                    ),
+                    "fit_rmse": record.get("fit_rmse"),
+                    "fit_degree": record.get("fit_degree"),
+                    "exponent_estimation": record.get("exponent_estimation"),
+                    "recommendation_available": record.get("available", False),
+                    "recommendation_reason": record.get("reason"),
+                    "warnings": list(mean_diagnostics.warnings),
+                }
+
+        if (
+            spec.name.startswith("mean_module.")
+            and constraint is not None
+            and spec.constraint_strategy is not ConstraintStrategy.WAVELENGTH_MEAN
+        ):
             metadata["constraint_reason"] = (
                 "constraint_not_enforceable_plain_parameter"
             )
@@ -202,6 +235,15 @@ class ParameterEstimateBuilder:
                 return "global_diagnostics_unavailable"
 
             return "robust_flux_span_unavailable"
+
+        if spec.guess_strategy is GuessStrategy.WAVELENGTH_MEAN:
+            diagnostics = context.wavelength_mean_diagnostics
+            if diagnostics is None:
+                return "wavelength_mean_diagnostics_unavailable"
+            record = self._wavelength_mean_record(spec, context)
+            if not record:
+                return "wavelength_mean_model_recommendation_unavailable"
+            return record.get("reason") or "wavelength_mean_parameter_unavailable"
 
         if spec.guess_strategy is GuessStrategy.WAVELENGTH_RANGE:
             diagnostics = context.wavelength_diagnostics
@@ -298,6 +340,9 @@ class ParameterEstimateBuilder:
 
         if spec.guess_strategy is GuessStrategy.WAVELENGTH_RANGE:
             return self._estimate_wavelength_range_value(spec, context)
+
+        if spec.guess_strategy is GuessStrategy.WAVELENGTH_MEAN:
+            return self._estimate_wavelength_mean_value(spec, context)
 
         return None
 
@@ -449,7 +494,69 @@ class ParameterEstimateBuilder:
         if spec.constraint_strategy is ConstraintStrategy.WAVELENGTH_RANGE:
             return self._estimate_wavelength_range_constraint(spec, context)
 
+        if spec.constraint_strategy is ConstraintStrategy.WAVELENGTH_MEAN:
+            return self._estimate_wavelength_mean_constraint(spec, context)
+
         return None
+
+    @staticmethod
+    def _wavelength_mean_record(
+        spec: ParameterSpec,
+        context: ParameterEstimationContext,
+    ):
+        """Return the model-specific wavelength-mean recommendation record."""
+        diagnostics = context.wavelength_mean_diagnostics
+        if diagnostics is None:
+            return None
+        model_name = spec.metadata.get("wavelength_mean_model")
+        if not model_name:
+            return None
+        return diagnostics.recommendations.get(model_name)
+
+    def _estimate_wavelength_mean_value(
+        self,
+        spec: ParameterSpec,
+        context: ParameterEstimationContext,
+    ):
+        """Return a model-ready wavelength-mean parameter recommendation."""
+        record = self._wavelength_mean_record(spec, context)
+        if not record or not record.get("available"):
+            return None
+        parameter_name = spec.metadata.get(
+            "wavelength_mean_parameter", spec.name
+        )
+        value = record.get("initial_values", {}).get(parameter_name)
+        return self._reshape_initial_value(value, spec.shape)
+
+    def _estimate_wavelength_mean_constraint(
+        self,
+        spec: ParameterSpec,
+        context: ParameterEstimationContext,
+    ):
+        """Return a model-ready wavelength-mean parameter interval."""
+        record = self._wavelength_mean_record(spec, context)
+        if not record or not record.get("available"):
+            return None
+        parameter_name = spec.metadata.get(
+            "wavelength_mean_parameter", spec.name
+        )
+        bounds = record.get("constraints", {}).get(parameter_name)
+        if bounds is None:
+            return None
+        lower, upper = bounds
+        if spec.shape is None:
+            return (lower, upper)
+        lower_tensor = torch.as_tensor(lower, dtype=DEFAULT_DTYPE)
+        upper_tensor = torch.as_tensor(upper, dtype=DEFAULT_DTYPE)
+        if lower_tensor.numel() == 1:
+            lower_tensor = lower_tensor.expand(spec.shape).clone()
+        else:
+            lower_tensor = lower_tensor.reshape(spec.shape)
+        if upper_tensor.numel() == 1:
+            upper_tensor = upper_tensor.expand(spec.shape).clone()
+        else:
+            upper_tensor = upper_tensor.reshape(spec.shape)
+        return (lower_tensor, upper_tensor)
 
     def _estimate_wavelength_range_value(
         self,

--- a/pgmuvi/parameter_context.py
+++ b/pgmuvi/parameter_context.py
@@ -109,6 +109,35 @@ class WavelengthEstimationDiagnostics:
         return asdict(self)
 
 
+WAVELENGTH_MEAN_ESTIMATION_SCHEMA_VERSION = "pgmuvi-wavelength-mean-estimation-v1"
+
+
+@dataclass(frozen=True)
+class WavelengthMeanEstimationDiagnostics:
+    """Model-ready wavelength-mean initialization and constraint candidates.
+
+    ``physical_wavelength`` recommendations use the raw positive wavelength
+    coordinate together with the transformed GP target.  ``model_wavelength``
+    recommendations use the wavelength coordinate actually supplied to the GP.
+    This distinction keeps dust and power-law parameters physically interpretable
+    while allowing the flexible quadratic mean to follow the fitted coordinate.
+    """
+
+    schema_version: str = WAVELENGTH_MEAN_ESTIMATION_SCHEMA_VERSION
+    available: bool = False
+    n_usable_bands: int = 0
+    raw_wavelengths: tuple[float, ...] = ()
+    model_wavelengths: tuple[float, ...] = ()
+    model_median_fluxes: tuple[float, ...] = ()
+    recommendations: dict[str, dict[str, Any]] = field(default_factory=dict)
+    warnings: tuple[str, ...] = ()
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-safe dictionary representation."""
+        return asdict(self)
+
+
 @dataclass(frozen=True)
 class ConsensusDiagnostics:
     """Period/frequency diagnostics from a cross-band consensus analysis."""
@@ -132,6 +161,7 @@ class ParameterEstimationContext:
     band_diagnostics: dict[str, BandDiagnostics] = field(default_factory=dict)
     consensus_diagnostics: ConsensusDiagnostics | None = None
     wavelength_diagnostics: WavelengthEstimationDiagnostics | None = None
+    wavelength_mean_diagnostics: WavelengthMeanEstimationDiagnostics | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
 
     def bands(self) -> list[str]:

--- a/pgmuvi/parameter_specs.py
+++ b/pgmuvi/parameter_specs.py
@@ -70,6 +70,7 @@ class GuessStrategy(str, Enum):
     VARIABILITY_TIMESCALE = "variability_timescale"
 
     WAVELENGTH_RANGE = "wavelength_range"
+    WAVELENGTH_MEAN = "wavelength_mean"
 
     CUSTOM = "custom"
 
@@ -96,6 +97,7 @@ class ConstraintStrategy(str, Enum):
     VARIABILITY_TIMESCALE = "variability_timescale"
 
     WAVELENGTH_RANGE = "wavelength_range"
+    WAVELENGTH_MEAN = "wavelength_mean"
 
     CUSTOM = "custom"
 

--- a/pgmuvi/wavelength_estimation.py
+++ b/pgmuvi/wavelength_estimation.py
@@ -18,6 +18,7 @@ from pgmuvi.parameter_context import (
     BandDiagnostics,
     WAVELENGTH_ESTIMATION_SCHEMA_VERSION,
     WavelengthEstimationDiagnostics,
+    WavelengthMeanEstimationDiagnostics,
 )
 from pgmuvi.preprocess.quality import robust_scale
 
@@ -473,8 +474,330 @@ def build_wavelength_estimation_context(
     return diagnostics, band_diagnostics
 
 
+def _wavelength_mean_band_points(
+    raw_wavelengths: Any,
+    model_wavelengths: Any,
+    model_fluxes: Any,
+    band_labels: Any | None,
+    *,
+    min_points_per_band: int,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, tuple[str, ...]]:
+    """Return robust per-band points for wavelength-mean estimation."""
+    raw = _finite_array(raw_wavelengths)
+    model = _finite_array(model_wavelengths)
+    flux = _finite_array(model_fluxes)
+    if raw.size != model.size or raw.size != flux.size:
+        raise ValueError(
+            "raw_wavelengths, model_wavelengths, and model_fluxes must "
+            "have the same length."
+        )
+
+    if band_labels is None:
+        labels = np.asarray(
+            [
+                _band_label_for_wavelength(value)
+                if math.isfinite(value)
+                else "wavelength=nonfinite"
+                for value in raw
+            ],
+            dtype=str,
+        )
+    else:
+        labels = np.asarray(band_labels, dtype=str).reshape(-1)
+        if labels.size != raw.size:
+            raise ValueError(
+                "band_labels must have the same length as wavelength inputs."
+            )
+
+    rows: list[tuple[float, float, float, str]] = []
+    excluded: list[str] = []
+    for label in dict.fromkeys(labels.tolist()):
+        mask = labels == label
+        finite = mask & np.isfinite(raw) & np.isfinite(model) & np.isfinite(flux)
+        raw_values = raw[finite]
+        model_values = model[finite]
+        flux_values = flux[finite]
+        if flux_values.size < min_points_per_band:
+            excluded.append(label)
+            continue
+        raw_median = float(np.median(raw_values))
+        model_median = float(np.median(model_values))
+        raw_spread = float(np.max(raw_values) - np.min(raw_values))
+        model_spread = float(np.max(model_values) - np.min(model_values))
+        raw_tol = 1.0e-10 * max(abs(raw_median), 1.0)
+        model_tol = 1.0e-10 * max(abs(model_median), 1.0)
+        if (
+            raw_median <= 0.0
+            or raw_spread > raw_tol
+            or model_spread > model_tol
+        ):
+            excluded.append(label)
+            continue
+        rows.append(
+            (
+                raw_median,
+                model_median,
+                float(np.median(flux_values)),
+                label,
+            )
+        )
+
+    rows.sort(key=lambda item: item[0])
+    return (
+        np.asarray([item[0] for item in rows], dtype=float),
+        np.asarray([item[1] for item in rows], dtype=float),
+        np.asarray([item[2] for item in rows], dtype=float),
+        tuple(excluded),
+    )
+
+
+def _wavelength_mean_flux_interval(values: np.ndarray) -> tuple[float, float, float]:
+    """Return a padded finite target interval and a robust positive scale."""
+    finite = values[np.isfinite(values)]
+    if finite.size == 0:
+        return (-1.0, 1.0, 1.0)
+    low = float(np.min(finite))
+    high = float(np.max(finite))
+    span = high - low
+    floor = max(float(np.max(np.abs(finite))) * 1.0e-6, 1.0e-8)
+    span = max(span, floor)
+    return (low - 2.0 * span, high + 2.0 * span, span)
+
+
+def _quadratic_mean_recommendation(
+    model_wavelengths: np.ndarray,
+    fluxes: np.ndarray,
+) -> dict[str, Any]:
+    """Fit a stable quadratic recommendation in the GP wavelength coordinate."""
+    if model_wavelengths.size < 2:
+        return {"available": False, "reason": "fewer_than_two_usable_bands"}
+    if float(np.ptp(model_wavelengths)) <= 0.0:
+        return {"available": False, "reason": "zero_model_wavelength_span"}
+
+    degree = 2 if model_wavelengths.size >= 3 else 1
+    coeff = np.polyfit(model_wavelengths, fluxes, deg=degree)
+    if degree == 1:
+        slope, bias = coeff
+        weights = np.asarray([slope, 0.0], dtype=float)
+    else:
+        quad, slope, bias = coeff
+        weights = np.asarray([slope, quad], dtype=float)
+    predicted = bias + weights[0] * model_wavelengths
+    predicted = predicted + weights[1] * model_wavelengths**2
+    rmse = float(np.sqrt(np.mean((fluxes - predicted) ** 2)))
+
+    offset_low, offset_high, flux_span = _wavelength_mean_flux_interval(fluxes)
+    x_span = max(float(np.ptp(model_wavelengths)), 1.0e-8)
+    slope_scale = max(abs(float(weights[0])), flux_span / x_span, 1.0e-8)
+    quad_scale = max(abs(float(weights[1])), flux_span / (x_span**2), 1.0e-8)
+    lower = [-5.0 * slope_scale, -5.0 * quad_scale]
+    upper = [5.0 * slope_scale, 5.0 * quad_scale]
+
+    return {
+        "available": True,
+        "coordinate_basis": "model_wavelength_and_model_flux",
+        "initial_values": {
+            "mean_module.bias": float(bias),
+            "mean_module.weights": [float(weights[0]), float(weights[1])],
+        },
+        "constraints": {
+            "mean_module.bias": [offset_low, offset_high],
+            "mean_module.weights": [lower, upper],
+        },
+        "fit_rmse": rmse,
+        "fit_degree": degree,
+        "reason": None,
+    }
+
+
+def _power_law_mean_recommendation(
+    raw_wavelengths: np.ndarray,
+    fluxes: np.ndarray,
+) -> dict[str, Any]:
+    """Fit offset + weight * wavelength**exponent on robust band medians."""
+    if raw_wavelengths.size < 2:
+        return {"available": False, "reason": "fewer_than_two_usable_bands"}
+    if np.any(raw_wavelengths <= 0.0):
+        return {"available": False, "reason": "nonpositive_physical_wavelength"}
+
+    flux_scale = max(float(np.max(np.abs(fluxes))), 1.0)
+    approximately_constant = float(np.ptp(fluxes)) <= 1.0e-10 * flux_scale
+    if raw_wavelengths.size == 2 or approximately_constant:
+        candidates = np.asarray([-2.0])
+        exponent_estimation = (
+            "fixed_default_flat_trend"
+            if approximately_constant
+            else "fixed_default_two_band"
+        )
+    else:
+        candidates = np.concatenate(
+            [
+                np.linspace(-10.0, -0.05, 240),
+                np.linspace(0.05, 10.0, 240),
+            ]
+        )
+        exponent_estimation = "grid_profile_fit"
+    best: tuple[float, float, float, float] | None = None
+    for exponent in candidates:
+        basis = np.power(raw_wavelengths, exponent)
+        if not np.all(np.isfinite(basis)) or float(np.ptp(basis)) <= 0.0:
+            continue
+        design = np.column_stack([np.ones_like(basis), basis])
+        offset, weight = np.linalg.lstsq(design, fluxes, rcond=None)[0]
+        predicted = offset + weight * basis
+        mse = float(np.mean((fluxes - predicted) ** 2))
+        if best is None or mse < best[0]:
+            best = (mse, float(offset), float(weight), float(exponent))
+
+    if best is None:
+        return {"available": False, "reason": "power_law_fit_failed"}
+
+    mse, offset, weight, exponent = best
+    offset_low, offset_high, flux_span = _wavelength_mean_flux_interval(fluxes)
+    weight_scale = max(
+        abs(weight),
+        flux_span,
+        0.1 * float(np.max(np.abs(fluxes))),
+        1.0e-3,
+    )
+    return {
+        "available": True,
+        "coordinate_basis": "physical_wavelength_and_model_flux",
+        "initial_values": {
+            "mean_module.offset": offset,
+            "mean_module.weight": weight,
+            "mean_module.exponent": exponent,
+        },
+        "constraints": {
+            "mean_module.offset": [offset_low, offset_high],
+            "mean_module.weight": [-5.0 * weight_scale, 5.0 * weight_scale],
+            "mean_module.exponent": [-10.0, 10.0],
+        },
+        "fit_rmse": float(math.sqrt(mse)),
+        "exponent_estimation": exponent_estimation,
+        "reason": None,
+    }
+
+
+def _dust_mean_recommendation(
+    raw_wavelengths: np.ndarray,
+    fluxes: np.ndarray,
+) -> dict[str, Any]:
+    """Fit a coarse physical dust-attenuation recommendation."""
+    if raw_wavelengths.size < 3:
+        return {"available": False, "reason": "fewer_than_three_usable_bands"}
+    if np.any(raw_wavelengths <= 0.0):
+        return {"available": False, "reason": "nonpositive_physical_wavelength"}
+    flux_scale = max(float(np.max(np.abs(fluxes))), 1.0)
+    if float(np.ptp(fluxes)) <= 1.0e-10 * flux_scale:
+        return {"available": False, "reason": "wavelength_mean_not_resolved"}
+
+    alphas = np.geomspace(0.1, 10.0, 48)
+    taus = np.geomspace(1.0e-3, 1.0e3, 72)
+    best: tuple[float, float, float, float, float] | None = None
+    for alpha in alphas:
+        wavelength_term = np.power(raw_wavelengths, -alpha)
+        for tau in taus:
+            attenuation = np.exp(-tau * wavelength_term)
+            if float(np.ptp(attenuation)) <= 1.0e-12:
+                continue
+            design = np.column_stack([np.ones_like(attenuation), attenuation])
+            offset, amplitude = np.linalg.lstsq(design, fluxes, rcond=None)[0]
+            if not math.isfinite(float(amplitude)) or amplitude <= 0.0:
+                continue
+            predicted = offset + amplitude * attenuation
+            mse = float(np.mean((fluxes - predicted) ** 2))
+            if best is None or mse < best[0]:
+                best = (
+                    mse,
+                    float(offset),
+                    float(amplitude),
+                    float(tau),
+                    float(alpha),
+                )
+
+    if best is None:
+        return {"available": False, "reason": "dust_fit_failed"}
+
+    mse, offset, amplitude, tau, alpha = best
+    offset_low, offset_high, flux_span = _wavelength_mean_flux_interval(fluxes)
+    amplitude_floor = max(1.0e-8, 1.0e-6 * flux_span)
+    amplitude_high = max(5.0 * amplitude, 5.0 * flux_span, 10.0 * amplitude_floor)
+    return {
+        "available": True,
+        "coordinate_basis": "physical_wavelength_and_model_flux",
+        "initial_values": {
+            "mean_module.offset": offset,
+            "mean_module.log_amplitude": amplitude,
+            "mean_module.log_tau": tau,
+            "mean_module.log_alpha": alpha,
+        },
+        "constraints": {
+            "mean_module.offset": [offset_low, offset_high],
+            "mean_module.log_amplitude": [amplitude_floor, amplitude_high],
+            "mean_module.log_tau": [1.0e-3, 1.0e3],
+            "mean_module.log_alpha": [0.1, 10.0],
+        },
+        "fit_rmse": float(math.sqrt(mse)),
+        "reason": None,
+    }
+
+
+def build_wavelength_mean_estimation_context(
+    raw_wavelengths: Any,
+    model_wavelengths: Any,
+    model_fluxes: Any,
+    band_labels: Any | None = None,
+    *,
+    min_points_per_band: int = 3,
+) -> WavelengthMeanEstimationDiagnostics:
+    """Build model-ready wavelength-mean estimates from robust band medians.
+
+    Dust and power-law recommendations use raw positive wavelength values but
+    fluxes in the transformed training-target coordinate.  The quadratic model
+    uses the transformed wavelength coordinate because its coefficients are not
+    assigned a physical wavelength interpretation.
+    """
+    raw, model, flux, excluded = _wavelength_mean_band_points(
+        raw_wavelengths,
+        model_wavelengths,
+        model_fluxes,
+        band_labels,
+        min_points_per_band=min_points_per_band,
+    )
+    recommendations = {
+        "2DWavelengthDependent": _quadratic_mean_recommendation(model, flux),
+        "2DPowerLawMean": _power_law_mean_recommendation(raw, flux),
+        "2DDustMean": _dust_mean_recommendation(raw, flux),
+    }
+    warnings = tuple(
+        f"{model_name}: {record.get('reason')}"
+        for model_name, record in recommendations.items()
+        if not record.get("available")
+    )
+    return WavelengthMeanEstimationDiagnostics(
+        available=any(record.get("available") for record in recommendations.values()),
+        n_usable_bands=int(raw.size),
+        raw_wavelengths=tuple(float(value) for value in raw),
+        model_wavelengths=tuple(float(value) for value in model),
+        model_median_fluxes=tuple(float(value) for value in flux),
+        recommendations=recommendations,
+        warnings=warnings,
+        metadata={
+            "uses_log_flux": False,
+            "physical_mean_wavelength_coordinate": "raw_positive_wavelength",
+            "quadratic_mean_wavelength_coordinate": "model_input_wavelength",
+            "flux_coordinate": "model_training_target",
+            "excluded_bands": list(excluded),
+            "recommendations_applied_to_models": False,
+        },
+    )
+
+
 __all__ = [
     "WAVELENGTH_ESTIMATION_SCHEMA_VERSION",
     "WavelengthEstimationDiagnostics",
+    "WavelengthMeanEstimationDiagnostics",
     "build_wavelength_estimation_context",
+    "build_wavelength_mean_estimation_context",
 ]

--- a/tests/test_constraint_integrity_regression.py
+++ b/tests/test_constraint_integrity_regression.py
@@ -10,16 +10,19 @@ import unittest
 import gpytorch
 import torch
 
-from pgmuvi.gps import MaternGPModel, PowerLawMeanGPModel, SpectralMixtureGPModel
+from pgmuvi.gps import MaternGPModel, SpectralMixtureGPModel
 from pgmuvi.lightcurve import Lightcurve
 from pgmuvi.parameter_application import ParameterEstimateApplicator
 from pgmuvi.parameter_context import LightcurveDiagnostics, ParameterEstimationContext
 from pgmuvi.parameter_estimates import ParameterEstimate, ParameterEstimateCollection
 from pgmuvi.parameter_specs import (
+    ConstraintStrategy,
+    GuessStrategy,
     ParameterDomain,
     ParameterRole,
     ParameterScale,
     ParameterSpec,
+    ParameterSpecCollection,
 )
 from pgmuvi.parameter_workflow import build_and_apply_parameter_estimates
 
@@ -111,24 +114,40 @@ class TestConstraintIntegrityRegression(unittest.TestCase):
 
     def test_mean_constraint_reporting_is_honest_for_plain_parameters(self):
         """Plain nn.Parameter mean constraints should not be reported as enforced."""
-        x = torch.stack(
-            [
-                torch.linspace(0.0, 10.0, 30),
-                torch.full((30,), 2.2),
-            ],
-            dim=1,
-        )
-        y = 10.0 + 2.0 * torch.sin(2.0 * torch.pi * x[:, 0] / 3.0)
-        likelihood = gpytorch.likelihoods.GaussianLikelihood()
-        model = PowerLawMeanGPModel(x, y, likelihood, time_kernel_type="matern")
+        class PlainMean(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.offset = torch.nn.Parameter(torch.tensor(0.0))
 
+        class PlainMeanModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.mean_module = PlainMean()
+
+            def parameter_schema(self):
+                return ParameterSpecCollection(
+                    [
+                        ParameterSpec(
+                            name="mean_module.offset",
+                            role=ParameterRole.OFFSET,
+                            domain=ParameterDomain.FLUX,
+                            scale=ParameterScale.LINEAR,
+                            guess_strategy=GuessStrategy.MEDIAN_FLUX,
+                            constraint_strategy=(
+                                ConstraintStrategy.ROBUST_FLUX_RANGE
+                            ),
+                        )
+                    ]
+                )
+
+        model = PlainMeanModel()
         context = ParameterEstimationContext(
             is_multiband=True,
             global_diagnostics=LightcurveDiagnostics(
                 baseline_duration=10.0,
                 median_flux=10.0,
                 flux_percentiles={2.5: 8.0, 50.0: 10.0, 97.5: 12.0},
-                n_points=len(x),
+                n_points=30,
             ),
         )
 

--- a/tests/test_docs_wavelength_estimation.py
+++ b/tests/test_docs_wavelength_estimation.py
@@ -31,7 +31,7 @@ class TestWavelengthEstimationDocumentation(unittest.TestCase):
         self.assertIn("Existing registered bounds are", self.module_text)
         self.assertIn("2DWavelengthDependent", self.module_text)
         self.assertIn("full non-separable ``2D``", self.module_text)
-        self.assertIn("No logarithmic flux transformation", self.module_text)
+        self.assertIn("No logarithmic flux fitting", self.module_text)
 
     def test_model_guide_documents_application_provenance_and_scope(self):
         self.assertIn(
@@ -51,8 +51,11 @@ class TestWavelengthEstimationDocumentation(unittest.TestCase):
         )
         self.assertIn("quasi-periodic", self.consensus_text)
 
-    def test_future_work_retains_mean_ard_and_validation_work(self):
-        self.assertIn("wavelength-dependent mean parameters", self.future_work_text)
+    def test_future_work_records_mean_completion_and_retains_ard_validation(self):
+        self.assertIn(
+            "Data-derived wavelength-mean initialization",
+            self.future_work_text,
+        )
         self.assertIn("temporal and wavelength ARD", self.future_work_text)
         self.assertIn("wavelength-constraint-validation", self.future_work_text)
 

--- a/tests/test_docs_wavelength_mean_estimates.py
+++ b/tests/test_docs_wavelength_mean_estimates.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class TestWavelengthMeanEstimateDocumentation(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.module = (
+            ROOT / "docs/source/pgmuvi.wavelength_estimation.rst"
+        ).read_text(encoding="utf-8")
+        cls.models = (
+            ROOT / "docs/source/howto/wavelength_models.rst"
+        ).read_text(encoding="utf-8")
+        cls.constraints = (
+            ROOT / "docs/source/howto/priors_constraints.rst"
+        ).read_text(encoding="utf-8")
+        cls.future = (ROOT / "docs/source/future_work.rst").read_text(
+            encoding="utf-8"
+        )
+        cls.module_normalized = " ".join(cls.module.split())
+        cls.constraints_normalized = " ".join(cls.constraints.split())
+        cls.future_normalized = " ".join(cls.future.split())
+
+    def test_module_documents_mean_strategies_and_coordinate_bases(self):
+        for token in (
+            "GuessStrategy.WAVELENGTH_MEAN",
+            "ConstraintStrategy.WAVELENGTH_MEAN",
+            "reconstructed physical",
+            "training-target coordinate",
+            "registered GPyTorch raw-parameter interval",
+            "No logarithmic flux fitting",
+        ):
+            with self.subTest(token=token):
+                self.assertIn(token, self.module_normalized)
+
+    def test_model_guide_documents_all_target_mean_families(self):
+        for token in (
+            "Data-derived wavelength mean initialization",
+            "2DWavelengthDependent",
+            "2DDustMean",
+            "2DPowerLawMean",
+            "wavelength_mean_estimate_provenance",
+            "custom non-affine wavelength transform is rejected",
+        ):
+            with self.subTest(token=token):
+                self.assertIn(token, self.models)
+
+    def test_constraints_are_documented_as_enforced(self):
+        self.assertIn(
+            "registered GPyTorch raw-parameter constraints",
+            self.constraints_normalized,
+        )
+        self.assertIn("enforced during", self.constraints_normalized)
+        self.assertIn("optimization", self.constraints_normalized)
+
+    def test_full_2d_ard_and_validation_remain_future_work(self):
+        self.assertIn("Data-derived wavelength-mean initialization", self.future_normalized)
+        self.assertIn("full ``2D``", self.future_normalized)
+        self.assertIn("temporal and wavelength ARD dimensions", self.future_normalized)
+        self.assertIn("TBD[wavelength-constraint-validation]", self.future_normalized)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dust_mean_parameter_schema.py
+++ b/tests/test_dust_mean_parameter_schema.py
@@ -10,8 +10,8 @@ from pgmuvi.parameter_specs import (
 )
 from pgmuvi.parameter_builders import ParameterEstimateBuilder
 from pgmuvi.parameter_context import (
-    LightcurveDiagnostics,
     ParameterEstimationContext,
+    WavelengthMeanEstimationDiagnostics,
 )
 
 
@@ -71,42 +71,42 @@ class TestDustMeanParameterSchema(unittest.TestCase):
 
         self.assertEqual(
             schema["mean_module.offset"].guess_strategy,
-            GuessStrategy.MEDIAN_FLUX,
+            GuessStrategy.WAVELENGTH_MEAN,
         )
 
         self.assertEqual(
             schema["mean_module.offset"].constraint_strategy,
-            ConstraintStrategy.ROBUST_FLUX_RANGE,
+            ConstraintStrategy.WAVELENGTH_MEAN,
         )
 
         self.assertEqual(
             schema["mean_module.log_amplitude"].guess_strategy,
-            GuessStrategy.ROBUST_FLUX_SPAN,
+            GuessStrategy.WAVELENGTH_MEAN,
         )
 
         self.assertEqual(
             schema["mean_module.log_amplitude"].constraint_strategy,
-            ConstraintStrategy.ROBUST_POSITIVE_FLUX_SPAN,
+            ConstraintStrategy.WAVELENGTH_MEAN,
         )
 
         self.assertEqual(
             schema["mean_module.log_tau"].guess_strategy,
-            GuessStrategy.DEFAULT,
+            GuessStrategy.WAVELENGTH_MEAN,
         )
 
         self.assertEqual(
             schema["mean_module.log_tau"].constraint_strategy,
-            ConstraintStrategy.DEFAULT,
+            ConstraintStrategy.WAVELENGTH_MEAN,
         )
 
         self.assertEqual(
             schema["mean_module.log_alpha"].guess_strategy,
-            GuessStrategy.DEFAULT,
+            GuessStrategy.WAVELENGTH_MEAN,
         )
 
         self.assertEqual(
             schema["mean_module.log_alpha"].constraint_strategy,
-            ConstraintStrategy.DEFAULT,
+            ConstraintStrategy.WAVELENGTH_MEAN,
         )
 
     def test_dust_mean_schema_builds_estimates_from_diagnostics(self):
@@ -114,12 +114,30 @@ class TestDustMeanParameterSchema(unittest.TestCase):
 
         context = ParameterEstimationContext(
             is_multiband=True,
-            global_diagnostics=LightcurveDiagnostics(
-                median_flux=55.0,
-                flux_percentiles={
-                    2.5: 10.0,
-                    50.0: 55.0,
-                    97.5: 100.0,
+            wavelength_mean_diagnostics=WavelengthMeanEstimationDiagnostics(
+                available=True,
+                n_usable_bands=4,
+                recommendations={
+                    "2DDustMean": {
+                        "available": True,
+                        "coordinate_basis": (
+                            "physical_wavelength_and_model_flux"
+                        ),
+                        "initial_values": {
+                            "mean_module.offset": 0.2,
+                            "mean_module.log_amplitude": 3.0,
+                            "mean_module.log_tau": 1.4,
+                            "mean_module.log_alpha": 1.8,
+                        },
+                        "constraints": {
+                            "mean_module.offset": [-1.0, 4.0],
+                            "mean_module.log_amplitude": [1.0e-4, 10.0],
+                            "mean_module.log_tau": [1.0e-3, 1.0e3],
+                            "mean_module.log_alpha": [0.1, 10.0],
+                        },
+                        "fit_rmse": 0.01,
+                        "reason": None,
+                    }
                 },
             ),
         )
@@ -129,28 +147,36 @@ class TestDustMeanParameterSchema(unittest.TestCase):
             context=context,
         )
 
-        offset = estimates["mean_module.offset"]
-        amplitude = estimates["mean_module.log_amplitude"]
-
-        tau = estimates["mean_module.log_tau"]
-        alpha = estimates["mean_module.log_alpha"]
-
-        self.assertEqual(offset.value, 55.0)
-        self.assertEqual(offset.constraint, (10.0, 100.0))
-
-        self.assertEqual(amplitude.value, 90.0)
-
-        self.assertAlmostEqual(
-            amplitude.constraint[0],
-            9.0e-5,
+        self.assertEqual(estimates["mean_module.offset"].value, 0.2)
+        self.assertEqual(
+            estimates["mean_module.offset"].constraint,
+            (-1.0, 4.0),
         )
-        self.assertAlmostEqual(
-            amplitude.constraint[1],
-            450.0,
+        self.assertEqual(
+            estimates["mean_module.log_amplitude"].value,
+            3.0,
+        )
+        self.assertEqual(
+            estimates["mean_module.log_tau"].value,
+            1.4,
+        )
+        self.assertEqual(
+            estimates["mean_module.log_alpha"].value,
+            1.8,
+        )
+        self.assertEqual(
+            estimates["mean_module.log_amplitude"].constraint,
+            (1.0e-4, 10.0),
+        )
+        self.assertEqual(
+            estimates["mean_module.log_tau"].constraint,
+            (1.0e-3, 1.0e3),
+        )
+        self.assertEqual(
+            estimates["mean_module.log_alpha"].constraint,
+            (0.1, 10.0),
         )
 
-        self.assertEqual(tau.value, 1.0)
-        self.assertEqual(tau.constraint, (1.0e-3, 1.0e3))
 
-        self.assertEqual(alpha.value, 1.7)
-        self.assertEqual(alpha.constraint, (0.1, 10.0))
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_lightcurve_parameter_context.py
+++ b/tests/test_lightcurve_parameter_context.py
@@ -654,7 +654,7 @@ class TestLightcurveParameterEstimationContext(unittest.TestCase):
             },
         )
 
-    def test_parameter_workflow_propagates_global_diagnostics_reason(self):
+    def test_parameter_workflow_propagates_wavelength_mean_diagnostics_reason(self):
         import gpytorch
 
         from pgmuvi.gps import DustMeanGPModel
@@ -690,5 +690,5 @@ class TestLightcurveParameterEstimationContext(unittest.TestCase):
 
         self.assertEqual(
             result["mean_module.offset"]["value_reason"],
-            "global_diagnostics_unavailable",
+            "wavelength_mean_diagnostics_unavailable",
         )

--- a/tests/test_power_law_mean_parameter_schema.py
+++ b/tests/test_power_law_mean_parameter_schema.py
@@ -61,11 +61,11 @@ class TestPowerLawMeanParameterSchema(unittest.TestCase):
 
         self.assertEqual(
             offset.guess_strategy,
-            GuessStrategy.MEDIAN_FLUX,
+            GuessStrategy.WAVELENGTH_MEAN,
         )
         self.assertEqual(
             offset.constraint_strategy,
-            ConstraintStrategy.ROBUST_FLUX_RANGE,
+            ConstraintStrategy.WAVELENGTH_MEAN,
         )
 
     def test_power_law_mean_weight_estimation_strategies(self):
@@ -75,11 +75,11 @@ class TestPowerLawMeanParameterSchema(unittest.TestCase):
 
         self.assertEqual(
             weight.guess_strategy,
-            GuessStrategy.ROBUST_FLUX_SPAN,
+            GuessStrategy.WAVELENGTH_MEAN,
         )
         self.assertEqual(
             weight.constraint_strategy,
-            ConstraintStrategy.ROBUST_FLUX_RANGE,
+            ConstraintStrategy.WAVELENGTH_MEAN,
         )
 
     def test_power_law_mean_exponent_default_estimation_strategies(self):
@@ -91,9 +91,9 @@ class TestPowerLawMeanParameterSchema(unittest.TestCase):
         self.assertEqual(exponent.constraint, (-10.0, 10.0))
         self.assertEqual(
             exponent.guess_strategy,
-            GuessStrategy.DEFAULT,
+            GuessStrategy.WAVELENGTH_MEAN,
         )
         self.assertEqual(
             exponent.constraint_strategy,
-            ConstraintStrategy.DEFAULT,
+            ConstraintStrategy.WAVELENGTH_MEAN,
         )

--- a/tests/test_wavelength_mean_estimate_application.py
+++ b/tests/test_wavelength_mean_estimate_application.py
@@ -1,0 +1,165 @@
+import unittest
+
+import gpytorch
+import numpy as np
+import torch
+
+from pgmuvi.constraint_utils import register_constraint_preserving_value
+from pgmuvi.lightcurve import Lightcurve
+
+
+class TestWavelengthMeanEstimateApplication(unittest.TestCase):
+    def _lightcurve(self, flux_function, *, xtransform="minmax"):
+        wavelengths = np.asarray([0.45, 0.65, 1.2, 2.2, 4.0])
+        rows = []
+        fluxes = []
+        bands = []
+        for band_index, wavelength in enumerate(wavelengths):
+            for sample in range(8):
+                rows.append([float(sample), wavelength])
+                fluxes.append(
+                    float(flux_function(wavelength))
+                    + 0.01 * np.sin(float(sample))
+                )
+                bands.append(f"b{band_index}")
+        return Lightcurve(
+            np.asarray(rows),
+            np.asarray(fluxes),
+            band=np.asarray(bands),
+            xtransform=xtransform,
+            ytransform="zscore",
+        )
+
+    def test_power_law_mean_uses_reconstructed_physical_wavelength(self):
+        for transform in ("minmax", "zscore", "robust_zscore", "time_center"):
+            with self.subTest(transform=transform):
+                lc = self._lightcurve(
+                    lambda wavelength: 1.0 + 2.0 * wavelength**1.5,
+                    xtransform=transform,
+                )
+                lc.set_model("2DPowerLawMean")
+                result = lc._apply_parameter_workflow_estimates()
+
+                mean = lc.model.mean_module
+                reconstructed = mean.physical_wavelength(lc._xdata_transformed)
+                self.assertTrue(
+                    torch.allclose(
+                        reconstructed,
+                        lc._xdata_raw[:, 1],
+                        atol=1.0e-6,
+                        rtol=1.0e-6,
+                    )
+                )
+                for name in ("offset", "weight", "exponent"):
+                    record = result[f"mean_module.{name}"]
+                    self.assertTrue(record["value"])
+                    self.assertTrue(record["constraint"])
+                    self.assertIn("wavelength_mean_estimate_provenance", record)
+                    self.assertIsInstance(
+                        getattr(mean, f"raw_{name}_constraint"),
+                        gpytorch.constraints.Interval,
+                    )
+                self.assertTrue(
+                    torch.all(torch.isfinite(mean(lc._xdata_transformed)))
+                )
+                parameters = lc.get_parameters(transform=False)
+                self.assertIn("mean_module.weight", parameters)
+                self.assertNotIn("mean_module.eight", parameters)
+                self.assertIsNotNone(
+                    result["mean_module.weight"][
+                        "wavelength_mean_estimate_provenance"
+                    ]["effective_constraint"]
+                )
+
+    def test_dust_mean_applies_positive_physical_shape_estimates(self):
+        lc = self._lightcurve(
+            lambda wavelength: 0.2
+            + 3.0 * np.exp(-1.4 * wavelength ** -1.8)
+        )
+        lc.set_model("2DDustMean")
+        result = lc._apply_parameter_workflow_estimates()
+
+        mean = lc.model.mean_module
+        for name in ("offset", "log_amplitude", "log_tau", "log_alpha"):
+            record = result[f"mean_module.{name}"]
+            self.assertTrue(record["value"])
+            self.assertTrue(record["constraint"])
+            self.assertIn("wavelength_mean_estimate_provenance", record)
+        self.assertGreater(float(mean.log_amplitude.detach().exp()), 0.0)
+        self.assertGreater(float(mean.log_tau.detach().exp()), 0.0)
+        self.assertGreater(float(mean.log_alpha.detach().exp()), 0.0)
+        self.assertTrue(torch.all(torch.isfinite(mean(lc._xdata_transformed))))
+
+    def test_quadratic_mean_applies_vector_constraints(self):
+        lc = self._lightcurve(
+            lambda wavelength: 1.0 + 0.5 * wavelength - 0.1 * wavelength**2
+        )
+        lc.set_model("2DWavelengthDependent")
+        result = lc._apply_parameter_workflow_estimates()
+
+        mean = lc.model.mean_module
+        weights = result["mean_module.weights"]
+        bias = result["mean_module.bias"]
+        self.assertTrue(weights["value"])
+        self.assertTrue(weights["constraint"])
+        self.assertTrue(bias["value"])
+        self.assertTrue(bias["constraint"])
+        lower = mean.raw_weights_constraint.lower_bound
+        upper = mean.raw_weights_constraint.upper_bound
+        self.assertEqual(tuple(lower.shape), (2,))
+        self.assertTrue(torch.all(lower < mean.weights))
+        self.assertTrue(torch.all(mean.weights < upper))
+
+    def test_existing_tighter_exponent_constraint_is_preserved(self):
+        lc = self._lightcurve(lambda wavelength: 1.0 + 2.0 * wavelength**0.5)
+        lc.set_model("2DPowerLawMean")
+        mean = lc.model.mean_module
+        register_constraint_preserving_value(
+            mean,
+            "raw_exponent",
+            gpytorch.constraints.Interval(0.25, 0.75),
+        )
+
+        result = lc._apply_parameter_workflow_estimates()
+        constraint = mean.raw_exponent_constraint
+        self.assertAlmostEqual(float(constraint.lower_bound), 0.25)
+        self.assertAlmostEqual(float(constraint.upper_bound), 0.75)
+        self.assertGreaterEqual(float(mean.exponent.detach()), 0.25)
+        self.assertLessEqual(float(mean.exponent.detach()), 0.75)
+        provenance = result["mean_module.exponent"][
+            "wavelength_mean_estimate_provenance"
+        ]
+        self.assertEqual(provenance["effective_constraint"], [0.25, 0.75])
+
+    def test_quasi_periodic_time_handoff_is_unchanged(self):
+        lc = self._lightcurve(lambda wavelength: 1.0 + wavelength**1.2)
+        lc.set_model(
+            "2DPowerLawMean",
+            time_kernel_type="quasi_periodic",
+            period=3.0,
+        )
+        result = lc._apply_parameter_workflow_estimates()
+
+        self.assertTrue(result["mean_module.exponent"]["value"])
+        period_length = (
+            lc.model.covar_module.kernels[0]
+            .base_kernel.kernels[0]
+            .period_length.detach()
+            .reshape(-1)[0]
+        )
+        self.assertAlmostEqual(float(period_length), 3.0, places=6)
+
+    def test_non_affine_wavelength_transform_is_rejected(self):
+        class SquareWavelengthTransform(torch.nn.Module):
+            pass
+
+        lc = self._lightcurve(lambda wavelength: wavelength, xtransform=None)
+        lc._xdata_transformed = lc._xdata_raw.clone()
+        lc._xdata_transformed[:, 1] = lc._xdata_raw[:, 1] ** 2
+        lc.xtransform = SquareWavelengthTransform()
+        with self.assertRaisesRegex(ValueError, "affine wavelength input transform"):
+            lc.set_model("2DPowerLawMean")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wavelength_mean_estimation.py
+++ b/tests/test_wavelength_mean_estimation.py
@@ -1,0 +1,139 @@
+import unittest
+
+import numpy as np
+
+from pgmuvi.wavelength_estimation import (
+    build_wavelength_mean_estimation_context,
+)
+
+
+class TestWavelengthMeanEstimation(unittest.TestCase):
+    def _rows(self, wavelengths, model_wavelengths, fluxes, n=5):
+        raw = []
+        model = []
+        values = []
+        bands = []
+        for index, (raw_wl, model_wl, flux) in enumerate(
+            zip(wavelengths, model_wavelengths, fluxes, strict=True)
+        ):
+            for offset in np.linspace(-0.02, 0.02, n):
+                raw.append(raw_wl)
+                model.append(model_wl)
+                values.append(flux + offset)
+                bands.append(f"b{index}")
+        return raw, model, values, bands
+
+    def test_quadratic_recommendation_uses_model_coordinate(self):
+        model_wavelengths = np.asarray([-1.0, -0.2, 0.6, 1.4])
+        fluxes = 3.0 + 2.0 * model_wavelengths - 0.5 * model_wavelengths**2
+        inputs = self._rows(
+            [0.5, 1.0, 2.0, 4.0],
+            model_wavelengths,
+            fluxes,
+        )
+        diagnostics = build_wavelength_mean_estimation_context(*inputs)
+        record = diagnostics.recommendations["2DWavelengthDependent"]
+
+        self.assertTrue(record["available"])
+        self.assertEqual(
+            record["coordinate_basis"],
+            "model_wavelength_and_model_flux",
+        )
+        self.assertAlmostEqual(
+            record["initial_values"]["mean_module.bias"],
+            3.0,
+            places=6,
+        )
+        weights = record["initial_values"]["mean_module.weights"]
+        self.assertAlmostEqual(weights[0], 2.0, places=6)
+        self.assertAlmostEqual(weights[1], -0.5, places=6)
+
+    def test_power_law_recommendation_uses_physical_wavelength(self):
+        raw_wavelengths = np.asarray([0.5, 1.0, 2.0, 4.0, 8.0])
+        model_wavelengths = (raw_wavelengths - raw_wavelengths.min()) / np.ptp(
+            raw_wavelengths
+        )
+        fluxes = 1.5 + 2.25 * raw_wavelengths**1.7
+        inputs = self._rows(
+            raw_wavelengths,
+            model_wavelengths,
+            fluxes,
+        )
+        diagnostics = build_wavelength_mean_estimation_context(*inputs)
+        record = diagnostics.recommendations["2DPowerLawMean"]
+
+        self.assertTrue(record["available"])
+        self.assertEqual(
+            record["coordinate_basis"],
+            "physical_wavelength_and_model_flux",
+        )
+        exponent = record["initial_values"]["mean_module.exponent"]
+        self.assertAlmostEqual(exponent, 1.7, delta=0.08)
+        self.assertLess(record["fit_rmse"], 0.1)
+
+    def test_dust_recommendation_is_positive_in_physical_parameters(self):
+        raw_wavelengths = np.asarray([0.45, 0.65, 1.2, 2.2, 4.0])
+        model_wavelengths = (raw_wavelengths - 2.0) / 1.5
+        fluxes = 0.2 + 3.0 * np.exp(-1.4 * raw_wavelengths ** -1.8)
+        inputs = self._rows(
+            raw_wavelengths,
+            model_wavelengths,
+            fluxes,
+        )
+        diagnostics = build_wavelength_mean_estimation_context(*inputs)
+        record = diagnostics.recommendations["2DDustMean"]
+
+        self.assertTrue(record["available"])
+        values = record["initial_values"]
+        self.assertGreater(values["mean_module.log_amplitude"], 0.0)
+        self.assertGreater(values["mean_module.log_tau"], 0.0)
+        self.assertGreater(values["mean_module.log_alpha"], 0.0)
+        self.assertEqual(
+            record["coordinate_basis"],
+            "physical_wavelength_and_model_flux",
+        )
+
+    def test_two_band_power_law_uses_fixed_default_exponent(self):
+        inputs = self._rows([0.5, 2.0], [0.0, 1.0], [4.0, 1.0])
+        diagnostics = build_wavelength_mean_estimation_context(*inputs)
+        record = diagnostics.recommendations["2DPowerLawMean"]
+
+        self.assertTrue(record["available"])
+        self.assertEqual(record["exponent_estimation"], "fixed_default_two_band")
+        self.assertEqual(
+            record["initial_values"]["mean_module.exponent"],
+            -2.0,
+        )
+
+    def test_flat_trend_does_not_invent_dust_shape(self):
+        inputs = self._rows(
+            [0.5, 1.0, 2.0, 4.0],
+            [0.0, 0.3, 0.7, 1.0],
+            [2.0, 2.0, 2.0, 2.0],
+            n=3,
+        )
+        # Remove the small within-band offsets added by _rows so the band
+        # medians are exactly constant.
+        inputs = (inputs[0], inputs[1], [2.0] * len(inputs[2]), inputs[3])
+        diagnostics = build_wavelength_mean_estimation_context(*inputs)
+        dust = diagnostics.recommendations["2DDustMean"]
+        power = diagnostics.recommendations["2DPowerLawMean"]
+
+        self.assertFalse(dust["available"])
+        self.assertEqual(dust["reason"], "wavelength_mean_not_resolved")
+        self.assertTrue(power["available"])
+        self.assertEqual(power["exponent_estimation"], "fixed_default_flat_trend")
+
+    def test_insufficient_bands_are_reported_per_model(self):
+        inputs = self._rows([0.5, 1.0], [0.0, 1.0], [1.0, 2.0])
+        diagnostics = build_wavelength_mean_estimation_context(*inputs)
+
+        self.assertTrue(
+            diagnostics.recommendations["2DWavelengthDependent"]["available"]
+        )
+        self.assertFalse(diagnostics.recommendations["2DDustMean"]["available"])
+        self.assertIn("2DDustMean", " ".join(diagnostics.warnings))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1560,9 +1560,9 @@ class TestPowerLawMean(unittest.TestCase):
         """PowerLawMean registers offset, weight, and exponent parameters."""
         mean = self.PowerLawMean()
         param_names = [n for n, _ in mean.named_parameters()]
-        self.assertIn("offset", param_names)
-        self.assertIn("weight", param_names)
-        self.assertIn("exponent", param_names)
+        self.assertIn("raw_offset", param_names)
+        self.assertIn("raw_weight", param_names)
+        self.assertIn("raw_exponent", param_names)
 
     def test_default_exponent(self):
         """Default exponent is -2.0 (steep optical-to-IR decline)."""
@@ -1573,10 +1573,11 @@ class TestPowerLawMean(unittest.TestCase):
         """Forward output matches expected power-law calculation."""
         mean = self.PowerLawMean()
         # Set known parameters: offset=0, weight=1, exponent=-2
-        with torch.no_grad():
-            mean.offset.fill_(0.0)
-            mean.weight.fill_(1.0)
-            mean.exponent.fill_(-2.0)
+        mean.initialize(
+            offset=torch.tensor([0.0]),
+            weight=torch.tensor([1.0]),
+            exponent=torch.tensor([-2.0]),
+        )
         out = mean(self.x)
         wavelengths = self.x[:, 1]
         expected = wavelengths.pow(-2.0)
@@ -1608,20 +1609,21 @@ class TestDustMean(unittest.TestCase):
         """DustMean registers the required parameters."""
         mean = self.DustMean()
         param_names = [n for n, _ in mean.named_parameters()]
-        self.assertIn("offset", param_names)
-        self.assertIn("log_amplitude", param_names)
-        self.assertIn("log_tau", param_names)
-        self.assertIn("log_alpha", param_names)
+        self.assertIn("raw_offset", param_names)
+        self.assertIn("raw_log_amplitude", param_names)
+        self.assertIn("raw_log_tau", param_names)
+        self.assertIn("raw_log_alpha", param_names)
 
     def test_extinction_increases_at_short_wavelength(self):
         """Extinction is greater at shorter wavelengths (dust behaviour)."""
         mean = self.DustMean()
         # Set tau > 0, alpha > 0; offset = 0
-        with torch.no_grad():
-            mean.offset.fill_(0.0)
-            mean.log_amplitude.fill_(0.0)   # amplitude = 1
-            mean.log_tau.fill_(0.0)         # tau = 1
-            mean.log_alpha.fill_(0.0)       # alpha = 1
+        mean.initialize(
+            offset=torch.tensor([0.0]),
+            log_amplitude=torch.tensor([0.0]),
+            log_tau=torch.tensor([0.0]),
+            log_alpha=torch.tensor([0.0]),
+        )
         x_optical = torch.tensor([[0.0, 0.5]], dtype=torch.float32)
         x_ir = torch.tensor([[0.0, 2.0]], dtype=torch.float32)
         out_optical = mean(x_optical)
@@ -1632,11 +1634,12 @@ class TestDustMean(unittest.TestCase):
     def test_zero_tau_gives_constant_mean(self):
         """With tau -> 0, DustMean approaches amplitude + offset."""
         mean = self.DustMean()
-        with torch.no_grad():
-            mean.offset.fill_(0.5)
-            mean.log_amplitude.fill_(0.0)   # amplitude = 1
-            mean.log_tau.fill_(-30.0)       # tau ≈ 0
-            mean.log_alpha.fill_(0.0)
+        mean.initialize(
+            offset=torch.tensor([0.5]),
+            log_amplitude=torch.tensor([0.0]),
+            log_tau=torch.tensor([-30.0]),
+            log_alpha=torch.tensor([0.0]),
+        )
         out = mean(self.x)
         # Should be approximately offset + amplitude = 1.5 for all points
         self.assertTrue(torch.allclose(out, torch.full((3,), 1.5), atol=1e-3))


### PR DESCRIPTION
## Summary

This PR derives and applies wavelength-dependent mean estimates for:

- `2DWavelengthDependent`
- `2DDustMean`
- `2DPowerLawMean`

The estimates are based on robust per-band flux summaries and are handled separately from the wavelength-covariance estimates introduced in PR122.

## Mean parameter constraints

The dust and power-law mean parameters now use enforceable GPyTorch raw-parameter transforms rather than advisory-only bounds on plain parameters.

The implementation:

- registers final constraints before assigning parameter values;
- intersects data-derived intervals with existing tighter constraints;
- preserves valid parameter values where possible;
- records estimate, constraint, coordinate, and application provenance;
- avoids log-flux fitting.

## Coordinate handling

Dust and power-law wavelength laws are evaluated using reconstructed positive physical wavelengths when the GP input wavelength coordinate has undergone a supported affine transform.

Unsupported non-affine wavelength mappings are rejected rather than silently applying physically invalid mean functions.

## Additional correction

The parameter-discovery code now removes the exact `raw_` prefix instead of using character stripping, which could corrupt names such as `raw_weight`.

## Scope boundary

This PR does not modify:

- wavelength covariance initialization introduced in PR122;
- the full non-separable `2D` spectral-mixture ARD parameterization;
- temporal-frequency initialization or constraints;
- fitting scores, ranking, or comparison eligibility.

The independent temporal/wavelength ARD redesign remains a separate package.

## Validation

- targeted tests passed;
- CI-equivalent Ruff passed;
- strict Sphinx documentation passed after resolving duplicate constrained-property indexing;
- complete unittest suite passed.