### PR TITLE
Fix consensus harmonic and transform handoff

### DIFF
--- a/docs/source/howto/consensus_fitting.rst
+++ b/docs/source/howto/consensus_fitting.rst
@@ -148,8 +148,8 @@ Model and kernel roles
    * - ``2DSeparable``
      - Generic direct product-kernel baseline with a Matérn time kernel and RBF
        wavelength kernel by default.
-     - The default model has no spectral-mixture or ``period_length`` handoff;
-       do not use it as the standard consensus path.
+     - Use ``time_kernel_type="quasi_periodic"`` for period-length handoff or
+       ``"spectral_mixture"`` for frequency-space handoff.
    * - ``2DWavelengthDependent``
      - Flexible separable covariance with a smooth wavelength kernel and a
        configurable wavelength-dependent mean.
@@ -164,10 +164,10 @@ Model and kernel roles
      - Same supported consensus time-kernel choices as
        ``2DWavelengthDependent``.
 
-The generic ``2DSeparable`` family is useful as a direct product-kernel control,
-but its convenience interface does not accept ``time_kernel_type`` or
-``wavelength_kernel_type`` selectors.  Use ``2DWavelengthDependent`` when you
-need those string-configurable kernels.
+The generic ``2DSeparable`` family is useful as a direct product-kernel control.
+Its convenience interface accepts the same ``time_kernel_type`` and
+``wavelength_kernel_type`` selectors used by the other separable families while
+retaining a constant mean function.
 
 For a model-by-model explanation of the wavelength means, covariance
 assumptions, coordinate requirements, and try-first ordering, see
@@ -320,7 +320,13 @@ including:
    averaged into a midpoint period supported by neither band.
 
 ``use_acf``
-   Enables the optional ACF contribution to the consensus diagnostics.
+   Enables ACF validation and conservative LS--ACF harmonic reconciliation.
+   Direct agreement retains the Lomb--Scargle peak.  When ACF identifies a
+   longer period related to the LS period by an integer harmonic, consensus
+   promotes the lower ACF frequency as the candidate fundamental and records
+   ``selected_from='acf_fundamental_harmonic_reconciliation'``.  A shorter-period
+   ACF harmonic does not replace the slower LS candidate.  The original LS
+   frequency and period remain available in the per-band diagnostics.
 
 ``constrain_consensus`` and ``consensus_width_factor``
    Control whether and how tightly the final temporal parameters are constrained
@@ -425,6 +431,18 @@ Also inspect:
    print(lc.get_parameter_workflow_summary())
    print(lc.get_fit_history_summary())
    lc.export_fit_history_json("fit_history.json")
+
+Transform isolation during per-band diagnostics
+-----------------------------------------------
+
+Consensus splitting constructs temporary one-dimensional light curves from the
+raw time, flux, and uncertainty arrays.  These diagnostic objects deliberately
+do not inherit the parent light curve's fitted coordinate or flux transforms.
+A two-dimensional affine coordinate transform stores separate state for time
+and wavelength and cannot be applied safely to a one-dimensional time vector.
+Lomb--Scargle, ACF, and sampling diagnostics therefore remain in the original
+physical time units, while the parent multiband light curve keeps its configured
+transform for the final GP fit.
 
 The consensus diagnostics identify accepted and rejected bands, per-band
 periods or frequencies, the consensus estimate, and the parameter target used

--- a/docs/source/pgmuvi.wavelength_validation_recovery.rst
+++ b/docs/source/pgmuvi.wavelength_validation_recovery.rst
@@ -60,9 +60,10 @@ Use ``stop_on_error=True`` only when deliberate fail-fast behavior is required.
 
 The maintained LPV defaults are:
 
-* ``fit_strategy='consensus'`` and ``time_kernel_type='quasi_periodic'`` for
-  ``2DWavelengthDependent``, ``2DDustMean``, ``2DPowerLawMean``, and
-  ``2DSeparable``;
+* ``fit_strategy='consensus'``, ``time_kernel_type='quasi_periodic'``, and
+  ``use_acf=True`` for ``2DWavelengthDependent``, ``2DDustMean``,
+  ``2DPowerLawMean``, and ``2DSeparable`` so nominal D1 runs can reconcile a
+  dominant LS harmonic with a longer ACF-supported fundamental;
 * independent two-dimensional spectral-mixture initialization for ``2D`` with
   one requested component unless overridden by the validation driver;
 * ``learn_additional_noise=True`` and linear-flux fitting.

--- a/pgmuvi/gps.py
+++ b/pgmuvi/gps.py
@@ -2190,11 +2190,30 @@ class SeparableGPModel(ExactGP):
     likelihood : gpytorch.likelihoods.Likelihood
         Likelihood function for the model.
     time_kernel : gpytorch.kernels.Kernel, optional
-        Kernel for the temporal dimension (``active_dims`` will be set to
-        ``[0]`` automatically). Defaults to a scaled Matérn-1.5.
+        Explicit kernel for the temporal dimension (``active_dims`` will be
+        set to ``[0]`` automatically). Mutually exclusive with
+        ``time_kernel_type``.
     wavelength_kernel : gpytorch.kernels.Kernel, optional
-        Kernel for the wavelength dimension (``active_dims`` will be set to
-        ``[1]`` automatically). Defaults to a scaled RBF.
+        Explicit kernel for the wavelength dimension (``active_dims`` will be
+        set to ``[1]`` automatically). Mutually exclusive with
+        ``wavelength_kernel_type``.
+    time_kernel_type : str or gpytorch.kernels.Kernel, optional
+        String-configurable temporal kernel used when ``time_kernel`` is not
+        supplied. Supported values are ``'matern'``, ``'quasi_periodic'``,
+        ``'rbf'``, and ``'spectral_mixture'``/``'sm'``. The default remains a
+        scaled Matérn-1.5 kernel.
+    wavelength_kernel_type : str or gpytorch.kernels.Kernel, optional
+        String-configurable wavelength kernel used when
+        ``wavelength_kernel`` is not supplied. Supported values are ``'rbf'``,
+        ``'matern'``, and ``'rational_quadratic'``/``'rq'``. The default
+        remains a scaled RBF kernel.
+    period : float, optional
+        Initial period for ``time_kernel_type='quasi_periodic'``. Defaults to
+        half the transformed time span.
+    wavelength_lengthscale : float, optional
+        Initial wavelength lengthscale for a string-configured wavelength
+        kernel. Defaults to half the transformed wavelength span, with a
+        minimum of 1.0.
 
     Notes
     -----
@@ -2210,15 +2229,56 @@ class SeparableGPModel(ExactGP):
         time_kernel=None,
         wavelength_kernel=None,
         mean_module=None,
+        time_kernel_type=None,
+        wavelength_kernel_type=None,
+        period=None,
+        wavelength_lengthscale=None,
+        num_mixtures=4,
+        add_flicker=False,
+        wavelength_scaling="constant",
         **kwargs
     ):
         super().__init__(train_x, train_y, likelihood)
         self.mean_module = ConstantMean() if mean_module is None else mean_module
 
+        if time_kernel is not None and time_kernel_type is not None:
+            raise ValueError(
+                "Pass either time_kernel or time_kernel_type, not both."
+            )
+        if wavelength_kernel is not None and wavelength_kernel_type is not None:
+            raise ValueError(
+                "Pass either wavelength_kernel or wavelength_kernel_type, "
+                "not both."
+            )
+
         if time_kernel is None:
-            time_kernel = ScaleKernel(MaternKernel(nu=1.5))
+            if time_kernel_type is None:
+                time_kernel = ScaleKernel(MaternKernel(nu=1.5))
+            else:
+                if period is None:
+                    span = float(train_x[:, 0].max() - train_x[:, 0].min())
+                    period = span / 2.0
+                time_kernel = _build_time_kernel(
+                    time_kernel_type,
+                    period,
+                    num_mixtures,
+                    add_flicker=add_flicker,
+                )
+
         if wavelength_kernel is None:
-            wavelength_kernel = ScaleKernel(RBFKernel())
+            if wavelength_kernel_type is None:
+                wavelength_kernel = ScaleKernel(RBFKernel())
+            else:
+                if wavelength_lengthscale is None:
+                    wl_span = float(
+                        train_x[:, 1].max() - train_x[:, 1].min()
+                    )
+                    wavelength_lengthscale = max(wl_span / 2.0, 1.0)
+                wavelength_kernel = _build_wavelength_kernel(
+                    wavelength_kernel_type,
+                    wavelength_lengthscale,
+                    scaling=wavelength_scaling,
+                )
 
         # Restrict each sub-kernel to its own dimension via active_dims.
         time_kernel.register_buffer(

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -588,6 +588,8 @@ _CONSENSUS_BAND_SCHEMA_FIELDS = MappingProxyType(
         "metrics": _consensus_schema_field(default=None, nullable=True),
         "dominant_frequency": _consensus_schema_field(default=None, nullable=True),
         "dominant_period": _consensus_schema_field(default=None, nullable=True),
+        "ls_frequency": _consensus_schema_field(default=None, nullable=True),
+        "ls_period": _consensus_schema_field(default=None, nullable=True),
         "ls_significant": _consensus_schema_field(default=None, nullable=True),
         "ls_peak_power": _consensus_schema_field(default=None, nullable=True),
         "ls_peak_prominence": _consensus_schema_field(default=None, nullable=True),
@@ -603,6 +605,9 @@ _CONSENSUS_BAND_SCHEMA_FIELDS = MappingProxyType(
         "acf_period_ratio": _consensus_schema_field(default=None, nullable=True),
         "acf_harmonic_order": _consensus_schema_field(default=None, nullable=True),
         "acf_error": _consensus_schema_field(default=None, nullable=True),
+        "harmonic_reconciliation_applied": _consensus_schema_field(
+            default=False, nullable=False
+        ),
         "selected_from": _consensus_schema_field(default=None, nullable=True),
         "gp_validation_used": _consensus_schema_field(default=False, nullable=False),
         "gp_dominant_frequency": _consensus_schema_field(default=None, nullable=True),
@@ -12832,12 +12837,20 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 if hasattr(self, "_yerr_raw") and self._yerr_raw is not None
                 else None
             )
+            # These temporary 1D light curves exist only for per-band
+            # sampling, Lomb--Scargle, and ACF diagnostics.  Do not inherit
+            # the parent transforms: a fitted 2D affine x-transform stores
+            # one offset/scale per coordinate and is therefore incompatible
+            # with the 1D time vector extracted here.  The diagnostics below
+            # operate on raw time/flux values, while the parent multiband
+            # light curve retains its transforms for the final GP fit.
             lc_band = Lightcurve(
                 t,
                 y,
                 yerr=yerr,
-                xtransform=self.xtransform,
-                ytransform=self.ytransform,
+                xtransform=None,
+                ytransform=None,
+                center_time=False,
                 name=self.name,
                 band=np.asarray([band_label], dtype=np.str_),
             )
@@ -13359,6 +13372,56 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             "ratio": float(ratio),
             "harmonic_order": None,
         }
+
+    @staticmethod
+    def _consensus_reconcile_ls_acf_harmonic(
+        *,
+        ls_frequency,
+        acf_frequency,
+        comparison_status,
+        harmonic_order,
+    ):
+        """Choose a conservative effective frequency for an LS--ACF harmonic.
+
+        Direct LS--ACF agreement retains the Lomb--Scargle frequency.  For a
+        recognised harmonic relationship, the lower of the two frequencies is
+        the only candidate that can represent the shared fundamental rather
+        than a higher-order harmonic.  The ACF frequency is therefore promoted
+        only when it is lower than the LS frequency.  An ACF frequency above
+        the LS frequency is retained as diagnostic support but does not replace
+        the slower LS candidate.
+        """
+        ls_value = float(ls_frequency)
+        if not (np.isfinite(ls_value) and ls_value > 0.0):
+            raise ValueError(
+                "ls_frequency must be finite and strictly positive."
+            )
+
+        result = {
+            "frequency": ls_value,
+            "selected_from": "ls_primary_peak",
+            "applied": False,
+        }
+        if comparison_status != _ACF_STATUS_HARMONIC:
+            return result
+
+        try:
+            order_value = int(harmonic_order)
+            acf_value = float(acf_frequency)
+        except (TypeError, ValueError):
+            return result
+        if order_value < 2 or not (
+            np.isfinite(acf_value) and acf_value > 0.0
+        ):
+            return result
+
+        if acf_value < ls_value:
+            return {
+                "frequency": acf_value,
+                "selected_from": "acf_fundamental_harmonic_reconciliation",
+                "applied": True,
+            }
+        return result
 
     @staticmethod
     def _consensus_make_json_safe(value):
@@ -15136,7 +15199,12 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 ),
                 plausible_candidates[0],
             )
-            dominant_freq = float(best_candidate["frequency"])
+            ls_frequency = float(best_candidate["frequency"])
+            ls_period = float(1.0 / ls_frequency)
+            dominant_freq = ls_frequency
+            selected_from = "ls_primary_peak"
+            record["ls_frequency"] = ls_frequency
+            record["ls_period"] = ls_period
 
             # Final plausibility guard: frequency must meet the minimum
             # detectable frequency threshold.
@@ -15190,6 +15258,36 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                         _ACF_STATUS_HARMONIC,
                     )
                 )
+                harmonic_reconciliation = (
+                    self._consensus_reconcile_ls_acf_harmonic(
+                        ls_frequency=ls_frequency,
+                        acf_frequency=record["acf_frequency"],
+                        comparison_status=acf_compare["status"],
+                        harmonic_order=acf_compare["harmonic_order"],
+                    )
+                )
+                reconciled_frequency = float(
+                    harmonic_reconciliation["frequency"]
+                )
+                if (
+                    harmonic_reconciliation["applied"]
+                    and ls_candidates["min_detectable_frequency"] > 0
+                    and reconciled_frequency
+                    < ls_candidates["min_detectable_frequency"]
+                ):
+                    harmonic_reconciliation = {
+                        "frequency": ls_frequency,
+                        "selected_from": (
+                            "ls_primary_peak_acf_fundamental_out_of_range"
+                        ),
+                        "applied": False,
+                    }
+                    reconciled_frequency = ls_frequency
+                dominant_freq = reconciled_frequency
+                selected_from = harmonic_reconciliation["selected_from"]
+                record["harmonic_reconciliation_applied"] = bool(
+                    harmonic_reconciliation["applied"]
+                )
 
                 # ACF is a direct time-domain periodicity diagnostic. Strong
                 # LS-vs-ACF disagreement is treated conservatively as likely
@@ -15207,7 +15305,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             record["dominant_frequency"] = dominant_freq
             record["dominant_period"] = dominant_period
             record["ls_significant"] = bool(best_candidate["significant"])
-            record["selected_from"] = "ls_primary_peak"
+            record["selected_from"] = selected_from
             self._consensus_set_band_status(
                 record,
                 _CONSENSUS_BAND_STATUS_ACCEPTED,
@@ -15231,6 +15329,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                         _msg += (
                             f" acf_status={_record.get('acf_comparison_status')}"
                             f" harmonic_order={_record.get('acf_harmonic_order')}"
+                            f" selected_from={_record.get('selected_from')}"
                         )
                     print(_msg)
                 elif _band in rejection_reasons:

--- a/pgmuvi/wavelength_validation_recovery.py
+++ b/pgmuvi/wavelength_validation_recovery.py
@@ -809,6 +809,7 @@ def _default_fit_configuration(
             {
                 "fit_strategy": "consensus",
                 "time_kernel_type": "quasi_periodic",
+                "use_acf": True,
             }
         )
     configuration.update(dict(overrides or {}))

--- a/tests/test_consensus_band_transform_inheritance.py
+++ b/tests/test_consensus_band_transform_inheritance.py
@@ -1,0 +1,82 @@
+"""Regression tests for consensus per-band transform isolation."""
+
+import unittest
+
+import numpy as np
+import torch
+
+from pgmuvi.lightcurve import Lightcurve, MinMax
+
+
+class TestConsensusBandTransformInheritance(unittest.TestCase):
+    def _make_multiband_lightcurve(self):
+        times = torch.arange(36.0, dtype=torch.float64)
+        time = torch.cat((times, times))
+        wavelength = torch.cat(
+            (
+                torch.full_like(times, 1.25),
+                torch.full_like(times, 3.50),
+            )
+        )
+        xdata = torch.stack((time, wavelength), dim=1)
+        ydata = 20.0 + torch.sin(2.0 * torch.pi * time / 12.0)
+        yerr = torch.full_like(ydata, 0.1)
+        band = np.asarray(["short"] * 36 + ["long"] * 36, dtype=np.str_)
+        return Lightcurve(
+            xdata,
+            ydata,
+            yerr=yerr,
+            band=band,
+            xtransform="minmax",
+            ytransform="minmax",
+        )
+
+    def test_per_band_consensus_lightcurves_do_not_inherit_2d_transform(self):
+        lc = self._make_multiband_lightcurve()
+
+        self.assertIsInstance(lc.xtransform, MinMax)
+        self.assertEqual(tuple(lc.xtransform.min.shape), (1, 2))
+        parent_x_transformed = lc._xdata_transformed.clone()
+        parent_y_transformed = lc._ydata_transformed.clone()
+
+        per_band = dict(lc._consensus_iter_band_lightcurves())
+
+        self.assertEqual(set(per_band), {"short", "long"})
+        for band_lc in per_band.values():
+            self.assertEqual(band_lc.ndim, 1)
+            self.assertIsNone(band_lc.xtransform)
+            self.assertIsNone(band_lc.ytransform)
+            torch.testing.assert_close(
+                band_lc._xdata_transformed,
+                band_lc._xdata_raw,
+            )
+            torch.testing.assert_close(
+                band_lc._ydata_transformed,
+                band_lc._ydata_raw,
+            )
+
+        self.assertIsInstance(lc.xtransform, MinMax)
+        self.assertEqual(tuple(lc.xtransform.min.shape), (1, 2))
+        torch.testing.assert_close(lc._xdata_transformed, parent_x_transformed)
+        torch.testing.assert_close(lc._ydata_transformed, parent_y_transformed)
+
+    def test_per_band_sampling_preparation_accepts_parent_minmax_transform(self):
+        lc = self._make_multiband_lightcurve()
+
+        prepared = lc._consensus_prepare_band_consensus_inputs(
+            min_points_per_band=8,
+            max_gap_fraction=1.0,
+            min_duty_cycle=0.0,
+        )
+
+        self.assertEqual(set(prepared["per_band_lc"]), {"short", "long"})
+        self.assertEqual(
+            prepared["controls"]["min_points_per_band"],
+            8,
+        )
+        for metrics in prepared["metrics_by_band"].values():
+            self.assertEqual(metrics["n_points"], 36)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_consensus_harmonic_reconciliation.py
+++ b/tests/test_consensus_harmonic_reconciliation.py
@@ -1,0 +1,124 @@
+import unittest
+from unittest import mock
+
+import numpy as np
+
+from pgmuvi.lightcurve import Lightcurve
+
+
+class _FakeBandLightcurve:
+    def acf(self, method="data", normalize=True):
+        return {"method": method, "normalize": normalize}
+
+
+class TestConsensusHarmonicReconciliation(unittest.TestCase):
+    def test_lower_acf_frequency_is_promoted_as_fundamental(self):
+        result = Lightcurve._consensus_reconcile_ls_acf_harmonic(
+            ls_frequency=1.0 / 250.0,
+            acf_frequency=1.0 / 500.0,
+            comparison_status="harmonic",
+            harmonic_order=2,
+        )
+
+        self.assertTrue(result["applied"])
+        self.assertAlmostEqual(result["frequency"], 1.0 / 500.0)
+        self.assertEqual(
+            result["selected_from"],
+            "acf_fundamental_harmonic_reconciliation",
+        )
+
+    def test_higher_acf_frequency_does_not_replace_slower_ls_candidate(self):
+        result = Lightcurve._consensus_reconcile_ls_acf_harmonic(
+            ls_frequency=1.0 / 500.0,
+            acf_frequency=1.0 / 250.0,
+            comparison_status="harmonic",
+            harmonic_order=2,
+        )
+
+        self.assertFalse(result["applied"])
+        self.assertAlmostEqual(result["frequency"], 1.0 / 500.0)
+        self.assertEqual(result["selected_from"], "ls_primary_peak")
+
+    def test_direct_agreement_retains_ls_candidate(self):
+        result = Lightcurve._consensus_reconcile_ls_acf_harmonic(
+            ls_frequency=1.0 / 500.0,
+            acf_frequency=1.0 / 510.0,
+            comparison_status="agreement",
+            harmonic_order=1,
+        )
+
+        self.assertFalse(result["applied"])
+        self.assertAlmostEqual(result["frequency"], 1.0 / 500.0)
+
+    def test_collection_preserves_ls_and_promotes_acf_fundamental(self):
+        lightcurve = object.__new__(Lightcurve)
+        controls = {
+            "min_points_per_band": 5,
+            "max_gap_fraction": 0.5,
+            "min_duty_cycle": 0.05,
+            "outlier_sigma": 3.5,
+            "consensus_width_factor": 3.0,
+        }
+        ls_frequency = 1.0 / 250.0
+        acf_frequency = 1.0 / 500.0
+        ls_payload = {
+            "ls_frequencies": np.asarray([ls_frequency], dtype=float),
+            "ls_significant": np.asarray([True], dtype=bool),
+            "candidates": [
+                {
+                    "frequency": ls_frequency,
+                    "period": 250.0,
+                    "ls_rank": 0,
+                    "significant": True,
+                }
+            ],
+            "min_detectable_frequency": 1.0 / 600.0,
+            "nyquist_frequency": 1.0,
+        }
+
+        with mock.patch.object(
+            Lightcurve,
+            "_consensus_prepare_band_consensus_inputs",
+            return_value={
+                "per_band_lc": {"V": _FakeBandLightcurve()},
+                "metrics_by_band": {"V": {"baseline": 1200.0}},
+                "controls": controls,
+            },
+        ), mock.patch.object(
+            Lightcurve,
+            "_consensus_reject_bad_bands",
+            return_value=[],
+        ), mock.patch.object(
+            Lightcurve,
+            "_consensus_extract_band_ls_candidates",
+            return_value=ls_payload,
+        ), mock.patch.object(
+            Lightcurve,
+            "_consensus_extract_acf_candidate",
+            return_value={"frequency": acf_frequency, "period": 500.0},
+        ), mock.patch.object(
+            Lightcurve,
+            "_consensus_debug_checkpoint_from_candidate_state",
+            return_value=None,
+        ):
+            result = lightcurve._consensus_collect_band_candidates(
+                use_acf=True,
+                gp_validation_requested=False,
+            )
+
+        record = result["band_records"]["V"]
+        self.assertEqual(result["accepted_bands"], ["V"])
+        self.assertAlmostEqual(record["ls_frequency"], ls_frequency)
+        self.assertAlmostEqual(record["ls_period"], 250.0)
+        self.assertAlmostEqual(record["acf_frequency"], acf_frequency)
+        self.assertAlmostEqual(record["dominant_frequency"], acf_frequency)
+        self.assertAlmostEqual(record["dominant_period"], 500.0)
+        self.assertTrue(record["harmonic_reconciliation_applied"])
+        self.assertEqual(
+            record["selected_from"],
+            "acf_fundamental_harmonic_reconciliation",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_consensus_period_kernel_handoff.py
+++ b/tests/test_consensus_period_kernel_handoff.py
@@ -40,6 +40,7 @@ def _make_lpv_like_lc():
 class TestConsensusPeriodKernelHandoff(unittest.TestCase):
     def test_quasi_periodic_lpv_models_resolve_period_length_mode(self):
         for model_name in (
+            "2DSeparable",
             "2DWavelengthDependent",
             "2DDustMean",
             "2DPowerLawMean",

--- a/tests/test_wavelength_validation_recovery.py
+++ b/tests/test_wavelength_validation_recovery.py
@@ -390,6 +390,7 @@ class TestSyntheticRecoveryRun(RecoveryCaseMixin, unittest.TestCase):
         self.assertEqual(
             seen["fit_kwargs"]["time_kernel_type"], "quasi_periodic"
         )
+        self.assertTrue(seen["fit_kwargs"]["use_acf"])
         self.assertEqual(run.status.technical_outcome, TechnicalOutcome.COMPLETED)
 
     def test_2d_defaults_preserve_independent_ard_initialization(self):


### PR DESCRIPTION
## Summary

- prevent temporary one-dimensional consensus band light curves from inheriting fitted two-dimensional coordinate transforms
- enable configurable time and wavelength kernel selectors for `2DSeparable`
- preserve explicitly supplied kernel objects
- reconcile Lomb–Scargle harmonic peaks with longer-period ACF fundamentals when supported by an integer harmonic relationship
- retain original Lomb–Scargle candidate provenance
- enable ACF-assisted consensus for nominal synthetic recovery runs
- add regression coverage for transform inheritance, quasi-periodic period handoff, harmonic reconciliation, and recovery behavior

## Defects exposed by D1 validation

The real synthetic recovery smoke test exposed three independent defects:

1. per-band consensus diagnostics inherited a two-dimensional parent transform, causing a tensor-size mismatch
2. `2DSeparable` silently ignored string kernel selectors and therefore lacked the required quasi-periodic `period_length`
3. standard consensus selected a roughly 250-day second harmonic despite coherent cross-band and ACF evidence for the approximately 500-day fundamental

After correction, the smoke case recovered:

- truth period: 500 days
- consensus period: approximately 504.3 days
- relative period error: approximately 0.86%
- all evaluable recovery metrics passed
- no ARD boundary hits

## Scientific boundary

This PR corrects consensus and model-construction behavior required by D1 validation.

It does not:

- perform automatic model selection
- treat training-residual ranking as model evidence
- alter wavelength-model advisory conclusions
- execute the full multi-seed D1 campaign
- implement the later robustness or representative-LPV phases

## Validation

- consensus transform-inheritance regression tests
- period-kernel handoff tests
- harmonic-reconciliation tests
- wavelength-recovery regression tests
- real GPyTorch D1 smoke fit
- complete consensus regression suite
- complete wavelength-validation regression suite
- complete wavelength regression suite
- complete test suite: 2201 tests passed
- Ruff
- strict Sphinx build
- documentation TBD-marker audit