### PR TITLE
Separate temporal and wavelength ARD constraints

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -60,6 +60,7 @@ Data, diagnostics, and validation
    pgmuvi.wavelength_conclusions
    pgmuvi.wavelength_diagnostics
    pgmuvi.wavelength_estimation
+   pgmuvi.spectral_mixture_ard
    pgmuvi.wavelength_hypotheses
    pgmuvi.wavelength_results
    pgmuvi.wavelength_status

--- a/docs/source/future_work.rst
+++ b/docs/source/future_work.rst
@@ -59,12 +59,18 @@ Wavelength-derived fitting constraints and validation
     records the robust-band fit, proposed interval, effective interval, and
     coordinate basis.
 
-    The remaining scientific fitting tranche must redesign the full ``2D``
-    spectral-mixture parameterization so temporal and wavelength ARD dimensions
-    can receive genuinely independent bounds, and extend explicit
-    component/dimension saturation diagnostics.  It must continue to use the
-    recorded usable-band, adjacent-spacing, gap, uncertainty, robust mean, and
-    robust amplitude summaries rather than reverting to generic constants.
+    The full ``2D`` spectral-mixture baseline now gives temporal and wavelength ARD
+    dimensions genuinely independent broadcast tensor intervals
+    for both ``mixture_means`` and ``mixture_scales``.  ARD index 0
+    receives temporal-frequency values and bounds, while index 1 receives
+    independently wavelength-derived values and bounds.  Source-type period
+    limits alter only index 0, and raw/model-coordinate provenance is retained.
+
+    The remaining work in this tranche is explicit component/dimension
+    saturation and distance-to-bound reporting.  It must distinguish a
+    scientifically long wavelength correlation scale from optimizer pressure,
+    identify the affected component and ARD dimension, and record whether the
+    spectral-mixture component count was fixed at one.
 
 **TBD[wavelength-constraint-validation]**
     Validate the wavelength-derived initialization and constraint tranche with

--- a/docs/source/howto/consensus_fitting.rst
+++ b/docs/source/howto/consensus_fitting.rst
@@ -339,12 +339,15 @@ component.
 ``fit_strategy="consensus_multicomp"`` is an implemented staged workflow for
 extracting, clustering, and aggregating multiple frequency components before a
 final 2-D spectral-mixture fit.  It is not the default LPV workflow.  The current
-implementation still applies one broad global frequency interval to accepted
-components rather than component-specific constraints.
+implementation still applies one broad global **temporal-frequency** interval
+across accepted components rather than component-specific temporal intervals.
+For the full ``2D`` spectral-mixture baseline, that consensus interval updates
+only ARD index 0; the independently derived wavelength-frequency bounds at ARD
+index 1 are preserved.
 
 .. admonition:: TBD: multi-periodic support
 
-   Component-specific constraints, model-family support beyond the final 2-D
+   component-specific constraints, model-family support beyond the final 2-D
    spectral-mixture fit, and a complete scientific validation standard for
    multi-periodic sources remain future work.
 

--- a/docs/source/howto/priors_constraints.rst
+++ b/docs/source/howto/priors_constraints.rst
@@ -109,11 +109,18 @@ For the noise variance::
    reconstructed physical wavelength coordinate when an affine input transform
    is active.
 
-   For the **non-separable ``model="2D"``**, GPyTorch applies constraints
-   element-wise to the entire ``mixture_means`` tensor (which spans both time
-   and wavelength dimensions), so temporal and wavelength constraints cannot be
-   set independently.  If independent per-dimension constraints are required,
-   use one of the separable 2D model families.
+   For the full non-separable ``"2D"`` spectral-mixture baseline, GPyTorch
+   tensor-valued intervals are registered with shape ``(1, 1, 2)``.  They
+   broadcast across components while keeping ARD index 0 (temporal frequency)
+   independent from ARD index 1 (wavelength frequency).  The same separation is
+   applied to ``mixture_scales``.  Source-type period limits modify only the
+   temporal entry.
+
+   Consensus fitting also respects this separation.  Consensus frequency and
+   scale intervals intersect only ARD index 0, while the wavelength-frequency
+   bounds at ARD index 1 remain unchanged.  The multi-component workflow still
+   uses one broad temporal interval across accepted components; it does not
+   impose that temporal interval on the wavelength coordinate.
 
 Using Pre-defined Constraint Sets
 -----------------------------------

--- a/docs/source/howto/wavelength_advisory.rst
+++ b/docs/source/howto/wavelength_advisory.rst
@@ -609,7 +609,7 @@ initialization with enforceable constraints for ``2DWavelengthDependent``,
 conclusion records into automatic selection evidence.
 
 The remaining roadmap is tracked by ``TBD[wavelength-derived-constraints]`` and
-``TBD[wavelength-constraint-validation]``.  It covers dimension-aware temporal
-versus wavelength ARD bounds for the full ``2D`` spectral-mixture baseline,
-saturation provenance, synthetic recovery, consensus compatibility, and
-real-LPV validation.
+``TBD[wavelength-constraint-validation]``.  Independent temporal and wavelength
+ARD bounds are now implemented for the full ``2D`` spectral-mixture baseline.
+The remaining work covers component/dimension saturation provenance, synthetic
+recovery, consensus compatibility, and real-LPV validation.

--- a/docs/source/howto/wavelength_models.rst
+++ b/docs/source/howto/wavelength_models.rst
@@ -281,9 +281,11 @@ records both the proposed and effective bounds under
 ``wavelength_estimate_provenance``.
 
 This is an initialization and optimization-domain improvement, not evidence
-that a source has resolved wavelength dependence.  It does not apply to the
-full non-separable ``2D`` spectral-mixture kernel, whose temporal and wavelength
-ARD entries still share tensor-wide constraints.
+that a source has resolved wavelength dependence.  For the full non-separable
+``2D`` spectral-mixture kernel, temporal and wavelength entries now receive
+independent broadcast tensor intervals for both ``mixture_means`` and
+``mixture_scales``.  The fixed ordering is ARD index 0 for temporal frequency
+and index 1 for wavelength frequency.
 
 Data-derived wavelength mean initialization
 -------------------------------------------

--- a/docs/source/pgmuvi.spectral_mixture_ard.rst
+++ b/docs/source/pgmuvi.spectral_mixture_ard.rst
@@ -1,0 +1,29 @@
+pgmuvi.spectral_mixture_ard
+=================================
+
+The full non-separable ``2D`` spectral-mixture kernel stores both ARD
+coordinates in tensors whose last axis is ordered as:
+
+* index 0: temporal frequency;
+* index 1: wavelength frequency.
+
+PGMUVI now derives separate initial values and finite bounds for both
+``mixture_means`` and ``mixture_scales``.  The registered GPyTorch intervals
+have shape ``(1, 1, 2)`` and broadcast across mixture components, so the two
+coordinates no longer share a scalar bound.
+
+Temporal bounds are derived from the model-coordinate time span and cadence.
+Wavelength bounds are derived independently from wavelength span, adjacent-band
+spacing, gap structure, and the wavelength-lengthscale recommendation.  Raw and
+model-coordinate values are retained in
+``spectral_mixture_ard_provenance``.
+
+This parameterization improves initialization and constraint integrity.  It is
+not evidence that wavelength dependence is resolved, and a wavelength value at
+or near a bound must be interpreted through the separate saturation
+diagnostics planned under ``TBD[wavelength-derived-constraints]``.
+
+.. automodule:: pgmuvi.spectral_mixture_ard
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/pgmuvi.wavelength_estimation.rst
+++ b/docs/source/pgmuvi.wavelength_estimation.rst
@@ -26,8 +26,10 @@ model-coordinate recommendations, the transform, the proposed interval, and
 the effective registered interval.
 
 This applies to the wavelength covariance in ``2DWavelengthDependent``,
-``2DDustMean``, ``2DPowerLawMean``, and ``2DSeparable``.  It does not change the
-full non-separable ``2D`` spectral-mixture ARD parameterization.
+``2DDustMean``, ``2DPowerLawMean``, and ``2DSeparable``.  The
+full non-separable ``2D`` baseline consumes the same sampling context through the
+dimension-aware spectral-mixture ARD layer documented in
+:mod:`pgmuvi.spectral_mixture_ard`.
 
 The same module now builds model-ready wavelength-mean recommendations from
 robust per-band median fluxes.  ``GuessStrategy.WAVELENGTH_MEAN`` and

--- a/pgmuvi/__init__.py
+++ b/pgmuvi/__init__.py
@@ -19,6 +19,7 @@ __all__ = [
     "initialization",
     "lightcurve",
     "priors",
+    "spectral_mixture_ard",
     "synthetic",
     "trainers",
     "wavelength_conclusions",

--- a/pgmuvi/constraint_utils.py
+++ b/pgmuvi/constraint_utils.py
@@ -174,7 +174,9 @@ def _as_common_dtype_tensors(first: Any, second: Any) -> tuple[torch.Tensor, tor
     if not torch.is_floating_point(torch.empty((), dtype=common_dtype)):
         common_dtype = torch.get_default_dtype()
 
-    return first_tensor.to(dtype=common_dtype), second_tensor.to(dtype=common_dtype)
+    first_tensor = first_tensor.to(dtype=common_dtype)
+    second_tensor = second_tensor.to(dtype=common_dtype)
+    return torch.broadcast_tensors(first_tensor, second_tensor)
 
 
 def bounds_are_equivalent(first: tuple[Any, Any], second: tuple[Any, Any]) -> bool:

--- a/pgmuvi/gps.py
+++ b/pgmuvi/gps.py
@@ -207,6 +207,19 @@ def spectral_mixture_parameter_schema(
     else:
         shape = (num_mixtures,)
 
+    dimension_aware = ard_num_dims == 2
+    ard_metadata = (
+        {
+            "coordinate_order": [
+                "temporal_frequency",
+                "wavelength_frequency",
+            ],
+            "parameterization": "broadcast_tensor_intervals",
+        }
+        if dimension_aware
+        else {}
+    )
+
     return ParameterSpecCollection(
         [
             ParameterSpec(
@@ -217,12 +230,25 @@ def spectral_mixture_parameter_schema(
                 shape=shape,
                 initial_value=None,
                 constraint=(1.0e-6, 1.0e6),
-                guess_strategy=GuessStrategy.CONSENSUS_FREQUENCY,
-                constraint_strategy=ConstraintStrategy.DEFAULT,
+                guess_strategy=(
+                    GuessStrategy.DIMENSION_AWARE_SM_ARD
+                    if dimension_aware
+                    else GuessStrategy.CONSENSUS_FREQUENCY
+                ),
+                constraint_strategy=(
+                    ConstraintStrategy.DIMENSION_AWARE_SM_ARD
+                    if dimension_aware
+                    else ConstraintStrategy.DEFAULT
+                ),
+                metadata={
+                    **ard_metadata,
+                    "spectral_mixture_ard_parameter": "mixture_means",
+                },
                 description=(
                     "Central frequencies of the spectral-mixture components. "
-                    "Period diagnostics should be converted to frequencies before "
-                    "constructing estimates for this parameter."
+                    "For two-dimensional kernels, temporal and wavelength "
+                    "frequencies receive independent tensor-valued values and "
+                    "bounds in ARD indices 0 and 1."
                 ),
             ),
             ParameterSpec(
@@ -233,10 +259,25 @@ def spectral_mixture_parameter_schema(
                 shape=shape,
                 initial_value=None,
                 constraint=(1.0e-6, 1.0e3),
-                guess_strategy=GuessStrategy.DEFAULT,
-                constraint_strategy=ConstraintStrategy.DEFAULT,
+                guess_strategy=(
+                    GuessStrategy.DIMENSION_AWARE_SM_ARD
+                    if dimension_aware
+                    else GuessStrategy.DEFAULT
+                ),
+                constraint_strategy=(
+                    ConstraintStrategy.DIMENSION_AWARE_SM_ARD
+                    if dimension_aware
+                    else ConstraintStrategy.DEFAULT
+                ),
+                metadata={
+                    **ard_metadata,
+                    "spectral_mixture_ard_parameter": "mixture_scales",
+                },
                 description=(
-                    "Positive frequency-space widths of the spectral-mixture components."
+                    "Positive frequency-space widths of the spectral-mixture "
+                    "components. For two-dimensional kernels, temporal and "
+                    "wavelength widths receive independent tensor-valued values "
+                    "and bounds."
                 ),
             ),
             ParameterSpec(

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -72,8 +72,15 @@ from pgmuvi.wavelength_estimation import (
     build_wavelength_estimation_context,
     build_wavelength_mean_estimation_context,
 )
+from pgmuvi.constraint_utils import bounds_are_valid
 from pgmuvi.constraint_utils import clamp_to_constraint_interior
+from pgmuvi.constraint_utils import get_bounds
+from pgmuvi.constraint_utils import intersect_constraint_bounds
+from pgmuvi.constraint_utils import make_interval_constraint
 from pgmuvi.constraint_utils import register_constraint_preserving_value
+from pgmuvi.spectral_mixture_ard import (
+    build_dimension_aware_sm_ard_estimates,
+)
 
 try:
     from scipy.signal import find_peaks as _scipy_find_peaks
@@ -437,6 +444,15 @@ _CONSENSUS_TOP_LEVEL_SCHEMA_FIELDS = MappingProxyType(
         ),
         "consensus_scale_constraint_target_key": _consensus_schema_field(
             default=None, nullable=True
+        ),
+        "consensus_constraint_ard_scope": _consensus_schema_field(
+            default=None, nullable=True
+        ),
+        "consensus_wavelength_constraint_preserved": _consensus_schema_field(
+            default=None, nullable=True
+        ),
+        "consensus_sm_constraint_provenance": _consensus_schema_field(
+            default_factory="dict", nullable=False, container_type="dict"
         ),
         "consensus_time_kernel_constraint_mode": _consensus_schema_field(
             default=None, nullable=True
@@ -6956,6 +6972,40 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         self.__PRIORS_SET = True
         pass
 
+    def _transform_frequency_like_to_model(self, values):
+        """Transform frequency-like values from raw to fitted input units.
+
+        Spectral-mixture means and scales transform inversely to coordinate
+        lengths.  For multivariate affine input transforms, the last tensor
+        axis is scaled independently, preserving ARD index 0 as time and ARD
+        index 1 as wavelength.
+        """
+        value = torch.as_tensor(
+            values,
+            dtype=self._xdata_transformed.dtype,
+            device=self._xdata_transformed.device,
+        )
+        if self.xtransform is None:
+            return value
+
+        raw = self._xdata_raw
+        model = self._xdata_transformed
+        if self.ndim > 1:
+            raw_span = raw.max(dim=0).values - raw.min(dim=0).values
+            model_span = model.max(dim=0).values - model.min(dim=0).values
+            scale = torch.ones_like(raw_span)
+            valid = (raw_span > 0) & (model_span > 0)
+            scale[valid] = raw_span[valid] / model_span[valid]
+            if value.ndim > 0 and value.shape[-1] == self.ndim:
+                return value * scale
+            return value * scale[0]
+
+        raw_span = raw.max() - raw.min()
+        model_span = model.max() - model.min()
+        if raw_span > 0 and model_span > 0:
+            return value * (raw_span / model_span)
+        return value
+
     def set_constraint(self, constraint, debug=False, **kwargs):
         """Set the constraint for the model parameters
 
@@ -6995,83 +7045,23 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                         constraint[key],
                     )
                 elif any(p in key for p in pars_to_transform["x"]):
-                    # now apply the x transform
-                    # remember that the means and scales are in fourier space
-                    # so we need to transform them back to real space
-                    # before applying the transform
-                    # and then transform them back to fourier space
-                    # luckily, when the shift is removed from the transform,
-                    # the factors of 2pi cancel out for the scales
-                    # so we can just do 1/ for both means and scales
+                    transformed_constraint = constraint[key]
                     if self.xtransform is not None:
-                        # now things get complicated...
-                        # if we have gotten to here, we know that the parameter
-                        # is a mixture mean or scale, so we need to transform
-                        # it to real space, apply the constraint, and then
-                        # transform it back to fourier space
-                        # luckily, when the shift is removed from the transform,
-                        # the factors of 2pi cancel out for the scales
-                        # so we can just do 1/ for both means and scales
+                        lower, upper = get_bounds(constraint[key])
+                        transformed_constraint = make_interval_constraint(
+                            self._transform_frequency_like_to_model(lower),
+                            self._transform_frequency_like_to_model(upper),
+                        )
                         if debug:
-                            print(constraint[key])
-                        if constraint[key].lower_bound not in [
-                            torch.tensor(0),
-                            torch.tensor(-torch.inf),
-                        ]:
-                            # we need to transform the lower bound
-                            # NOTE: For 2D data, GPyTorch constraints are scalar
-                            # and apply element-wise to all parameter elements
-                            # (time and wavelength).
-                            # We transform using dimension 0 (time) as it's
-                            # typically the primary independent variable.
-                            # Users setting manual constraints should be aware
-                            # that the same constraint applies to both
-                            # dimensions.
-                            transformed_bound = 1.0 / self.xtransform.transform(
-                                1.0 / constraint[key].lower_bound, shift=False
+                            print(
+                                "Transformed frequency-like constraint with "
+                                "independent input-dimension scales:"
                             )
-                            # Handle both 1D and 2D cases
-                            if transformed_bound.numel() > 1:
-                                # For 2D case, use the first dimension's
-                                # transformation. Take element [0, 0] to get
-                                # a scalar
-                                transformed_bound = transformed_bound.flatten()[0]
-                            if debug:
-                                print(f"Transformed lower bound: {transformed_bound}")
-                            constraint[key].lower_bound = torch.tensor(
-                                transformed_bound.item()
-                            )
-                            if debug:
-                                print(constraint[key].lower_bound)
-                                print(constraint[key])
-                        if constraint[key].upper_bound not in [
-                            torch.tensor(0),
-                            torch.tensor(torch.inf),
-                        ]:
-                            # we need to transform the upper bound
-                            # (Same dimension-0 transformation logic as
-                            # lower_bound above)
-                            transformed_bound = 1.0 / self.xtransform.transform(
-                                1.0 / constraint[key].upper_bound, shift=False
-                            )
-                            # Handle both 1D and 2D cases
-                            if transformed_bound.numel() > 1:
-                                # For 2D case, use the first dimension's
-                                # transformation. Take element [0, 0] to get
-                                # a scalar
-                                transformed_bound = transformed_bound.flatten()[0]
-                            constraint[key].upper_bound = torch.tensor(
-                                transformed_bound.item()
-                            )
-                            if debug:
-                                print(constraint[key].upper_bound)
-                                print(constraint[key])
-                        if debug:
-                            print(constraint[key])
+                            print(transformed_constraint)
                     register_constraint_preserving_value(
                         self._model_pars[key]["module"],
                         k,
-                        constraint[key],
+                        transformed_constraint,
                     )
                 elif any(p in key for p in pars_to_transform["y"]):
                     if self.ytransform is not None:
@@ -7748,175 +7738,224 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         # (e.g. Matérn, quasi-periodic, separable) do not have this parameter
         # and must not be constrained here; they would raise KeyError otherwise.
         if "mixture_means" in self._model_pars:
-            # this should correspond to the longest frequency entirely
-            # contained in the dataset:
-            if self.ndim > 1:
-                # For 2D spectral-mixture models the mixture_means parameter
-                # has shape (num_mixtures, 1, ard_num_dims), where ard_num_dims
-                # equals the number of input dimensions (typically 2: time and
-                # wavelength).  GPyTorch applies a *single scalar* constraint
-                # element-wise to every entry in that tensor — it is not
-                # possible to set different lower bounds for the time dimension
-                # and the wavelength dimension simultaneously via the standard
-                # register_constraint API.
-                #
-                # We therefore base the lower bound exclusively on the *time*
-                # dimension (column 0 of xdata_transformed):
-                #
-                #   lower_bound = 1 / time_span
-                #
-                # This guarantees that the time-axis frequencies are always
-                # >= 1/time_span, i.e., that the inferred periods are not
-                # longer than the observational baseline — a physically
-                # meaningful and stable lower bound.
-                #
-                # Note that this same lower bound is also applied to the
-                # wavelength-axis frequency elements of mixture_means.  In
-                # practice, wavelength frequencies represent the spatial
-                # frequency of the SED variation across bands; constraining
-                # them to be >= 1/time_span is conservative (frequencies
-                # corresponding to structures much narrower in wavelength than
-                # the observation baseline are still allowed), and is
-                # preferable to using min(time_bound, wavelength_bound) which
-                # would make the time lower bound arbitrarily permissive
-                # whenever the wavelength span is large or the wavelength
-                # range is zero.
-                #
-                # Users who need achromatic behaviour (wavelength-frequency
-                # near zero) should use the separable model classes
-                # (AchromaticGPModel, WavelengthDependentGPModel) which apply
-                # kernels to each dimension independently, avoiding this
-                # limitation entirely.
-                time_span = (
-                    self._xdata_transformed[:, 0].max()
-                    - self._xdata_transformed[:, 0].min()
+            covar_module = self._model_pars["mixture_means"]["module"]
+            if self.ndim > 1 and getattr(covar_module, "ard_num_dims", 1) == 2:
+                context = self._build_parameter_estimation_context()
+                diagnostics = context.spectral_mixture_ard_diagnostics
+                if diagnostics is None:
+                    raise RuntimeError(
+                        "Dimension-aware spectral-mixture ARD diagnostics "
+                        "could not be constructed."
+                    )
+                model_coordinate = diagnostics["model_coordinate"]
+                means_record = model_coordinate["mixture_means"]
+                raw_means = covar_module.raw_mixture_means
+                means_lower = torch.as_tensor(
+                    means_record["constraint_lower"],
+                    dtype=raw_means.dtype,
+                    device=raw_means.device,
                 )
-                if float(time_span) <= 0.0:
-                    raise ValueError(
-                        "set_default_constraints requires a dataset whose "
-                        "timestamps span a positive time range, but all "
-                        "timestamps in the 2D input are identical "
-                        "(time_span = 0). Ensure the training data covers "
-                        "more than one distinct observation time."
-                    )
-                lower_frequency = 1.0 / time_span
-
-                # Compute the Nyquist upper bound from the minimum positive
-                # gap between consecutive sorted timestamps (O(N log N), O(N)
-                # memory — avoids the O(N²) pairwise-difference matrix).
-                t_sorted = self._xdata_transformed[:, 0].sort().values
-                consecutive_diffs = (t_sorted[1:] - t_sorted[:-1])
-                positive_diffs = consecutive_diffs[consecutive_diffs > 0]
-                if positive_diffs.numel() > 0:
-                    min_diff = positive_diffs.min()
-                    max_freq = 1 / (2 * min_diff)  # Nyquist based on time sampling
-                    mixture_means_constraint = Interval(lower_frequency, max_freq)
-                else:
-                    # time_span > 0 guarantees at least two distinct timestamps,
-                    # so positive_diffs is always non-empty here.  This branch
-                    # is unreachable in practice.
-                    raise ValueError(  # pragma: no cover
-                        "Unexpected degenerate timestamps: time_span > 0 but "
-                        "no consecutive positive differences found."
-                    )
-            else:
-                # 1D case: base the lower-frequency bound on the time span
-                # (max - min) rather than the absolute maximum. This prevents
-                # allowing periods longer than the observational baseline and
-                # is consistent with the 2D logic above.
-                time_span = (
-                    self._xdata_transformed.max()
-                    - self._xdata_transformed.min()
+                means_upper = torch.as_tensor(
+                    means_record["constraint_upper"],
+                    dtype=raw_means.dtype,
+                    device=raw_means.device,
                 )
-                if float(time_span) <= 0.0:
-                    raise ValueError(
-                        "set_default_constraints requires a dataset whose "
-                        "timestamps span a positive time range, but all "
-                        "timestamps in the 1D input are identical "
-                        "(time_span = 0). Ensure the training data covers "
-                        "more than one distinct observation time."
-                    )
-                mixture_means_constraint = GreaterThan(1 / time_span)
 
-            # Apply any constraint_set period bounds to the mixture_means
-            # constraint
-            if constraint_set is not None:
-                cs = get_constraint_set(constraint_set)
-                if "period" in cs:
-                    period_bounds = cs["period"]
-                    lower_val, lower_active = period_bounds["lower"]
-                    upper_val, upper_active = period_bounds["upper"]
-
-                    # Compute the scale factor to convert a period in original
-                    # (untransformed) units to a frequency in transformed space.
-                    # For any linear rescaling transform:
-                    #   freq_transformed = freq_original * (x_orig_span /
-                    #                                       x_trans_span)
-                    if self.ndim > 1:
-                        x_orig_span = float(
+                if constraint_set is not None:
+                    cs = get_constraint_set(constraint_set)
+                    if "period" in cs:
+                        period_bounds = cs["period"]
+                        lower_val, lower_active = period_bounds["lower"]
+                        upper_val, upper_active = period_bounds["upper"]
+                        raw_time_span = float(
                             self._xdata_raw[:, 0].max()
                             - self._xdata_raw[:, 0].min()
                         )
-                        x_trans_span = float(
+                        model_time_span = float(
                             self._xdata_transformed[:, 0].max()
                             - self._xdata_transformed[:, 0].min()
                         )
-                    else:
-                        x_orig_span = float(
-                            self._xdata_raw.max() - self._xdata_raw.min()
+                        freq_scale = (
+                            raw_time_span / model_time_span
+                            if model_time_span > 0
+                            else 1.0
                         )
-                        x_trans_span = float(
-                            self._xdata_transformed.max()
-                            - self._xdata_transformed.min()
-                        )
-                    freq_scale = (
-                        x_orig_span / x_trans_span if x_trans_span > 0 else 1.0
+                        if lower_active and lower_val is not None:
+                            proposed_upper = freq_scale / lower_val
+                            if proposed_upper > float(means_lower[0, 0, 0]):
+                                means_upper[0, 0, 0] = min(
+                                    float(means_upper[0, 0, 0]),
+                                    proposed_upper,
+                                )
+                        if upper_active and upper_val is not None:
+                            proposed_lower = freq_scale / upper_val
+                            if proposed_lower < float(means_upper[0, 0, 0]):
+                                means_lower[0, 0, 0] = max(
+                                    float(means_lower[0, 0, 0]),
+                                    proposed_lower,
+                                )
+
+                if torch.any(means_lower >= means_upper):
+                    raise ValueError(
+                        "The temporal period limits conflict with the "
+                        "dimension-aware spectral-mixture frequency bounds."
                     )
+                proposed_means_constraint = Interval(
+                    means_lower,
+                    means_upper,
+                )
+                existing_means_constraint = getattr(
+                    covar_module,
+                    "raw_mixture_means_constraint",
+                    None,
+                )
+                effective_means_bounds = intersect_constraint_bounds(
+                    existing_means_constraint,
+                    proposed_means_constraint,
+                )
+                if bounds_are_valid(effective_means_bounds):
+                    means_constraint = make_interval_constraint(
+                        *effective_means_bounds
+                    )
+                else:
+                    means_constraint = existing_means_constraint
+                register_constraint_preserving_value(
+                    covar_module,
+                    "raw_mixture_means",
+                    means_constraint,
+                )
 
-                    # Period lower limit → frequency upper limit
-                    if lower_active and lower_val is not None:
-                        max_freq_from_period = freq_scale / lower_val
-                        cur_lower = float(mixture_means_constraint.lower_bound)
-                        if max_freq_from_period > cur_lower:
-                            if isinstance(mixture_means_constraint, GreaterThan):
-                                mixture_means_constraint = Interval(
-                                    cur_lower, max_freq_from_period
-                                )
-                            else:
-                                # Already an Interval: tighten the upper bound
-                                cur_upper = float(
-                                    mixture_means_constraint.upper_bound
-                                )
-                                mixture_means_constraint = Interval(
-                                    cur_lower,
-                                    min(cur_upper, max_freq_from_period),
-                                )
+                scale_record = model_coordinate["mixture_scales"]
+                raw_scales = covar_module.raw_mixture_scales
+                scales_lower = torch.as_tensor(
+                    scale_record["constraint_lower"],
+                    dtype=raw_scales.dtype,
+                    device=raw_scales.device,
+                )
+                scales_upper = torch.as_tensor(
+                    scale_record["constraint_upper"],
+                    dtype=raw_scales.dtype,
+                    device=raw_scales.device,
+                )
+                proposed_scales_constraint = Interval(
+                    scales_lower,
+                    scales_upper,
+                )
+                existing_scales_constraint = getattr(
+                    covar_module,
+                    "raw_mixture_scales_constraint",
+                    None,
+                )
+                effective_scales_bounds = intersect_constraint_bounds(
+                    existing_scales_constraint,
+                    proposed_scales_constraint,
+                )
+                if bounds_are_valid(effective_scales_bounds):
+                    scales_constraint = make_interval_constraint(
+                        *effective_scales_bounds
+                    )
+                else:
+                    scales_constraint = existing_scales_constraint
+                register_constraint_preserving_value(
+                    covar_module,
+                    "raw_mixture_scales",
+                    scales_constraint,
+                )
+                effective_means_lower, effective_means_upper = get_bounds(
+                    means_constraint
+                )
+                effective_scales_lower, effective_scales_upper = get_bounds(
+                    scales_constraint
+                )
+                self._spectral_mixture_ard_constraint_provenance = {
+                    "schema_version": diagnostics["schema_version"],
+                    "parameterization": diagnostics["parameterization"],
+                    "coordinate_order": diagnostics["coordinate_order"],
+                    "ard_index": diagnostics["ard_index"],
+                    "constraint_set": constraint_set,
+                    "mixture_means": {
+                        "proposed_lower": means_lower.detach().cpu().tolist(),
+                        "proposed_upper": means_upper.detach().cpu().tolist(),
+                        "effective_lower": torch.as_tensor(
+                            effective_means_lower
+                        ).detach().cpu().tolist(),
+                        "effective_upper": torch.as_tensor(
+                            effective_means_upper
+                        ).detach().cpu().tolist(),
+                    },
+                    "mixture_scales": {
+                        "proposed_lower": scales_lower.detach().cpu().tolist(),
+                        "proposed_upper": scales_upper.detach().cpu().tolist(),
+                        "effective_lower": torch.as_tensor(
+                            effective_scales_lower
+                        ).detach().cpu().tolist(),
+                        "effective_upper": torch.as_tensor(
+                            effective_scales_upper
+                        ).detach().cpu().tolist(),
+                    },
+                }
+            else:
+                time_values = (
+                    self._xdata_transformed[:, 0]
+                    if self.ndim > 1
+                    else self._xdata_transformed
+                )
+                time_span = time_values.max() - time_values.min()
+                if float(time_span) <= 0.0:
+                    raise ValueError(
+                        "set_default_constraints requires timestamps that "
+                        "span a positive range."
+                    )
+                mixture_means_constraint = GreaterThan(1.0 / time_span)
 
-                    # Period upper limit → frequency lower limit
-                    if upper_active and upper_val is not None:
-                        min_freq_from_period = freq_scale / upper_val
-                        cur_lower = float(mixture_means_constraint.lower_bound)
-                        cur_upper = (
-                            float(mixture_means_constraint.upper_bound)
-                            if isinstance(mixture_means_constraint, Interval)
-                            else float("inf")
+                if constraint_set is not None:
+                    cs = get_constraint_set(constraint_set)
+                    if "period" in cs:
+                        period_bounds = cs["period"]
+                        lower_val, lower_active = period_bounds["lower"]
+                        upper_val, upper_active = period_bounds["upper"]
+                        raw_time = (
+                            self._xdata_raw[:, 0]
+                            if self.ndim > 1
+                            else self._xdata_raw
                         )
-                        new_lower = max(cur_lower, min_freq_from_period)
-                        if new_lower < cur_upper:
-                            if isinstance(mixture_means_constraint, GreaterThan):
-                                mixture_means_constraint = GreaterThan(new_lower)
-                            else:
-                                mixture_means_constraint = Interval(
-                                    new_lower, cur_upper
-                                )
+                        raw_time_span = float(raw_time.max() - raw_time.min())
+                        model_time_span = float(time_span)
+                        freq_scale = (
+                            raw_time_span / model_time_span
+                            if model_time_span > 0
+                            else 1.0
+                        )
+                        current_lower = float(
+                            mixture_means_constraint.lower_bound
+                        )
+                        current_upper = float("inf")
+                        if lower_active and lower_val is not None:
+                            proposed_upper = freq_scale / lower_val
+                            if proposed_upper > current_lower:
+                                current_upper = proposed_upper
+                        if upper_active and upper_val is not None:
+                            proposed_lower = freq_scale / upper_val
+                            current_lower = max(
+                                current_lower,
+                                proposed_lower,
+                            )
+                        if math.isfinite(current_upper):
+                            mixture_means_constraint = Interval(
+                                current_lower,
+                                current_upper,
+                            )
+                        else:
+                            mixture_means_constraint = GreaterThan(
+                                current_lower
+                            )
 
-            register_constraint_preserving_value(
-                self._model_pars["mixture_means"]["module"],
-                "raw_mixture_means",
-                mixture_means_constraint,
-            )
+                register_constraint_preserving_value(
+                    covar_module,
+                    "raw_mixture_means",
+                    mixture_means_constraint,
+                )
 
-        # to-do - check if constraints on mixture scales are useful!
         self.__CONTRAINTS_SET = True
 
     def get_constraints(self):
@@ -7999,58 +8038,12 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         for key in hypers:
             # first, check if the parameter needs to be transformed:
             if any(p in key for p in pars_to_transform["x"]):
-                # now apply the x transform
-                # remember that the means and scales are in fourier space
-                # so we need to transform them back to real space
-                # before applying the transform
-                # and then transform them back to fourier space
-                # luckily, when the shift is removed from the transform,
-                # the factors of 2pi cancel out for the scales
-                # so we can just do 1/ for both means and scales
                 if self.xtransform is not None:
                     if debug:
-                        print(f"Applying x-transform to {key}")
-                    # Check if the parameter is 2D (for multi-dimensional data)
-                    if hypers[key].dim() == 2:
-                        # For 2D hyperparameters (num_mixtures, ard_num_dims),
-                        # the transform should be applied considering each
-                        # dimension's range. Since transform was fit on
-                        # (n_samples, 2) data, we need to handle this
-                        # carefully
-                        _num_mixtures, ard_num_dims = hypers[key].shape
-                        transformed = torch.zeros_like(hypers[key])
-
-                        # For each dimension of the 2D parameter
-                        for dim in range(ard_num_dims):
-                            # Get the range for this dimension from the
-                            # fitted transformer
-                            if (
-                                hasattr(self.xtransform, "range")
-                                and self.xtransform.range.shape[0] > dim
-                            ):
-                                # Apply dimension-specific scaling to the
-                                # Fourier space parameters
-                                # Formula: f_transformed = 1 / ((1 / f_raw)
-                                # / range)
-                                # This accounts for the data transformation
-                                # applied to each dimension
-                                # The 1/x transformations handle the Fourier
-                                # space representation
-                                dim_values = hypers[key][:, dim]
-                                # Transform back to real space, apply
-                                # scaling, then back to Fourier
-                                transformed[:, dim] = 1 / (
-                                    (1 / dim_values) / self.xtransform.range[0, dim]
-                                )
-                            else:
-                                # Fallback: just copy the values
-                                transformed[:, dim] = hypers[key][:, dim]
-                        hypers[key] = transformed
-                    else:
-                        # 1D case - original behavior
-                        hypers[key] = 1 / self.xtransform.transform(
-                            1 / hypers[key], shift=False
-                        )
+                        print(f"Applying dimension-aware x-transform to {key}")
+                    hypers[key] = self._transform_frequency_like_to_model(
+                        hypers[key]
+                    )
             elif any(p in key for p in pars_to_transform["y"]):
                 # now apply the y transform
                 # the mean function and noise are not defined in fourier
@@ -8060,14 +8053,10 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                         print(f"Applying y-transform to {key}")
                     hypers[key] = self.ytransform.transform(hypers[key])
         # GPyTorch validates constrained parameters when initialize() is called.
-        # The only known problematic path here is the 2D spectral-mixture
-        # initialiser, which builds a [num_mixtures, ard_num_dims] tensor whose
-        # temporal column is scientifically meaningful while the wavelength
-        # column is a placeholder.  GPyTorch applies the same scalar constraint
-        # element-wise to both columns, so only that multi-dimensional placeholder
-        # path should be clamped.  Do not clamp ordinary 1D MLS frequencies here:
-        # that silently changes the user/MLS-specified ordering and breaks the
-        # long-standing 1D initialisation contract.
+        # Clamp only multi-dimensional spectral-mixture means here. Their
+        # tensor-valued constraint broadcasts across mixture components while
+        # preserving distinct temporal and wavelength bounds. Ordinary 1D MLS
+        # frequencies retain their long-standing initialization contract.
         for key, value in list(hypers.items()):
             if "mixture_means" not in key:
                 continue
@@ -10129,6 +10118,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
 
         wavelength_diagnostics = None
         wavelength_mean_diagnostics = None
+        spectral_mixture_ard_diagnostics = None
         band_diagnostics = {}
         if self.ndim > 1:
             uncertainty_values = None
@@ -10184,6 +10174,27 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 metadata=mean_metadata,
             )
 
+            covar_module = getattr(
+                getattr(self, "model", None),
+                "covar_module",
+                None,
+            )
+            mixture_means = getattr(covar_module, "mixture_means", None)
+            if (
+                mixture_means is not None
+                and getattr(covar_module, "ard_num_dims", 1) == 2
+            ):
+                spectral_mixture_ard_diagnostics = (
+                    build_dimension_aware_sm_ard_estimates(
+                        raw_inputs=input_values,
+                        model_inputs=(
+                            self._xdata_transformed.detach().cpu().numpy()
+                        ),
+                        num_mixtures=int(mixture_means.shape[0]),
+                        wavelength_diagnostics=wavelength_diagnostics,
+                    )
+                )
+
         if finite_flux_values.size == 0:
             global_diagnostics = LightcurveDiagnostics(
                 baseline_duration=baseline_duration,
@@ -10212,6 +10223,9 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             band_diagnostics=band_diagnostics,
             wavelength_diagnostics=wavelength_diagnostics,
             wavelength_mean_diagnostics=wavelength_mean_diagnostics,
+            spectral_mixture_ard_diagnostics=(
+                spectral_mixture_ard_diagnostics
+            ),
         )
 
     def _apply_parameter_workflow_estimates(self):
@@ -10222,6 +10236,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             return None
 
         context = self._build_parameter_estimation_context()
+        self._parameter_estimation_context = context
 
         self.parameter_workflow_result = build_and_apply_parameter_estimates(
             model=self.model,
@@ -10324,6 +10339,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 "constraint_action",
                 "wavelength_estimate_provenance",
                 "wavelength_mean_estimate_provenance",
+                "spectral_mixture_ard_provenance",
             ):
                 if optional_key in info:
                     entry[optional_key] = copy.deepcopy(info[optional_key])
@@ -10333,11 +10349,18 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             else:
                 skipped.append(entry)
 
-        return {
+        report = {
             "available": True,
             "applied": applied,
             "skipped": skipped,
         }
+        if hasattr(self, "_spectral_mixture_ard_constraint_provenance"):
+            report["spectral_mixture_ard_constraint_provenance"] = (
+                copy.deepcopy(
+                    self._spectral_mixture_ard_constraint_provenance
+                )
+            )
+        return report
 
     def fit(self, *args, **kwargs):
         """Fit wrapper that records lightweight in-memory fit history."""
@@ -10628,10 +10651,10 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             frequencies.  Set to ``False`` to disable this behaviour and, for
             models that call it, fall back to GPyTorch's
             ``initialize_from_data``.  Note that several 2D spectral-mixture
-            models do not currently call ``initialize_from_data`` at all, so
-            for those models MLS-based or period-based frequency seeding is
-            not applied and the underlying GPyTorch defaults are used
-            instead.
+            models do not call ``initialize_from_data``.  Their full 2D
+            spectral-mixture tensors instead receive dimension-aware values
+            from the parameter workflow, with optional best-band temporal
+            replacement when requested.
         use_best_band_init : bool, optional
             If ``True`` and the lightcurve is multiband (``ndim > 1``) and
             ``use_mls_init=True`` and ``periods`` is ``None``, a 1D
@@ -10639,11 +10662,10 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             spectral-mixture frequency initialisation instead of the
             standard multiband LS.  For 2D spectral-mixture models
             (``ard_num_dims == 2``, non-SKI), the fitted temporal
-            frequencies are also used to initialise the temporal dimension
-            of the kernel mixture means, with the minimum wavelength
-            frequency (1/wavelength_span) as the default for the
-            wavelength dimension, corresponding to approximately achromatic
-            variability.  This can improve convergence for sources with a
+            frequencies are used to replace only ARD index 0 of the kernel
+            mixture means.  ARD index 1 retains its independently
+            wavelength-derived initialization.  This can improve convergence
+            for sources with a
             large dynamic range in the number of observations across bands.
             Has no effect for 1D lightcurves or when ``use_mls_init=False``.
         use_parameter_workflow : bool, optional
@@ -11214,60 +11236,27 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             and hasattr(self.model.covar_module, "mixture_means")
             and getattr(self.model.covar_module, "ard_num_dims", 1) == 2
         ):
-            # For 2D SM models: initialise the temporal dimension (dim 0)
-            # from the best-band 1D LS frequencies and use the minimum
-            # wavelength frequency (1/wavelength_span) as a placeholder for
-            # the wavelength dimension (dim 1), which encodes approximately
-            # achromatic variability.  This avoids leaving all mixture means
-            # at GPyTorch defaults while still seeding the most informative
-            # (temporal) dimension from the best-sampled band.
-            _bands_raw = self._xdata_raw[:, 1]
-            _wl_span = float(_bands_raw.max() - _bands_raw.min())
-            _default_wl_freq = 1.0 / _wl_span if _wl_span > 0 else 1e-6
+            # Build the raw-coordinate ARD tensor independently. Replace only
+            # index 0 with best-band temporal frequencies; index 1 retains the
+            # wavelength-derived initialization and is transformed with its own
+            # coordinate scale by set_hypers().
             _n_mix = len(_init_freqs)
-            # Build a [num_mixtures, 2] tensor: col 0 = temporal frequencies
-            # from the best-band LS, col 1 = default wavelength frequency.
-            # Using new_full preserves device and dtype of _init_freqs.
-            _init_freqs_2d = torch.stack(
-                [
-                    _init_freqs,
-                    _init_freqs.new_full((_n_mix,), _default_wl_freq),
-                ],
-                dim=1,  # shape: [num_mixtures, 2]
+            _context = self._build_parameter_estimation_context()
+            _ard_diagnostics = build_dimension_aware_sm_ard_estimates(
+                raw_inputs=self._xdata_raw.detach().cpu().numpy(),
+                model_inputs=self._xdata_transformed.detach().cpu().numpy(),
+                num_mixtures=_n_mix,
+                wavelength_diagnostics=_context.wavelength_diagnostics,
             )
-            # The mixture_means constraint is derived from the temporal
-            # dimension and is applied element-wise to all entries,
-            # including the wavelength dimension.  The wavelength
-            # frequency (1/wavelength_span) may fall below the
-            # temporal-based lower bound, causing a RuntimeError.
-            # Clamp to the constraint bounds only when xtransform is None
-            # (i.e. raw and transformed spaces are identical).  When an
-            # xtransform is active, _init_freqs_2d is still in raw units
-            # but the constraint bounds are in transformed space; clamping
-            # in the wrong space could create new out-of-bounds values
-            # after set_hypers() applies the transform, so we skip
-            # clamping and let set_hypers() handle the transform instead.
-            if self.xtransform is None:
-                _mixture_means_constraint = getattr(
-                    self.model.covar_module,
-                    "raw_mixture_means_constraint",
-                    None,
-                )
-                if _mixture_means_constraint is not None and hasattr(
-                    _mixture_means_constraint, "lower_bound"
-                ):
-                    _clamp_lower = float(
-                        _mixture_means_constraint.lower_bound
-                    )
-                    _clamp_upper = (
-                        float(_mixture_means_constraint.upper_bound)
-                        if hasattr(_mixture_means_constraint, "upper_bound")
-                        else float("inf")
-                    )
-                    _init_freqs_2d = _init_freqs_2d.clamp(
-                        min=_clamp_lower, max=_clamp_upper
-                    )
-            _hypers_to_set["covar_module.mixture_means"] = _init_freqs_2d
+            _raw_means = torch.as_tensor(
+                _ard_diagnostics["raw_coordinate"]["mixture_means"][
+                    "initial_value"
+                ],
+                dtype=_init_freqs.dtype,
+                device=_init_freqs.device,
+            )
+            _raw_means[:, 0, 0] = _init_freqs.reshape(-1)
+            _hypers_to_set["covar_module.mixture_means"] = _raw_means
         if guess is not None:
             _hypers_to_set.update(guess)
         if _hypers_to_set:
@@ -11589,6 +11578,192 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             raise exc
         return mode, keys
 
+    @staticmethod
+    def _consensus_temporal_bound_value(bound):
+        """Return the temporal (ARD index 0) value from a constraint bound."""
+        tensor = torch.as_tensor(bound)
+        if tensor.numel() == 0:
+            raise ValueError("Constraint bound is empty.")
+        if tensor.numel() == 1:
+            return float(tensor.reshape(-1)[0])
+        if tensor.ndim == 0:
+            return float(tensor)
+        temporal = tensor[..., 0].reshape(-1)
+        reference = temporal[0]
+        if not torch.allclose(temporal, reference.expand_as(temporal)):
+            raise ValueError(
+                "Temporal constraint bounds differ across broadcast entries."
+            )
+        return float(reference)
+
+    def _consensus_apply_temporal_sm_constraint(
+        self,
+        parameter_key,
+        lower,
+        upper,
+    ):
+        """Intersect a consensus interval with only ARD index 0.
+
+        The supplied bounds are expressed in raw temporal-frequency units.
+        They are converted to the fitted temporal coordinate before
+        registration.  For the full two-dimensional spectral-mixture kernel,
+        all wavelength-coordinate bounds (ARD index 1) are retained exactly.
+        """
+        model_pars = getattr(self, "_model_pars", None)
+        if not isinstance(model_pars, dict) or parameter_key not in model_pars:
+            raise ConsensusFitError(
+                "Consensus temporal constraint application failed: parameter "
+                f"{parameter_key!r} is unavailable."
+            )
+        metadata = model_pars[parameter_key]
+        if not isinstance(metadata, dict) or metadata.get("module") is None:
+            raise ConsensusFitError(
+                "Consensus temporal constraint application failed: parameter "
+                f"metadata for {parameter_key!r} has no target module."
+            )
+
+        module = metadata["module"]
+        parameter_name = parameter_key.split(".")[-1].removeprefix("raw_")
+        raw_name = f"raw_{parameter_name}"
+        current_value = getattr(module, parameter_name, None)
+        if current_value is None or not torch.is_tensor(current_value):
+            raise ConsensusFitError(
+                "Consensus temporal constraint application failed: constrained "
+                f"parameter {parameter_name!r} is unavailable on "
+                f"{module.__class__.__name__}."
+            )
+        existing = getattr(module, f"{raw_name}_constraint", None)
+        if existing is None:
+            raise ConsensusFitError(
+                "Consensus temporal constraint application failed: no existing "
+                f"constraint is registered for {parameter_key!r}."
+            )
+
+        raw_lower = float(lower)
+        raw_upper = float(upper)
+        if not (
+            math.isfinite(raw_lower)
+            and math.isfinite(raw_upper)
+            and raw_lower < raw_upper
+        ):
+            raise ConsensusFitError(
+                "Consensus temporal constraint application failed: proposed "
+                f"bounds [{raw_lower}, {raw_upper}] are invalid."
+            )
+
+        proposed_lower = self._transform_frequency_like_to_model(raw_lower).to(
+            dtype=current_value.dtype,
+            device=current_value.device,
+        )
+        proposed_upper = self._transform_frequency_like_to_model(raw_upper).to(
+            dtype=current_value.dtype,
+            device=current_value.device,
+        )
+        if proposed_lower.numel() != 1 or proposed_upper.numel() != 1:
+            raise ConsensusFitError(
+                "Consensus temporal constraint application failed: temporal "
+                "frequency conversion did not produce scalar bounds."
+            )
+        proposed_lower = proposed_lower.reshape(())
+        proposed_upper = proposed_upper.reshape(())
+
+        existing_lower, existing_upper = get_bounds(existing)
+        ard_dims = int(current_value.shape[-1]) if current_value.ndim else 1
+        bound_shape = (1,) * max(current_value.ndim - 1, 0) + (ard_dims,)
+        try:
+            lower_tensor = torch.broadcast_to(
+                torch.as_tensor(
+                    existing_lower,
+                    dtype=current_value.dtype,
+                    device=current_value.device,
+                ),
+                bound_shape,
+            ).clone()
+            upper_tensor = torch.broadcast_to(
+                torch.as_tensor(
+                    existing_upper,
+                    dtype=current_value.dtype,
+                    device=current_value.device,
+                ),
+                bound_shape,
+            ).clone()
+        except RuntimeError as exc:
+            raise ConsensusFitError(
+                "Consensus temporal constraint application failed: existing "
+                f"bounds for {parameter_key!r} cannot broadcast to ARD shape "
+                f"{bound_shape}."
+            ) from exc
+
+        wavelength_lower_before = (
+            lower_tensor[..., 1:].clone() if ard_dims > 1 else None
+        )
+        wavelength_upper_before = (
+            upper_tensor[..., 1:].clone() if ard_dims > 1 else None
+        )
+        effective_lower = torch.maximum(lower_tensor[..., 0], proposed_lower)
+        effective_upper = torch.minimum(upper_tensor[..., 0], proposed_upper)
+        if not torch.all(effective_lower < effective_upper):
+            raise ConsensusFitError(
+                "Consensus temporal constraint application failed: the "
+                "consensus interval does not overlap the existing temporal "
+                f"bounds for {parameter_key!r}. raw_proposed_bounds="
+                f"[{raw_lower:.6g}, {raw_upper:.6g}], model_proposed_bounds="
+                f"[{float(proposed_lower):.6g}, {float(proposed_upper):.6g}]."
+            )
+
+        lower_tensor[..., 0] = effective_lower
+        upper_tensor[..., 0] = effective_upper
+        final_constraint = make_interval_constraint(lower_tensor, upper_tensor)
+        register_constraint_preserving_value(module, raw_name, final_constraint)
+
+        wavelength_preserved = None
+        if ard_dims > 1:
+            wavelength_preserved = bool(
+                torch.equal(lower_tensor[..., 1:], wavelength_lower_before)
+                and torch.equal(upper_tensor[..., 1:], wavelength_upper_before)
+            )
+            if not wavelength_preserved:
+                raise ConsensusFitError(
+                    "Consensus temporal constraint application modified the "
+                    f"wavelength ARD bounds for {parameter_key!r}."
+                )
+
+        return self._consensus_make_json_safe(
+            {
+                "parameter": parameter_key,
+                "ard_scope": "temporal_only",
+                "coordinate_order": [
+                    "temporal_frequency",
+                    "wavelength_frequency",
+                ][:ard_dims],
+                "raw_proposed_bounds": [raw_lower, raw_upper],
+                "model_proposed_bounds": [proposed_lower, proposed_upper],
+                "existing_bounds": {
+                    "lower": torch.broadcast_to(
+                        torch.as_tensor(
+                            existing_lower,
+                            dtype=current_value.dtype,
+                            device=current_value.device,
+                        ),
+                        bound_shape,
+                    ),
+                    "upper": torch.broadcast_to(
+                        torch.as_tensor(
+                            existing_upper,
+                            dtype=current_value.dtype,
+                            device=current_value.device,
+                        ),
+                        bound_shape,
+                    ),
+                },
+                "effective_bounds": {
+                    "lower": lower_tensor,
+                    "upper": upper_tensor,
+                },
+                "wavelength_bounds_preserved": wavelength_preserved,
+            }
+        )
+
     def _consensus_validate_applied_sm_constraints(
         self, keys, consensus_frequencies, frequency_bounds
     ):
@@ -11711,7 +11886,10 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 f"got={_freqs_arr.tolist()}, mixture_means_key={_mm_key!r}, "
                 f"expected_frequency_bounds={frequency_bounds}."
             )
-        _target_freq = float(np.median(_freqs_arr))
+        _target_freq_raw = float(np.median(_freqs_arr))
+        _target_freq = float(
+            self._transform_frequency_like_to_model(_target_freq_raw)
+        )
         try:
             import math as _math
             _lower_raw = getattr(_found, "lower_bound", None)
@@ -11725,8 +11903,8 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                     f"expected_frequency_bounds={frequency_bounds}, "
                     f"consensus_frequency={_target_freq:.6g}."
                 )
-            _upper = float(_upper_raw)
-            _lower = float(_lower_raw)
+            _upper = self._consensus_temporal_bound_value(_upper_raw)
+            _lower = self._consensus_temporal_bound_value(_lower_raw)
             if _math.isinf(_upper):
                 raise ConsensusFitError(
                     "Consensus constraint validation failed: the registered "
@@ -11799,7 +11977,13 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         if _lower is None or _upper is None:
             return None
 
-        return [float(_lower), float(_upper)]
+        try:
+            return [
+                self._consensus_temporal_bound_value(_lower),
+                self._consensus_temporal_bound_value(_upper),
+            ]
+        except (TypeError, ValueError):
+            return None
 
 
     def _consensus_get_registered_period_constraint_bounds(self, keys):
@@ -12074,11 +12258,45 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 f"{int(expected_num_mixtures)})."
             )
 
+        def merge_temporal_values(parameter_key, temporal_values):
+            metadata = getattr(self, "_model_pars", {}).get(parameter_key, {})
+            module = metadata.get("module") if isinstance(metadata, dict) else None
+            parameter_name = parameter_key.split(".")[-1]
+            current = (
+                getattr(module, parameter_name, None)
+                if module is not None
+                else None
+            )
+            if current is None or not torch.is_tensor(current):
+                return temporal_values
+
+            component_values = temporal_values.reshape(-1)
+            if current.ndim < 3 or current.shape[-2] != 1:
+                return temporal_values
+            if current.shape[-3] != component_values.numel():
+                raise ValueError(
+                    "Consensus initialization component count does not match "
+                    f"the fitted parameter shape for {parameter_key!r}: "
+                    f"{component_values.numel()} != {current.shape[-3]}."
+                )
+
+            merged = current.detach().clone()
+            target = merged[..., :, 0, 0]
+            reshape = (1,) * (target.ndim - 1) + (component_values.numel(),)
+            target.copy_(component_values.reshape(reshape).expand_as(target))
+            return merged
+
         guess = {
-            keys["mixture_means"]: init["mixture_means"],
+            keys["mixture_means"]: merge_temporal_values(
+                keys["mixture_means"],
+                init["mixture_means"],
+            ),
         }
         if init["mixture_scales"] is not None:
-            guess[keys["mixture_scales"]] = init["mixture_scales"]
+            guess[keys["mixture_scales"]] = merge_temporal_values(
+                keys["mixture_scales"],
+                init["mixture_scales"],
+            )
 
         return guess
 
@@ -13767,13 +13985,16 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             )
 
         # --- 1. Required top-level keys must all be present ---
-        _pr55_optional_top_level_keys = {
+        _compat_optional_top_level_keys = {
             "consensus_time_kernel_constraint_mode",
             "consensus_period_constraint_bounds",
             "consensus_period_constraint_bounds_final",
+            "consensus_constraint_ard_scope",
+            "consensus_wavelength_constraint_preserved",
+            "consensus_sm_constraint_provenance",
         }
         missing_keys = _CONSENSUS_REQUIRED_RESULT_KEYS - (
-            set(diagnostics.keys()) | _pr55_optional_top_level_keys
+            set(diagnostics.keys()) | _compat_optional_top_level_keys
         )
         if missing_keys:
             raise RuntimeError(
@@ -17727,6 +17948,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
 
         if apply_consensus_constraints:
             _constraint_dict = {}
+            _sm_constraint_provenance = {}
             # --- Step 1: apply default/LPV constraints as a base first -------
             # This ensures any constraint_set period bounds are registered
             # before the consensus constraints override the time-kernel target.
@@ -17771,11 +17993,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 _global_lower = float(_lowers.min())
                 _global_upper = float(_uppers.max())
                 _frequency_constraint_bounds = (_global_lower, _global_upper)
-                if _constraint_mode == "spectral_mixture":
-                    _constraint_dict[_keys["mixture_means"]] = Interval(
-                        _global_lower, _global_upper
-                    )
-                elif _constraint_mode == "period_length":
+                if _constraint_mode == "period_length":
                     _period_constraint_bounds = (
                         self._consensus_frequency_bounds_to_period_bounds(
                             _frequency_constraint_bounds
@@ -17798,14 +18016,28 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                     consensus_scale_width_factor=consensus_scale_width_factor,
                 )
                 _scale_upper = float(_scale_info["upper"])
-                # Practical lower bound - scales must be positive.
-                _constraint_dict[_keys["mixture_scales"]] = Interval(
-                    _CONSENSUS_MIN_SCALE_BOUND, _scale_upper
-                )
             # --- Step 3: apply consensus constraints on top of defaults ------
-            # These must win over the defaults applied in step 1.
+            # Period-kernel constraints use the ordinary scalar path. For
+            # spectral-mixture kernels, update only temporal ARD index 0 and
+            # retain the wavelength bounds installed by the defaults.
             if _constraint_dict:
                 self.set_constraint(_constraint_dict)
+            if _constraint_mode == "spectral_mixture":
+                if _frequency_constraint_bounds is not None:
+                    _sm_constraint_provenance["mixture_means"] = (
+                        self._consensus_apply_temporal_sm_constraint(
+                            _keys["mixture_means"],
+                            *_frequency_constraint_bounds,
+                        )
+                    )
+                if _scale_upper is not None:
+                    _sm_constraint_provenance["mixture_scales"] = (
+                        self._consensus_apply_temporal_sm_constraint(
+                            _keys["mixture_scales"],
+                            _CONSENSUS_MIN_SCALE_BOUND,
+                            _scale_upper,
+                        )
+                    )
             # --- Step 4: mark constraints as set so _fit_core skips defaults -
             # set_default_constraints already set this flag in step 1, but we
             # re-assert it here to make the intent explicit and guard against
@@ -17844,6 +18076,24 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 if _constraint_mode == "spectral_mixture"
                 else _keys.get("period_length")
             )
+            result_diagnostics["consensus_constraint_ard_scope"] = (
+                "temporal_only"
+                if _constraint_mode == "spectral_mixture"
+                else "period_parameter"
+            )
+            result_diagnostics["consensus_sm_constraint_provenance"] = (
+                _sm_constraint_provenance
+                if _constraint_mode == "spectral_mixture"
+                else {}
+            )
+            _preservation_flags = [
+                item.get("wavelength_bounds_preserved")
+                for item in _sm_constraint_provenance.values()
+                if item.get("wavelength_bounds_preserved") is not None
+            ]
+            result_diagnostics["consensus_wavelength_constraint_preserved"] = (
+                all(_preservation_flags) if _preservation_flags else None
+            )
             result_diagnostics["consensus_scale_constraint_bounds"] = (
                 [float(_CONSENSUS_MIN_SCALE_BOUND), float(_scale_upper)]
                 if _scale_upper is not None
@@ -17881,6 +18131,9 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 False
             )
             result_diagnostics["constraints_marked_set_after_consensus"] = False
+            result_diagnostics["consensus_constraint_ard_scope"] = None
+            result_diagnostics["consensus_wavelength_constraint_preserved"] = None
+            result_diagnostics["consensus_sm_constraint_provenance"] = {}
 
 
         if (
@@ -18459,7 +18712,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 model_name=_requested_model,
                 time_kernel_type=fit_kwargs.get("time_kernel_type"),
             )
-            _constraint_dict = {}
+            _sm_constraint_provenance = {}
             _keys = self._consensus_resolve_time_spectral_mixture_keys()
             _constraint_set_for_defaults = fit_kwargs.get("constraint_set")
             self.set_default_constraints(
@@ -18480,10 +18733,6 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             _global_lower = float(_lowers.min())
             _global_upper = float(_uppers.max())
             _frequency_constraint_bounds = (_global_lower, _global_upper)
-            _constraint_dict[_keys["mixture_means"]] = Interval(
-                _global_lower,
-                _global_upper,
-            )
 
             _scale_info = self._consensus_resolve_scale_constraint_upper(
                 _freqs,
@@ -18492,11 +18741,19 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 consensus_scale_width_factor=consensus_scale_width_factor,
             )
             _scale_upper = float(_scale_info["upper"])
-            _constraint_dict[_keys["mixture_scales"]] = Interval(
-                _CONSENSUS_MIN_SCALE_BOUND,
-                _scale_upper,
+            _sm_constraint_provenance["mixture_means"] = (
+                self._consensus_apply_temporal_sm_constraint(
+                    _keys["mixture_means"],
+                    *_frequency_constraint_bounds,
+                )
             )
-            self.set_constraint(_constraint_dict)
+            _sm_constraint_provenance["mixture_scales"] = (
+                self._consensus_apply_temporal_sm_constraint(
+                    _keys["mixture_scales"],
+                    _CONSENSUS_MIN_SCALE_BOUND,
+                    _scale_upper,
+                )
+            )
             self.__CONTRAINTS_SET = True
             result_diagnostics[
                 "constraints_marked_set_after_consensus"
@@ -18512,6 +18769,18 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             )
             result_diagnostics["consensus_constraint_target_key"] = (
                 _keys.get("mixture_means")
+            )
+            result_diagnostics["consensus_constraint_ard_scope"] = "temporal_only"
+            result_diagnostics["consensus_sm_constraint_provenance"] = (
+                _sm_constraint_provenance
+            )
+            _preservation_flags = [
+                item.get("wavelength_bounds_preserved")
+                for item in _sm_constraint_provenance.values()
+                if item.get("wavelength_bounds_preserved") is not None
+            ]
+            result_diagnostics["consensus_wavelength_constraint_preserved"] = (
+                all(_preservation_flags) if _preservation_flags else None
             )
             result_diagnostics["consensus_scale_constraint_bounds"] = [
                 float(_CONSENSUS_MIN_SCALE_BOUND),
@@ -18550,6 +18819,9 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 False
             )
             result_diagnostics["constraints_marked_set_after_consensus"] = False
+            result_diagnostics["consensus_constraint_ard_scope"] = None
+            result_diagnostics["consensus_wavelength_constraint_preserved"] = None
+            result_diagnostics["consensus_sm_constraint_provenance"] = {}
 
         consensus_guess = self._consensus_build_guess(
             frequencies=consensus_frequencies,

--- a/pgmuvi/parameter_application.py
+++ b/pgmuvi/parameter_application.py
@@ -19,8 +19,10 @@ from pgmuvi.parameter_specs import ConstraintStrategy
 from pgmuvi.parameter_specs import GuessStrategy
 from pgmuvi.parameter_specs import ParameterScale
 import math
-import torch
+
 import gpytorch
+import numpy as np
+import torch
 
 
 class ParameterEstimateApplicator:
@@ -112,6 +114,23 @@ class ParameterEstimateApplicator:
                     "diagnostics": self._to_python(estimate.diagnostics),
                 }
 
+            if self._is_dimension_aware_sm_ard_estimate(estimate):
+                result["spectral_mixture_ard_provenance"] = {
+                    "value_source": estimate.value_source,
+                    "constraint_source": estimate.constraint_source,
+                    "estimated_value": self._to_python(estimate.value),
+                    "estimated_constraint": self._to_python(
+                        estimate.constraint
+                    ),
+                    "effective_constraint": self._to_python(
+                        self._effective_constraint_bounds(
+                            target_module,
+                            parameter_name,
+                        )
+                    ),
+                    "diagnostics": self._to_python(estimate.diagnostics),
+                }
+
             results[estimate.name] = result
 
         return results
@@ -132,6 +151,16 @@ class ParameterEstimateApplicator:
             estimate.spec.guess_strategy is GuessStrategy.WAVELENGTH_MEAN
             or estimate.spec.constraint_strategy
             is ConstraintStrategy.WAVELENGTH_MEAN
+        )
+
+    @staticmethod
+    def _is_dimension_aware_sm_ard_estimate(estimate) -> bool:
+        """Return whether an estimate separates the two SM ARD coordinates."""
+        return (
+            estimate.spec.guess_strategy
+            is GuessStrategy.DIMENSION_AWARE_SM_ARD
+            or estimate.spec.constraint_strategy
+            is ConstraintStrategy.DIMENSION_AWARE_SM_ARD
         )
 
     @staticmethod
@@ -159,6 +188,12 @@ class ParameterEstimateApplicator:
             if detached.numel() == 1:
                 return float(detached.item())
             return detached.tolist()
+        if isinstance(value, np.ndarray):
+            if value.size == 1:
+                return float(value.reshape(-1)[0])
+            return value.tolist()
+        if isinstance(value, np.generic):
+            return value.item()
         if isinstance(value, (bool, int, float, str)):
             return value
         return str(value)
@@ -338,6 +373,7 @@ class ParameterEstimateApplicator:
                     ConstraintStrategy.DEFAULT,
                     ConstraintStrategy.WAVELENGTH_RANGE,
                     ConstraintStrategy.WAVELENGTH_MEAN,
+                    ConstraintStrategy.DIMENSION_AWARE_SM_ARD,
                 }
                 and existing_constraint is not None
             ):

--- a/pgmuvi/parameter_builders.py
+++ b/pgmuvi/parameter_builders.py
@@ -159,6 +159,80 @@ class ParameterEstimateBuilder:
                 }
 
         if (
+            spec.guess_strategy is GuessStrategy.DIMENSION_AWARE_SM_ARD
+            or spec.constraint_strategy
+            is ConstraintStrategy.DIMENSION_AWARE_SM_ARD
+        ):
+            ard_diagnostics = context.spectral_mixture_ard_diagnostics
+            if ard_diagnostics is not None:
+                parameter_name = spec.metadata.get(
+                    "spectral_mixture_ard_parameter",
+                    spec.name.split(".")[-1],
+                )
+                model_record = ard_diagnostics.get(
+                    "model_coordinate", {}
+                ).get(parameter_name, {})
+                raw_record = ard_diagnostics.get(
+                    "raw_coordinate", {}
+                ).get(parameter_name, {})
+                diagnostics = {
+                    "schema_version": ard_diagnostics.get("schema_version"),
+                    "parameterization": ard_diagnostics.get(
+                        "parameterization"
+                    ),
+                    "parameter": parameter_name,
+                    "coordinate_order": ard_diagnostics.get(
+                        "coordinate_order"
+                    ),
+                    "ard_index": ard_diagnostics.get("ard_index"),
+                    "num_mixtures": ard_diagnostics.get("num_mixtures"),
+                    "constraint_shape": ard_diagnostics.get(
+                        "constraint_shape"
+                    ),
+                    "value_shape": ard_diagnostics.get("value_shape"),
+                    "raw_initial_value": raw_record.get("initial_value"),
+                    "raw_constraint_lower": raw_record.get(
+                        "constraint_lower"
+                    ),
+                    "raw_constraint_upper": raw_record.get(
+                        "constraint_upper"
+                    ),
+                    "model_initial_value": model_record.get(
+                        "initial_value"
+                    ),
+                    "model_constraint_lower": model_record.get(
+                        "constraint_lower"
+                    ),
+                    "model_constraint_upper": model_record.get(
+                        "constraint_upper"
+                    ),
+                    "raw_sampling": ard_diagnostics.get(
+                        "raw_coordinate", {}
+                    ).get("sampling"),
+                    "model_sampling": ard_diagnostics.get(
+                        "model_coordinate", {}
+                    ).get("sampling"),
+                    "temporal_initialization": model_record.get(
+                        "temporal_initialization"
+                    ),
+                    "wavelength_initialization": model_record.get(
+                        "wavelength_initialization"
+                    ),
+                    "wavelength_lengthscale_initial": model_record.get(
+                        "wavelength_lengthscale_initial"
+                    ),
+                    "wavelength_lengthscale_bounds": model_record.get(
+                        "wavelength_lengthscale_bounds"
+                    ),
+                    "wavelength_lengthscale_source": model_record.get(
+                        "wavelength_lengthscale_source"
+                    ),
+                    "lengthscale_to_spectral_scale": model_record.get(
+                        "lengthscale_to_spectral_scale"
+                    ),
+                }
+
+        if (
             spec.guess_strategy is GuessStrategy.WAVELENGTH_MEAN
             or spec.constraint_strategy is ConstraintStrategy.WAVELENGTH_MEAN
         ):
@@ -235,6 +309,14 @@ class ParameterEstimateBuilder:
                 return "global_diagnostics_unavailable"
 
             return "robust_flux_span_unavailable"
+
+        if spec.guess_strategy is GuessStrategy.DIMENSION_AWARE_SM_ARD:
+            diagnostics = context.spectral_mixture_ard_diagnostics
+            if diagnostics is None:
+                return "spectral_mixture_ard_diagnostics_unavailable"
+            if not diagnostics.get("available", False):
+                return "spectral_mixture_ard_estimate_unavailable"
+            return "spectral_mixture_ard_parameter_unavailable"
 
         if spec.guess_strategy is GuessStrategy.WAVELENGTH_MEAN:
             diagnostics = context.wavelength_mean_diagnostics
@@ -337,6 +419,9 @@ class ParameterEstimateBuilder:
 
         if spec.guess_strategy is GuessStrategy.CONSENSUS_MULTICOMP_PERIOD:
             return self._estimate_consensus_multicomp_period(spec, context)
+
+        if spec.guess_strategy is GuessStrategy.DIMENSION_AWARE_SM_ARD:
+            return self._estimate_dimension_aware_sm_ard_value(spec, context)
 
         if spec.guess_strategy is GuessStrategy.WAVELENGTH_RANGE:
             return self._estimate_wavelength_range_value(spec, context)
@@ -491,6 +576,15 @@ class ParameterEstimateBuilder:
         if spec.constraint_strategy is ConstraintStrategy.ROBUST_POSITIVE_FLUX_SPAN:
             return self._estimate_robust_positive_flux_span_constraint(context)
 
+        if (
+            spec.constraint_strategy
+            is ConstraintStrategy.DIMENSION_AWARE_SM_ARD
+        ):
+            return self._estimate_dimension_aware_sm_ard_constraint(
+                spec,
+                context,
+            )
+
         if spec.constraint_strategy is ConstraintStrategy.WAVELENGTH_RANGE:
             return self._estimate_wavelength_range_constraint(spec, context)
 
@@ -498,6 +592,55 @@ class ParameterEstimateBuilder:
             return self._estimate_wavelength_mean_constraint(spec, context)
 
         return None
+
+    @staticmethod
+    def _dimension_aware_sm_ard_record(
+        spec: ParameterSpec,
+        context: ParameterEstimationContext,
+    ):
+        diagnostics = context.spectral_mixture_ard_diagnostics
+        if diagnostics is None or not diagnostics.get("available", False):
+            return None
+        parameter_name = spec.metadata.get(
+            "spectral_mixture_ard_parameter",
+            spec.name.split(".")[-1],
+        )
+        return diagnostics.get("model_coordinate", {}).get(parameter_name)
+
+    def _estimate_dimension_aware_sm_ard_value(
+        self,
+        spec: ParameterSpec,
+        context: ParameterEstimationContext,
+    ):
+        record = self._dimension_aware_sm_ard_record(spec, context)
+        if not record:
+            return None
+        value = record.get("initial_value")
+        if value is None:
+            return None
+        value_tensor = torch.as_tensor(value, dtype=DEFAULT_DTYPE)
+        if spec.shape is not None and tuple(value_tensor.shape) != tuple(spec.shape):
+            if value_tensor.numel() != math.prod(spec.shape):
+                return None
+            value_tensor = value_tensor.reshape(spec.shape)
+        return value_tensor
+
+    def _estimate_dimension_aware_sm_ard_constraint(
+        self,
+        spec: ParameterSpec,
+        context: ParameterEstimationContext,
+    ):
+        record = self._dimension_aware_sm_ard_record(spec, context)
+        if not record:
+            return None
+        lower = record.get("constraint_lower")
+        upper = record.get("constraint_upper")
+        if lower is None or upper is None:
+            return None
+        return (
+            torch.as_tensor(lower, dtype=DEFAULT_DTYPE),
+            torch.as_tensor(upper, dtype=DEFAULT_DTYPE),
+        )
 
     @staticmethod
     def _wavelength_mean_record(

--- a/pgmuvi/parameter_context.py
+++ b/pgmuvi/parameter_context.py
@@ -162,6 +162,7 @@ class ParameterEstimationContext:
     consensus_diagnostics: ConsensusDiagnostics | None = None
     wavelength_diagnostics: WavelengthEstimationDiagnostics | None = None
     wavelength_mean_diagnostics: WavelengthMeanEstimationDiagnostics | None = None
+    spectral_mixture_ard_diagnostics: dict[str, Any] | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
 
     def bands(self) -> list[str]:

--- a/pgmuvi/parameter_specs.py
+++ b/pgmuvi/parameter_specs.py
@@ -71,6 +71,7 @@ class GuessStrategy(str, Enum):
 
     WAVELENGTH_RANGE = "wavelength_range"
     WAVELENGTH_MEAN = "wavelength_mean"
+    DIMENSION_AWARE_SM_ARD = "dimension_aware_sm_ard"
 
     CUSTOM = "custom"
 
@@ -98,6 +99,7 @@ class ConstraintStrategy(str, Enum):
 
     WAVELENGTH_RANGE = "wavelength_range"
     WAVELENGTH_MEAN = "wavelength_mean"
+    DIMENSION_AWARE_SM_ARD = "dimension_aware_sm_ard"
 
     CUSTOM = "custom"
 

--- a/pgmuvi/spectral_mixture_ard.py
+++ b/pgmuvi/spectral_mixture_ard.py
@@ -1,0 +1,363 @@
+"""Dimension-aware estimates for two-dimensional spectral-mixture kernels.
+
+The full non-separable ``2D`` model stores temporal-frequency and
+wavelength-frequency parameters in the last axis of the same GPyTorch tensor.
+This module derives separate values and bounds for those coordinates while
+retaining the native :class:`gpytorch.kernels.SpectralMixtureKernel`
+parameterization.  Bounds have shape ``(1, 1, 2)`` and therefore broadcast over
+mixture components without collapsing the two ARD dimensions to one scalar
+interval.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import numpy as np
+
+
+SPECTRAL_MIXTURE_ARD_SCHEMA_VERSION = "pgmuvi-spectral-mixture-ard-v1"
+ARD_COORDINATE_ORDER = (
+    "temporal_frequency",
+    "wavelength_frequency",
+)
+
+
+def _as_two_dimensional_array(values: Any, *, name: str) -> np.ndarray:
+    array = np.asarray(values, dtype=float)
+    if array.ndim != 2 or array.shape[1] < 2:
+        raise ValueError(f"{name} must have shape (n_observations, >=2).")
+    if array.shape[0] == 0:
+        raise ValueError(f"{name} must contain at least one observation.")
+    return array[:, :2]
+
+
+def _sampling_summary(values: np.ndarray) -> dict[str, Any]:
+    finite = np.asarray(values, dtype=float)
+    finite = finite[np.isfinite(finite)]
+    unique = np.unique(finite)
+    unique.sort()
+
+    summary: dict[str, Any] = {
+        "n_finite": int(finite.size),
+        "n_unique": int(unique.size),
+        "minimum": None,
+        "maximum": None,
+        "span": None,
+        "minimum_positive_spacing": None,
+        "median_positive_spacing": None,
+    }
+    if unique.size == 0:
+        return summary
+
+    summary["minimum"] = float(unique[0])
+    summary["maximum"] = float(unique[-1])
+    if unique.size == 1:
+        summary["span"] = 0.0
+        return summary
+
+    span = float(unique[-1] - unique[0])
+    positive = np.diff(unique)
+    positive = positive[np.isfinite(positive) & (positive > 0)]
+    summary["span"] = span
+    if positive.size:
+        summary["minimum_positive_spacing"] = float(np.min(positive))
+        summary["median_positive_spacing"] = float(np.median(positive))
+    return summary
+
+
+def _safe_frequency_bounds(summary: dict[str, Any]) -> tuple[float, float]:
+    span = summary.get("span")
+    minimum_spacing = summary.get("minimum_positive_spacing")
+    if span is None or not math.isfinite(span) or span <= 0:
+        raise ValueError("A positive coordinate span is required.")
+
+    lower = 1.0 / span
+    upper = None
+    if (
+        minimum_spacing is not None
+        and math.isfinite(minimum_spacing)
+        and minimum_spacing > 0
+    ):
+        upper = 1.0 / (2.0 * minimum_spacing)
+
+    # Two unique samples have a nominal Nyquist frequency below 1/span.  The
+    # interval still needs to be valid, so retain an explicit conservative cap.
+    if upper is None or not math.isfinite(upper) or upper <= lower:
+        upper = 2.0 * lower
+    return float(lower), float(upper)
+
+
+def _trend_requires_nonzero_wavelength_frequency(
+    wavelength_diagnostics: Any | None,
+) -> bool:
+    if wavelength_diagnostics is None:
+        return False
+    for name in (
+        "median_flux_monotonicity_class",
+        "amplitude_monotonicity_class",
+        "scatter_monotonicity_class",
+    ):
+        if getattr(wavelength_diagnostics, name, None) == "non_monotonic":
+            return True
+    return False
+
+
+def _lengthscale_recommendation(
+    wavelength_diagnostics: Any | None,
+    *,
+    coordinate: str,
+    sampling: dict[str, Any],
+) -> tuple[float, tuple[float, float], str]:
+    if coordinate not in {"raw", "model"}:
+        raise ValueError("coordinate must be 'raw' or 'model'.")
+
+    if wavelength_diagnostics is not None:
+        if coordinate == "raw":
+            initial = getattr(
+                wavelength_diagnostics,
+                "recommended_lengthscale_initial",
+                None,
+            )
+            bounds = getattr(
+                wavelength_diagnostics,
+                "recommended_lengthscale_bounds",
+                None,
+            )
+        else:
+            initial = getattr(
+                wavelength_diagnostics,
+                "model_recommended_lengthscale_initial",
+                None,
+            )
+            bounds = getattr(
+                wavelength_diagnostics,
+                "model_recommended_lengthscale_bounds",
+                None,
+            )
+        if initial is not None and bounds is not None:
+            lower, upper = (float(bounds[0]), float(bounds[1]))
+            initial = float(initial)
+            if (
+                math.isfinite(initial)
+                and math.isfinite(lower)
+                and math.isfinite(upper)
+                and 0 < lower < upper
+            ):
+                return (
+                    min(max(initial, lower), upper),
+                    (lower, upper),
+                    "wavelength_estimation_context",
+                )
+
+    span = sampling.get("span")
+    spacing = sampling.get("minimum_positive_spacing")
+    if span is None or not math.isfinite(span) or span <= 0:
+        # A single wavelength carries no resolved wavelength-covariance scale.
+        # Keep a broad, explicit fallback for backward compatibility, and mark
+        # it as degenerate in provenance rather than calling it data resolved.
+        return 1.0, (1.0e-3, 1.0e3), "single_wavelength_degenerate_fallback"
+
+    if spacing is None or not math.isfinite(spacing) or spacing <= 0:
+        spacing = span
+    lower = max(0.5 * spacing, 0.01 * span, 1.0e-12)
+    upper = max(5.0 * span, 2.0 * lower)
+    initial = math.sqrt(lower * upper)
+    return initial, (lower, upper), "sampling_only_fallback"
+
+
+def _spectral_scale_from_lengthscale(lengthscale: float) -> float:
+    return 1.0 / (2.0 * math.pi * lengthscale)
+
+
+def _coordinate_estimates(
+    inputs: np.ndarray,
+    *,
+    num_mixtures: int,
+    wavelength_diagnostics: Any | None,
+    coordinate: str,
+) -> dict[str, Any]:
+    time_sampling = _sampling_summary(inputs[:, 0])
+    wavelength_sampling = _sampling_summary(inputs[:, 1])
+
+    temporal_lower, temporal_upper = _safe_frequency_bounds(time_sampling)
+    temporal_values = np.asarray(
+        [
+            min(
+                max(temporal_lower * (index + 1), temporal_lower),
+                0.95 * temporal_upper,
+            )
+            for index in range(num_mixtures)
+        ],
+        dtype=float,
+    )
+
+    wavelength_span = wavelength_sampling.get("span")
+    if (
+        wavelength_span is None
+        or not math.isfinite(wavelength_span)
+        or wavelength_span <= 0
+    ):
+        wavelength_mean_lower = 1.0e-6
+        wavelength_mean_upper = 1.0e3
+        wavelength_mean_initial = 1.0e-3
+        wavelength_mean_method = "single_wavelength_degenerate_fallback"
+    else:
+        wavelength_mean_lower = max(0.05 / wavelength_span, 1.0e-12)
+        minimum_spacing = wavelength_sampling.get("minimum_positive_spacing")
+        if (
+            minimum_spacing is None
+            or not math.isfinite(minimum_spacing)
+            or minimum_spacing <= 0
+        ):
+            minimum_spacing = wavelength_span
+        wavelength_mean_upper = 1.0 / (2.0 * minimum_spacing)
+        if wavelength_mean_upper <= wavelength_mean_lower:
+            wavelength_mean_upper = 2.0 * wavelength_mean_lower
+        wavelength_mean_initial = (
+            1.0 / wavelength_span
+            if _trend_requires_nonzero_wavelength_frequency(
+                wavelength_diagnostics
+            )
+            else 0.1 / wavelength_span
+        )
+        wavelength_mean_initial = min(
+            max(wavelength_mean_initial, wavelength_mean_lower),
+            0.95 * wavelength_mean_upper,
+        )
+        wavelength_mean_method = (
+            "non_monotonic_wavelength_structure"
+            if _trend_requires_nonzero_wavelength_frequency(
+                wavelength_diagnostics
+            )
+            else "smooth_or_unresolved_wavelength_structure"
+        )
+
+    lengthscale_initial, lengthscale_bounds, lengthscale_source = (
+        _lengthscale_recommendation(
+            wavelength_diagnostics,
+            coordinate=coordinate,
+            sampling=wavelength_sampling,
+        )
+    )
+    lengthscale_lower, lengthscale_upper = lengthscale_bounds
+    wavelength_scale_initial = _spectral_scale_from_lengthscale(
+        lengthscale_initial
+    )
+    wavelength_scale_lower = _spectral_scale_from_lengthscale(
+        lengthscale_upper
+    )
+    wavelength_scale_upper = _spectral_scale_from_lengthscale(
+        lengthscale_lower
+    )
+
+    temporal_scale_initial = _spectral_scale_from_lengthscale(
+        float(time_sampling["span"])
+    )
+    temporal_scale_lower = max(0.01 * temporal_scale_initial, 1.0e-12)
+    temporal_scale_upper = max(
+        temporal_upper,
+        100.0 * temporal_scale_initial,
+        2.0 * temporal_scale_lower,
+    )
+
+    means = np.zeros((num_mixtures, 1, 2), dtype=float)
+    means[:, 0, 0] = temporal_values
+    means[:, 0, 1] = wavelength_mean_initial
+
+    scales = np.zeros((num_mixtures, 1, 2), dtype=float)
+    scales[:, 0, 0] = temporal_scale_initial
+    scales[:, 0, 1] = wavelength_scale_initial
+
+    return {
+        "sampling": {
+            "time": time_sampling,
+            "wavelength": wavelength_sampling,
+        },
+        "mixture_means": {
+            "initial_value": means.tolist(),
+            "constraint_lower": [
+                [[temporal_lower, wavelength_mean_lower]]
+            ],
+            "constraint_upper": [
+                [[temporal_upper, wavelength_mean_upper]]
+            ],
+            "temporal_initialization": "baseline_frequency_sequence",
+            "wavelength_initialization": wavelength_mean_method,
+        },
+        "mixture_scales": {
+            "initial_value": scales.tolist(),
+            "constraint_lower": [
+                [[temporal_scale_lower, wavelength_scale_lower]]
+            ],
+            "constraint_upper": [
+                [[temporal_scale_upper, wavelength_scale_upper]]
+            ],
+            "temporal_initialization": "inverse_time_span_spectral_scale",
+            "wavelength_initialization": (
+                "inverse_recommended_wavelength_lengthscale"
+            ),
+            "wavelength_lengthscale_initial": lengthscale_initial,
+            "wavelength_lengthscale_bounds": list(lengthscale_bounds),
+            "wavelength_lengthscale_source": lengthscale_source,
+            "lengthscale_to_spectral_scale": "1/(2*pi*lengthscale)",
+        },
+    }
+
+
+def build_dimension_aware_sm_ard_estimates(
+    *,
+    raw_inputs: Any,
+    model_inputs: Any,
+    num_mixtures: int,
+    wavelength_diagnostics: Any | None = None,
+) -> dict[str, Any]:
+    """Build separate temporal and wavelength SM values and bounds.
+
+    Parameters are returned in both raw-input and fitted-model coordinates.
+    Model-coordinate arrays are the values consumed by the parameter workflow;
+    raw arrays are retained solely as provenance and for raw-space
+    initialization helpers.
+    """
+    if not isinstance(num_mixtures, int) or num_mixtures < 1:
+        raise ValueError("num_mixtures must be a positive integer.")
+
+    raw = _as_two_dimensional_array(raw_inputs, name="raw_inputs")
+    model = _as_two_dimensional_array(model_inputs, name="model_inputs")
+    if raw.shape[0] != model.shape[0]:
+        raise ValueError("raw_inputs and model_inputs must have equal row counts.")
+
+    raw_records = _coordinate_estimates(
+        raw,
+        num_mixtures=num_mixtures,
+        wavelength_diagnostics=wavelength_diagnostics,
+        coordinate="raw",
+    )
+    model_records = _coordinate_estimates(
+        model,
+        num_mixtures=num_mixtures,
+        wavelength_diagnostics=wavelength_diagnostics,
+        coordinate="model",
+    )
+
+    return {
+        "schema_version": SPECTRAL_MIXTURE_ARD_SCHEMA_VERSION,
+        "available": True,
+        "parameterization": "broadcast_tensor_intervals",
+        "coordinate_order": list(ARD_COORDINATE_ORDER),
+        "ard_index": {
+            "temporal_frequency": 0,
+            "wavelength_frequency": 1,
+        },
+        "num_mixtures": num_mixtures,
+        "constraint_shape": [1, 1, 2],
+        "value_shape": [num_mixtures, 1, 2],
+        "raw_coordinate": raw_records,
+        "model_coordinate": model_records,
+        "wavelength_diagnostics_schema_version": getattr(
+            wavelength_diagnostics,
+            "schema_version",
+            None,
+        ),
+    }

--- a/tests/test_consensus_multicomp_fit.py
+++ b/tests/test_consensus_multicomp_fit.py
@@ -565,8 +565,13 @@ class TestConsensusMulticompFit(unittest.TestCase):
             return_value=None,
         ), mock.patch.object(
             self.lc,
-            "set_constraint",
-            return_value=None,
+            "_consensus_apply_temporal_sm_constraint",
+            side_effect=lambda key, lower, upper: {
+                "parameter": key,
+                "ard_scope": "temporal_only",
+                "raw_proposed_bounds": [lower, upper],
+                "wavelength_bounds_preserved": True,
+            },
         ), mock.patch.object(
             self.lc,
             "_consensus_validate_applied_sm_constraints",
@@ -598,6 +603,15 @@ class TestConsensusMulticompFit(unittest.TestCase):
         self.assertEqual(
             diagnostics["constraint_strategy"],
             "global_frequency_interval",
+        )
+        self.assertEqual(
+            diagnostics["consensus_constraint_ard_scope"],
+            "temporal_only",
+        )
+        self.assertTrue(diagnostics["consensus_wavelength_constraint_preserved"])
+        self.assertEqual(
+            set(diagnostics["consensus_sm_constraint_provenance"]),
+            {"mixture_means", "mixture_scales"},
         )
         self.assertAlmostEqual(diagnostics["consensus_constraint_bounds"][0], 0.71)
         self.assertAlmostEqual(diagnostics["consensus_constraint_bounds"][1], 3.59)

--- a/tests/test_consensus_scientific_regression.py
+++ b/tests/test_consensus_scientific_regression.py
@@ -844,6 +844,9 @@ class TestConsensusConstraintHandoff(unittest.TestCase):
             "consensus_constraint_target_key",
             "consensus_scale_constraint_bounds",
             "consensus_scale_constraint_target_key",
+            "consensus_constraint_ard_scope",
+            "consensus_wavelength_constraint_preserved",
+            "consensus_sm_constraint_provenance",
             "default_constraints_applied_before_consensus",
             "constraints_marked_set_after_consensus",
         ]
@@ -853,6 +856,12 @@ class TestConsensusConstraintHandoff(unittest.TestCase):
                 diag,
                 f"consensus_diagnostics must contain field {field!r}",
             )
+        self.assertEqual(diag["consensus_constraint_ard_scope"], "temporal_only")
+        self.assertTrue(diag["consensus_wavelength_constraint_preserved"])
+        self.assertEqual(
+            set(diag["consensus_sm_constraint_provenance"]),
+            {"mixture_means", "mixture_scales"},
+        )
 
     def test_second_fit_matches_first_fit_constraints(self):
         """Second fit must not produce different constraints than first fit.

--- a/tests/test_docs_spectral_mixture_ard.py
+++ b/tests/test_docs_spectral_mixture_ard.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class TestSpectralMixtureArdDocumentation(unittest.TestCase):
+    def test_api_reference_includes_module(self):
+        api = (ROOT / "docs/source/api.rst").read_text()
+        self.assertIn("pgmuvi.spectral_mixture_ard", api)
+        self.assertTrue(
+            (ROOT / "docs/source/pgmuvi.spectral_mixture_ard.rst").exists()
+        )
+
+    def test_module_page_documents_coordinate_order(self):
+        text = (
+            ROOT / "docs/source/pgmuvi.spectral_mixture_ard.rst"
+        ).read_text()
+        normalized = " ".join(text.split())
+        self.assertIn("index 0: temporal frequency", normalized)
+        self.assertIn("index 1: wavelength frequency", normalized)
+        self.assertIn("(1, 1, 2)", normalized)
+
+    def test_constraint_guide_documents_tensor_intervals(self):
+        text = (
+            ROOT / "docs/source/howto/priors_constraints.rst"
+        ).read_text()
+        normalized = " ".join(text.split())
+        self.assertIn("broadcast across components", normalized)
+        self.assertIn("Source-type period limits modify only the temporal entry", normalized)
+        self.assertIn("Consensus fitting also respects this separation", normalized)
+        self.assertIn("wavelength-frequency bounds at ARD index 1 remain unchanged", normalized)
+
+    def test_consensus_guide_documents_temporal_only_interval(self):
+        text = (ROOT / "docs/source/howto/consensus_fitting.rst").read_text()
+        normalized = " ".join(text.split())
+        self.assertIn("temporal-frequency** interval", normalized)
+        self.assertIn("updates only ARD index 0", normalized)
+        self.assertIn("wavelength-frequency bounds at ARD index 1 are preserved", normalized)
+
+    def test_future_work_keeps_saturation_validation_scope(self):
+        text = (ROOT / "docs/source/future_work.rst").read_text()
+        normalized = " ".join(text.split())
+        self.assertIn("component/dimension saturation", normalized)
+        self.assertIn("scientifically long wavelength correlation scale", normalized)
+        self.assertIn("TBD[wavelength-constraint-validation]", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_spectral_mixture_ard.py
+++ b/tests/test_spectral_mixture_ard.py
@@ -1,0 +1,158 @@
+import math
+import unittest
+
+import numpy as np
+
+from pgmuvi.parameter_context import WavelengthEstimationDiagnostics
+from pgmuvi.spectral_mixture_ard import (
+    ARD_COORDINATE_ORDER,
+    SPECTRAL_MIXTURE_ARD_SCHEMA_VERSION,
+    build_dimension_aware_sm_ard_estimates,
+)
+
+
+class TestDimensionAwareSpectralMixtureArd(unittest.TestCase):
+    @staticmethod
+    def _inputs():
+        raw = np.asarray(
+            [
+                [0.0, 1.0],
+                [1.0, 1.0],
+                [2.0, 1.0],
+                [8.0, 1.0],
+                [0.0, 2.0],
+                [1.0, 2.0],
+                [2.0, 2.0],
+                [8.0, 2.0],
+                [0.0, 5.0],
+                [1.0, 5.0],
+                [2.0, 5.0],
+                [8.0, 5.0],
+            ]
+        )
+        model = raw.copy()
+        model[:, 0] /= 8.0
+        model[:, 1] = (model[:, 1] - 1.0) / 4.0
+        return raw, model
+
+    def test_schema_and_shapes_are_explicit(self):
+        raw, model = self._inputs()
+        result = build_dimension_aware_sm_ard_estimates(
+            raw_inputs=raw,
+            model_inputs=model,
+            num_mixtures=3,
+        )
+
+        self.assertEqual(
+            result["schema_version"],
+            SPECTRAL_MIXTURE_ARD_SCHEMA_VERSION,
+        )
+        self.assertEqual(result["coordinate_order"], list(ARD_COORDINATE_ORDER))
+        self.assertEqual(result["ard_index"]["temporal_frequency"], 0)
+        self.assertEqual(result["ard_index"]["wavelength_frequency"], 1)
+        self.assertEqual(result["constraint_shape"], [1, 1, 2])
+        self.assertEqual(result["value_shape"], [3, 1, 2])
+        self.assertEqual(
+            np.asarray(
+                result["model_coordinate"]["mixture_means"]["initial_value"]
+            ).shape,
+            (3, 1, 2),
+        )
+
+    def test_time_and_wavelength_bounds_are_independent(self):
+        raw, model = self._inputs()
+        result = build_dimension_aware_sm_ard_estimates(
+            raw_inputs=raw,
+            model_inputs=model,
+            num_mixtures=2,
+        )
+        means = result["model_coordinate"]["mixture_means"]
+        scales = result["model_coordinate"]["mixture_scales"]
+
+        self.assertNotEqual(
+            means["constraint_lower"][0][0][0],
+            means["constraint_lower"][0][0][1],
+        )
+        self.assertNotEqual(
+            scales["constraint_upper"][0][0][0],
+            scales["constraint_upper"][0][0][1],
+        )
+        self.assertEqual(means["temporal_initialization"], "baseline_frequency_sequence")
+
+    def test_raw_and_model_coordinates_are_recorded_separately(self):
+        raw, model = self._inputs()
+        result = build_dimension_aware_sm_ard_estimates(
+            raw_inputs=raw,
+            model_inputs=model,
+            num_mixtures=1,
+        )
+        raw_lower = result["raw_coordinate"]["mixture_means"][
+            "constraint_lower"
+        ][0][0]
+        model_lower = result["model_coordinate"]["mixture_means"][
+            "constraint_lower"
+        ][0][0]
+
+        self.assertAlmostEqual(model_lower[0], 8.0 * raw_lower[0])
+        self.assertAlmostEqual(model_lower[1], 4.0 * raw_lower[1])
+
+    def test_wavelength_lengthscale_drives_wavelength_scale_only(self):
+        raw, model = self._inputs()
+        diagnostics = WavelengthEstimationDiagnostics(
+            available=True,
+            recommended_lengthscale_initial=2.0,
+            recommended_lengthscale_bounds=(0.5, 8.0),
+            model_recommended_lengthscale_initial=0.5,
+            model_recommended_lengthscale_bounds=(0.125, 2.0),
+        )
+        result = build_dimension_aware_sm_ard_estimates(
+            raw_inputs=raw,
+            model_inputs=model,
+            num_mixtures=1,
+            wavelength_diagnostics=diagnostics,
+        )
+        raw_scale = result["raw_coordinate"]["mixture_scales"]
+        model_scale = result["model_coordinate"]["mixture_scales"]
+
+        self.assertAlmostEqual(
+            raw_scale["initial_value"][0][0][1],
+            1.0 / (2.0 * math.pi * 2.0),
+        )
+        self.assertAlmostEqual(
+            model_scale["initial_value"][0][0][1],
+            1.0 / (2.0 * math.pi * 0.5),
+        )
+        self.assertEqual(
+            model_scale["wavelength_lengthscale_source"],
+            "wavelength_estimation_context",
+        )
+
+    def test_single_wavelength_is_explicit_degenerate_fallback(self):
+        raw, model = self._inputs()
+        raw[:, 1] = 2.0
+        model[:, 1] = 0.0
+        result = build_dimension_aware_sm_ard_estimates(
+            raw_inputs=raw,
+            model_inputs=model,
+            num_mixtures=1,
+        )
+
+        scales = result["model_coordinate"]["mixture_scales"]
+        self.assertEqual(
+            scales["wavelength_lengthscale_source"],
+            "single_wavelength_degenerate_fallback",
+        )
+        self.assertGreater(scales["constraint_upper"][0][0][1], 0.0)
+
+    def test_rejects_invalid_component_count(self):
+        raw, model = self._inputs()
+        with self.assertRaisesRegex(ValueError, "positive integer"):
+            build_dimension_aware_sm_ard_estimates(
+                raw_inputs=raw,
+                model_inputs=model,
+                num_mixtures=0,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_spectral_mixture_ard_parameter_workflow.py
+++ b/tests/test_spectral_mixture_ard_parameter_workflow.py
@@ -1,0 +1,267 @@
+import unittest
+
+import gpytorch
+import torch
+
+from pgmuvi.gps import spectral_mixture_parameter_schema
+from pgmuvi.lightcurve import Lightcurve
+from pgmuvi.parameter_specs import ConstraintStrategy, GuessStrategy
+
+
+class TestSpectralMixtureArdParameterWorkflow(unittest.TestCase):
+    @staticmethod
+    def _lightcurve(*, xtransform=None):
+        rows = []
+        fluxes = []
+        for wavelength in (1.0, 2.0, 5.0):
+            for time in (0.0, 1.0, 2.0, 100.0):
+                rows.append([time, wavelength])
+                fluxes.append(wavelength + 0.01 * time)
+        kwargs = {"center_time": False} if xtransform is None else {}
+        return Lightcurve(
+            torch.tensor(rows),
+            torch.tensor(fluxes),
+            xtransform=xtransform,
+            **kwargs,
+        )
+
+    def test_2d_schema_uses_dimension_aware_strategy(self):
+        schema = spectral_mixture_parameter_schema(
+            num_mixtures=2,
+            ard_num_dims=2,
+        )
+        for name in ("covar_module.mixture_means", "covar_module.mixture_scales"):
+            spec = schema[name]
+            self.assertIs(
+                spec.guess_strategy,
+                GuessStrategy.DIMENSION_AWARE_SM_ARD,
+            )
+            self.assertIs(
+                spec.constraint_strategy,
+                ConstraintStrategy.DIMENSION_AWARE_SM_ARD,
+            )
+            self.assertEqual(spec.metadata["coordinate_order"][0], "temporal_frequency")
+            self.assertEqual(spec.metadata["coordinate_order"][1], "wavelength_frequency")
+
+    def test_1d_schema_keeps_legacy_strategies(self):
+        schema = spectral_mixture_parameter_schema(
+            num_mixtures=2,
+            ard_num_dims=1,
+        )
+        self.assertIs(
+            schema["covar_module.mixture_means"].guess_strategy,
+            GuessStrategy.CONSENSUS_FREQUENCY,
+        )
+        self.assertIs(
+            schema["covar_module.mixture_scales"].guess_strategy,
+            GuessStrategy.DEFAULT,
+        )
+
+    def test_default_constraints_have_broadcast_ard_shape(self):
+        lc = self._lightcurve()
+        lc.set_model("2D", num_mixtures=2)
+        lc.set_default_constraints()
+
+        means = lc.model.covar_module.raw_mixture_means_constraint
+        scales = lc.model.covar_module.raw_mixture_scales_constraint
+        self.assertIsInstance(means, gpytorch.constraints.Interval)
+        self.assertEqual(tuple(means.lower_bound.shape), (1, 1, 2))
+        self.assertEqual(tuple(scales.lower_bound.shape), (1, 1, 2))
+        self.assertNotEqual(
+            float(means.lower_bound[0, 0, 0]),
+            float(means.lower_bound[0, 0, 1]),
+        )
+        self.assertNotEqual(
+            float(scales.upper_bound[0, 0, 0]),
+            float(scales.upper_bound[0, 0, 1]),
+        )
+
+    def test_default_constraints_do_not_widen_existing_tensor_interval(self):
+        lc = self._lightcurve()
+        lc.set_model("2D", num_mixtures=1)
+        existing = gpytorch.constraints.Interval(
+            torch.tensor([[[0.02, 0.02]]]),
+            torch.tensor([[[0.2, 0.2]]]),
+        )
+        lc.model.covar_module.register_constraint(
+            "raw_mixture_means",
+            existing,
+        )
+        lc.set_default_constraints()
+        effective = lc.model.covar_module.raw_mixture_means_constraint
+
+        self.assertAlmostEqual(
+            float(effective.lower_bound[0, 0, 0]), 0.02, places=6
+        )
+        self.assertAlmostEqual(
+            float(effective.lower_bound[0, 0, 1]), 0.02, places=6
+        )
+        self.assertAlmostEqual(
+            float(effective.upper_bound[0, 0, 0]), 0.2, places=6
+        )
+        self.assertAlmostEqual(
+            float(effective.upper_bound[0, 0, 1]), 0.2, places=6
+        )
+
+    def test_parameter_workflow_applies_values_and_provenance(self):
+        lc = self._lightcurve()
+        lc.set_model("2D", num_mixtures=2)
+        lc.set_default_constraints()
+        result = lc._apply_parameter_workflow_estimates()
+
+        for name in (
+            "covar_module.mixture_means",
+            "covar_module.mixture_scales",
+        ):
+            self.assertTrue(result[name]["value"])
+            self.assertTrue(result[name]["constraint"])
+            provenance = result[name]["spectral_mixture_ard_provenance"]
+            self.assertEqual(
+                provenance["diagnostics"]["coordinate_order"],
+                ["temporal_frequency", "wavelength_frequency"],
+            )
+            self.assertEqual(
+                provenance["diagnostics"]["constraint_shape"],
+                [1, 1, 2],
+            )
+
+        report = lc.get_parameter_workflow_report()
+        report_names = {entry["parameter"]: entry for entry in report["applied"]}
+        self.assertIn(
+            "spectral_mixture_ard_provenance",
+            report_names["covar_module.mixture_means"],
+        )
+        self.assertIn(
+            "spectral_mixture_ard_constraint_provenance",
+            report,
+        )
+
+    def test_lpv_period_limit_changes_only_temporal_mean_upper(self):
+        unconstrained = self._lightcurve()
+        unconstrained.set_model("2D", num_mixtures=1)
+        unconstrained.set_default_constraints()
+        base = unconstrained.model.covar_module.raw_mixture_means_constraint
+
+        constrained = self._lightcurve()
+        constrained.set_model("2D", num_mixtures=1)
+        constrained.set_default_constraints(constraint_set="LPV")
+        lpv = constrained.model.covar_module.raw_mixture_means_constraint
+
+        self.assertLessEqual(
+            float(lpv.upper_bound[0, 0, 0]),
+            float(base.upper_bound[0, 0, 0]),
+        )
+        self.assertEqual(
+            float(lpv.lower_bound[0, 0, 1]),
+            float(base.lower_bound[0, 0, 1]),
+        )
+        self.assertEqual(
+            float(lpv.upper_bound[0, 0, 1]),
+            float(base.upper_bound[0, 0, 1]),
+        )
+
+    def test_minmax_transform_scales_dimensions_independently(self):
+        lc = self._lightcurve(xtransform="minmax")
+        lc.set_model("2D", num_mixtures=1)
+        context = lc._build_parameter_estimation_context()
+        diagnostics = context.spectral_mixture_ard_diagnostics
+        raw_lower = diagnostics["raw_coordinate"]["mixture_means"][
+            "constraint_lower"
+        ][0][0]
+        model_lower = diagnostics["model_coordinate"]["mixture_means"][
+            "constraint_lower"
+        ][0][0]
+
+        self.assertAlmostEqual(model_lower[0], 100.0 * raw_lower[0])
+        self.assertAlmostEqual(model_lower[1], 4.0 * raw_lower[1])
+
+    def test_set_hypers_transforms_last_ard_axis_independently(self):
+        lc = self._lightcurve(xtransform="minmax")
+        lc.set_model("2D", num_mixtures=1)
+        lc.set_default_constraints()
+        raw = torch.tensor([[[0.02, 0.1]]])
+        lc.set_hypers({"covar_module.mixture_means": raw})
+        value = lc.model.covar_module.mixture_means.detach()
+
+        self.assertAlmostEqual(float(value[0, 0, 0]), 2.0, places=5)
+        self.assertAlmostEqual(float(value[0, 0, 1]), 0.4, places=5)
+
+    def test_consensus_updates_only_temporal_ard_bounds(self):
+        lc = self._lightcurve(xtransform="minmax")
+        lc.set_model("2D", num_mixtures=1)
+        lc.set_default_constraints()
+
+        means_before = lc.model.covar_module.raw_mixture_means_constraint
+        scales_before = lc.model.covar_module.raw_mixture_scales_constraint
+        means_wavelength_before = (
+            means_before.lower_bound[..., 1:].clone(),
+            means_before.upper_bound[..., 1:].clone(),
+        )
+        scales_wavelength_before = (
+            scales_before.lower_bound[..., 1:].clone(),
+            scales_before.upper_bound[..., 1:].clone(),
+        )
+
+        means_provenance = lc._consensus_apply_temporal_sm_constraint(
+            "covar_module.mixture_means",
+            0.02,
+            0.1,
+        )
+        scales_provenance = lc._consensus_apply_temporal_sm_constraint(
+            "covar_module.mixture_scales",
+            1.0e-4,
+            0.05,
+        )
+
+        means_after = lc.model.covar_module.raw_mixture_means_constraint
+        scales_after = lc.model.covar_module.raw_mixture_scales_constraint
+        self.assertAlmostEqual(float(means_after.lower_bound[..., 0]), 2.0)
+        self.assertAlmostEqual(float(means_after.upper_bound[..., 0]), 10.0)
+        self.assertAlmostEqual(float(scales_after.lower_bound[..., 0]), 0.01)
+        self.assertAlmostEqual(float(scales_after.upper_bound[..., 0]), 5.0)
+        self.assertTrue(
+            torch.equal(
+                means_after.lower_bound[..., 1:],
+                means_wavelength_before[0],
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                means_after.upper_bound[..., 1:],
+                means_wavelength_before[1],
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                scales_after.lower_bound[..., 1:],
+                scales_wavelength_before[0],
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                scales_after.upper_bound[..., 1:],
+                scales_wavelength_before[1],
+            )
+        )
+        self.assertEqual(means_provenance["ard_scope"], "temporal_only")
+        self.assertTrue(means_provenance["wavelength_bounds_preserved"])
+        self.assertTrue(scales_provenance["wavelength_bounds_preserved"])
+
+    def test_single_wavelength_does_not_reuse_temporal_bound(self):
+        rows = torch.tensor(
+            [[0.0, 2.0], [1.0, 2.0], [2.0, 2.0], [4.0, 2.0]]
+        )
+        lc = Lightcurve(rows, torch.tensor([1.0, 1.1, 0.9, 1.0]), center_time=False)
+        lc.set_model("2D", num_mixtures=1)
+        lc.set_default_constraints()
+        constraint = lc.model.covar_module.raw_mixture_means_constraint
+
+        self.assertEqual(tuple(constraint.lower_bound.shape), (1, 1, 2))
+        self.assertNotEqual(
+            float(constraint.lower_bound[0, 0, 0]),
+            float(constraint.lower_bound[0, 0, 1]),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wavelength_covariance_estimate_application.py
+++ b/tests/test_wavelength_covariance_estimate_application.py
@@ -274,12 +274,23 @@ class TestSeparableWavelengthCovarianceApplication(unittest.TestCase):
         )
         self.assertAlmostEqual(fitted_value, math.sqrt(8.0) / 4.0, places=5)
 
-    def test_full_2d_spectral_mixture_schema_is_not_changed(self):
+    def test_full_2d_uses_dimension_aware_spectral_mixture_strategy(self):
         lc = self._lightcurve()
         lc.set_model("2D", num_mixtures=1)
 
         schema = lc.model.parameter_schema()
+        means = schema["covar_module.mixture_means"]
+        scales = schema["covar_module.mixture_scales"]
 
+        for spec in (means, scales):
+            self.assertIs(
+                spec.guess_strategy,
+                GuessStrategy.DIMENSION_AWARE_SM_ARD,
+            )
+            self.assertIs(
+                spec.constraint_strategy,
+                ConstraintStrategy.DIMENSION_AWARE_SM_ARD,
+            )
         self.assertFalse(
             any(
                 spec.guess_strategy is GuessStrategy.WAVELENGTH_RANGE


### PR DESCRIPTION
## Summary

This PR introduces dimension-aware spectral-mixture ARD handling for the full non-separable `2D` model.

The coordinate convention is:

- ARD index 0: temporal frequency
- ARD index 1: wavelength frequency

Both `mixture_means` and `mixture_scales` now receive independent temporal and wavelength initialization, bounds, transforms, and provenance.

## Tensor-valued constraints

The implementation uses broadcast tensor intervals with shape `(1, 1, 2)` so the temporal and wavelength ARD dimensions can retain distinct lower and upper bounds.

It:

- derives temporal and wavelength limits independently;
- transforms each dimension using its own coordinate scale;
- intersects new intervals with existing tighter constraints;
- preserves constraint-before-value ordering;
- records raw-coordinate and model-coordinate diagnostics.

## Consensus compatibility

Consensus fitting now updates only the temporal ARD dimension.

The standard and multi-component consensus paths preserve:

- wavelength-frequency bounds;
- wavelength-scale bounds;
- wavelength initialization values;
- the two-dimensional tensor shape of the spectral-mixture parameters.

LPV period restrictions continue to apply only to the temporal-frequency dimension.

## Scope boundary

This PR does not:

- change the separable wavelength covariance models handled in PR122;
- change wavelength-dependent mean models handled in PR123;
- alter model ranking or advisory eligibility;
- interpret ARD ceiling saturation scientifically.

Dimension-specific ARD saturation diagnostics and scientific validation remain separate follow-up work.

## Validation

- targeted parameter, consensus, and documentation tests passed;
- CI-equivalent Ruff passed;
- strict Sphinx documentation passed;
- complete unittest suite passed: 2,298 tests.