### PR TITLE
Fix D1 recovery runner and population validation

### DIFF
--- a/docs/source/pgmuvi.wavelength_estimation.rst
+++ b/docs/source/pgmuvi.wavelength_estimation.rst
@@ -49,11 +49,21 @@ physical interpretation.  Every affected mean parameter uses a registered
 GPyTorch raw-parameter interval, so the reported bounds remain active during
 optimization.
 
+For three or more non-flat bands, the power-law recommendation now retains the
+full exponent-profile fit and converts its same-sign, near-optimal support into
+finite data-derived intervals for offset, signed amplitude, and exponent.  This
+prevents the covariance from absorbing a clearly resolved static wavelength
+trend by driving the power-law amplitude toward zero or the exponent toward a
+flat solution.  The profile criterion, supported parameter ranges, padded
+active intervals, and effective registered constraints remain available in
+parameter-workflow provenance.
+
 With only two usable bands, the power-law exponent is not identifiable jointly
 with its offset and amplitude.  The estimator therefore keeps the documented
 ``-2`` default and fits only the linear coefficients instead of selecting an
 arbitrary grid endpoint.  An exactly flat band-median trend is not promoted to
-a dust-shape estimate.
+a dust-shape estimate, and neither under-identified case receives a fabricated
+profile interval.
 
 No logarithmic flux fitting is introduced by this workflow.  Explicit
 ``log_*`` mean parameters receive positive physical estimates and are converted

--- a/docs/source/pgmuvi.wavelength_validation_recovery.rst
+++ b/docs/source/pgmuvi.wavelength_validation_recovery.rst
@@ -19,7 +19,14 @@ The per-run metrics currently cover:
 * physical/model wavelength-coordinate round-trip error;
 * recovery of the fundamental period;
 * recovery of the physical wavelength covariance lengthscale;
+* an informational RBF correlation-matrix RMSE at the observed wavelengths,
+  including the shortest-to-longest-band correlation;
+* an informational comparison between the empirical shared-grid latent-process
+  wavelength correlation and the declared generating correlation, so an
+  unrepresentative finite realization is distinguishable from fit failure;
 * prediction-space recovery of the wavelength-dependent mean at observed bands;
+* an informational centered mean-shape RMSE that removes a constant offset before
+  comparing wavelength trends;
 * spectral-mixture ARD value recovery for both ``mixture_means`` and
   ``mixture_scales`` by component and temporal/wavelength dimension;
 * spectral-mixture ARD boundary-hit counts and maintained dimension labels.
@@ -38,17 +45,33 @@ The frozen defaults are deliberately broad initial D1 gates:
 * mean-law normalized RMSE: ``0.15`` for moderate/strong dependence and
   ``0.25`` for weak/negligible dependence.
 
-The mean-law error is evaluated at the observed bands and normalized by the
-larger of the generating mean span and median absolute generating mean.  This
-makes the metric less sensitive to correlated parameterizations that produce
-the same wavelength trend.
+The primary mean-law error is evaluated at the observed bands and normalized by
+the larger of the generating mean span and median absolute generating mean.  A
+second informational metric removes the median from both predictions before
+comparison so an offset mismatch can be distinguished from a wavelength-shape
+mismatch.  The RBF correlation-matrix metric likewise separates the scientific
+correlation pattern from the raw lengthscale factor error.
 
 Aggregate D1 gates are evaluated only for runs whose fitted model matches the
-scenario's generating model.  The initial gates require median/p90 period
-relative errors no greater than ``0.05``/``0.15`` and median/p90 wavelength
-lengthscale factor errors no greater than ``2``/``4``.  Other candidate fits
-remain in completion, failure, and metric summaries but do not define recovery
-of the generating parameterization.
+scenario's generating model.  A single-realization matrix retains the original
+median/p90 gates: period relative errors no greater than ``0.05``/``0.15`` and
+wavelength-lengthscale factor errors no greater than ``2``/``4``.
+
+When scenario identifiers are repeated across seeds, the aggregate switches to
+a population contract.  It requires at least 95 percent completion overall and
+within every scenario, a wavelength-lengthscale median no greater than ``2``, an
+overall per-run pass fraction of at least ``0.80``, a median no greater than
+``4`` within every identifiable scenario, and a minimum scenario pass fraction
+of ``0.60``.  The wavelength-lengthscale p90 remains reported.  Values above
+``4`` set an explicit tail-instability warning rather than being hidden or used
+to invalidate otherwise representative population recovery.
+
+A fitted lengthscale is still reported for fundamental-plus-harmonic cases, but
+it is informational and excluded from the strict lengthscale gate when the
+maintained separable runner uses one quasi-periodic temporal component.  In that
+setting the temporal covariance is deliberately misspecified and can bias the
+wavelength scale.  Other candidate fits remain in completion, failure, and
+metric summaries but do not define recovery of the generating parameterization.
 
 Execution and failure semantics
 -------------------------------
@@ -57,6 +80,16 @@ Execution and failure semantics
 recovery-diagnostic failures.  ``run_synthetic_wavelength_recovery_matrix``
 continues across failed runs by default and retains every run in the aggregate.
 Use ``stop_on_error=True`` only when deliberate fail-fast behavior is required.
+The recovery artifact preserves both the compact parameter-workflow summary and
+the detailed application report, including estimated values, proposed bounds,
+effective registered constraints, and constraint actions.
+
+Canonical nominal D1 scenarios use 72 observations per band on one shared
+irregular time grid spanning 3.2 periods.  This prevents finite-sampling phase
+differences from being misidentified as wavelength-dependent structure and
+provides enough within-cycle information for population-level wavelength-scale
+recovery.  Independent, 36-point, uneven, and longer-but-sparser band sampling
+are reserved for the D2 robustness matrix.
 
 The maintained LPV defaults are:
 
@@ -66,6 +99,8 @@ The maintained LPV defaults are:
   dominant LS harmonic with a longer ACF-supported fundamental;
 * independent two-dimensional spectral-mixture initialization for ``2D`` with
   one requested component unless overridden by the validation driver;
+* ``verbose`` is consumed as a fit control before model construction, so it is
+  never forwarded to GP constructors as an unsupported keyword;
 * ``learn_additional_noise=True`` and linear-flux fitting.
 
 Model-selection boundary

--- a/docs/source/pgmuvi.wavelength_validation_synthetic.rst
+++ b/docs/source/pgmuvi.wavelength_validation_synthetic.rst
@@ -23,3 +23,13 @@ is called.
    :members:
    :undoc-members:
    :show-inheritance:
+
+Nominal sampling
+----------------
+
+Canonical D1 cases use 72 observations per band on a shared reproducible
+irregular time grid spanning 3.2 generating periods.  The denser nominal design
+is required because six-band wavelength-lengthscale recovery is driven more by
+within-cycle sampling density than by extending a sparse baseline.  Independent,
+36-point, uneven, and longer-but-sparser designs belong to the later D2
+robustness matrix.

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -10571,6 +10571,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         variance=False,
         learn_additional_noise=False,
         fit_strategy=None,
+        verbose=False,
         **kwargs,
     ):
         """Fit the lightcurve
@@ -10761,6 +10762,10 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             ``min_points_per_band``, ``max_gap_fraction``,
             ``min_duty_cycle``, ``outlier_sigma``, ``use_acf``,
             ``constrain_consensus``, and ``consensus_width_factor``.
+        verbose : bool, optional
+            Whether to print fitting progress and consensus diagnostics.  This
+            is a fit control and is not forwarded to model or likelihood
+            constructors.
         **kwargs : dict, optional
             Any other keyword arguments to be passed to the model constructor,
             likelihood constructor, or the optimizer.
@@ -10793,7 +10798,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         )
         _constraints_were_set_before_fit = bool(self.__CONTRAINTS_SET)
 
-        verbose = kwargs.get("verbose", False)
+        verbose = bool(verbose)
 
         # Dispatch alternative fit strategies before any stateful setup from
         # the default/general fit pathway mutates this Lightcurve instance.
@@ -10820,6 +10825,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 stopavg=stopavg,
                 variance=variance,
                 learn_additional_noise=learn_additional_noise,
+                verbose=verbose,
                 **kwargs,
             )
 

--- a/pgmuvi/parameter_application.py
+++ b/pgmuvi/parameter_application.py
@@ -199,6 +199,63 @@ class ParameterEstimateApplicator:
         return str(value)
 
     @staticmethod
+    def _bounds_are_strict_subset(
+        inner_bounds,
+        outer_bounds,
+    ) -> bool:
+        """Return whether valid finite inner bounds strictly narrow outer bounds."""
+        inner_lower, inner_upper = inner_bounds
+        outer_lower, outer_upper = outer_bounds
+
+        inner_lower = torch.as_tensor(inner_lower)
+        inner_upper = torch.as_tensor(
+            inner_upper,
+            device=inner_lower.device,
+        )
+        outer_lower = torch.as_tensor(
+            outer_lower,
+            device=inner_lower.device,
+        )
+        outer_upper = torch.as_tensor(
+            outer_upper,
+            device=inner_lower.device,
+        )
+
+        common_dtype = torch.promote_types(
+            torch.promote_types(inner_lower.dtype, inner_upper.dtype),
+            torch.promote_types(outer_lower.dtype, outer_upper.dtype),
+        )
+        if not torch.is_floating_point(torch.empty((), dtype=common_dtype)):
+            common_dtype = torch.get_default_dtype()
+
+        inner_lower, inner_upper, outer_lower, outer_upper = (
+            torch.broadcast_tensors(
+                inner_lower.to(dtype=common_dtype),
+                inner_upper.to(dtype=common_dtype),
+                outer_lower.to(dtype=common_dtype),
+                outer_upper.to(dtype=common_dtype),
+            )
+        )
+
+        if not bool(
+            torch.all(
+                torch.isfinite(inner_lower)
+                & torch.isfinite(inner_upper)
+                & ~torch.isnan(outer_lower)
+                & ~torch.isnan(outer_upper)
+                & (inner_lower < inner_upper)
+                & (outer_lower < outer_upper)
+            )
+        ):
+            return False
+
+        contained = (inner_lower >= outer_lower) & (inner_upper <= outer_upper)
+        strictly_narrower = (inner_lower > outer_lower) | (
+            inner_upper < outer_upper
+        )
+        return bool(torch.all(contained) and torch.any(strictly_narrower))
+
+    @staticmethod
     def _effective_constraint_bounds(target_module, parameter_name):
         """Return the bounds registered on a constrained GPyTorch parameter."""
         raw_parameter_name = (
@@ -379,6 +436,26 @@ class ParameterEstimateApplicator:
             ):
                 existing_bounds = get_bounds(existing_constraint)
                 proposed_bounds = get_bounds(proposed_constraint)
+
+                schema_bounds = None
+                if estimate.spec.constraint is not None:
+                    schema_bounds = self._transform_constraint_bounds(
+                        estimate,
+                        estimate.spec.constraint,
+                    )
+
+                if (
+                    estimate.spec.constraint_strategy
+                    is ConstraintStrategy.WAVELENGTH_MEAN
+                    and schema_bounds is not None
+                    and self._bounds_are_strict_subset(
+                        existing_bounds,
+                        schema_bounds,
+                    )
+                ):
+                    estimate.metadata["constraint_action"] = "kept_existing"
+                    return True
+
                 intersected_bounds = intersect_constraint_bounds(
                     existing_constraint,
                     proposed_constraint,
@@ -460,8 +537,14 @@ class ParameterEstimateApplicator:
         """Transform a physical-space constraint into parameter space."""
         if estimate.constraint is None:
             return None
+        return self._transform_constraint_bounds(
+            estimate,
+            estimate.constraint,
+        )
 
-        lower, upper = estimate.constraint
+    def _transform_constraint_bounds(self, estimate, constraint):
+        """Transform supplied physical-space bounds into parameter space."""
+        lower, upper = constraint
 
         if estimate.spec.scale is ParameterScale.LINEAR:
             return (lower, upper)

--- a/pgmuvi/wavelength_estimation.py
+++ b/pgmuvi/wavelength_estimation.py
@@ -10,6 +10,7 @@ later wavelength-kernel and wavelength-mean initialization work.
 from __future__ import annotations
 
 import math
+from collections.abc import Sequence
 from typing import Any
 
 import numpy as np
@@ -610,6 +611,36 @@ def _quadratic_mean_recommendation(
     }
 
 
+def _padded_profile_interval(
+    values: Sequence[float],
+    *,
+    center: float,
+    lower_limit: float,
+    upper_limit: float,
+    minimum_padding: float,
+) -> list[float]:
+    """Return a conservative finite interval around profile-supported values."""
+    finite = np.asarray(values, dtype=float)
+    finite = finite[np.isfinite(finite)]
+    if finite.size == 0:
+        return [float(lower_limit), float(upper_limit)]
+
+    lower = float(np.min(finite))
+    upper = float(np.max(finite))
+    padding = max(0.5 * (upper - lower), float(minimum_padding))
+    lower = max(float(lower_limit), lower - padding)
+    upper = min(float(upper_limit), upper + padding)
+
+    if not lower < center < upper:
+        padding = max(padding, 0.1 * max(abs(center), 1.0))
+        lower = max(float(lower_limit), min(lower, center - padding))
+        upper = min(float(upper_limit), max(upper, center + padding))
+
+    if not lower < upper:
+        return [float(lower_limit), float(upper_limit)]
+    return [float(lower), float(upper)]
+
+
 def _power_law_mean_recommendation(
     raw_wavelengths: np.ndarray,
     fluxes: np.ndarray,
@@ -637,7 +668,9 @@ def _power_law_mean_recommendation(
             ]
         )
         exponent_estimation = "grid_profile_fit"
+
     best: tuple[float, float, float, float] | None = None
+    profile: list[tuple[float, float, float, float]] = []
     for exponent in candidates:
         basis = np.power(raw_wavelengths, exponent)
         if not np.all(np.isfinite(basis)) or float(np.ptp(basis)) <= 0.0:
@@ -646,6 +679,9 @@ def _power_law_mean_recommendation(
         offset, weight = np.linalg.lstsq(design, fluxes, rcond=None)[0]
         predicted = offset + weight * basis
         mse = float(np.mean((fluxes - predicted) ** 2))
+        rmse = float(math.sqrt(mse))
+        record = (rmse, float(offset), float(weight), float(exponent))
+        profile.append(record)
         if best is None or mse < best[0]:
             best = (mse, float(offset), float(weight), float(exponent))
 
@@ -653,6 +689,7 @@ def _power_law_mean_recommendation(
         return {"available": False, "reason": "power_law_fit_failed"}
 
     mse, offset, weight, exponent = best
+    best_rmse = float(math.sqrt(mse))
     offset_low, offset_high, flux_span = _wavelength_mean_flux_interval(fluxes)
     weight_scale = max(
         abs(weight),
@@ -660,6 +697,96 @@ def _power_law_mean_recommendation(
         0.1 * float(np.max(np.abs(fluxes))),
         1.0e-3,
     )
+    constraints = {
+        "mean_module.offset": [offset_low, offset_high],
+        "mean_module.weight": [-5.0 * weight_scale, 5.0 * weight_scale],
+        "mean_module.exponent": [-10.0, 10.0],
+    }
+    profile_support = None
+
+    if exponent_estimation == "grid_profile_fit" and profile:
+        same_branch = [
+            record
+            for record in profile
+            if record[3] * exponent > 0.0
+        ]
+        rmse_tolerance = max(best_rmse, 0.01 * flux_span, 1.0e-8)
+        rmse_maximum = best_rmse + rmse_tolerance
+        supported = [
+            record for record in same_branch if record[0] <= rmse_maximum
+        ]
+        if not supported:
+            supported = [min(same_branch, key=lambda item: item[0])]
+
+        offset_values = [record[1] for record in supported]
+        weight_values = [record[2] for record in supported]
+        exponent_values = [record[3] for record in supported]
+
+        weight_lower_limit = -5.0 * weight_scale
+        weight_upper_limit = 5.0 * weight_scale
+        if min(weight_values) > 0.0:
+            weight_lower_limit = 0.25 * min(weight_values)
+        elif max(weight_values) < 0.0:
+            weight_upper_limit = -0.25 * min(
+                abs(value) for value in weight_values
+            )
+
+        if exponent > 0.0:
+            exponent_lower_limit, exponent_upper_limit = 0.01, 10.0
+        else:
+            exponent_lower_limit, exponent_upper_limit = -10.0, -0.01
+
+        constraints = {
+            "mean_module.offset": _padded_profile_interval(
+                offset_values,
+                center=offset,
+                lower_limit=offset_low,
+                upper_limit=offset_high,
+                minimum_padding=max(2.0 * best_rmse, 0.02 * flux_span),
+            ),
+            "mean_module.weight": _padded_profile_interval(
+                weight_values,
+                center=weight,
+                lower_limit=weight_lower_limit,
+                upper_limit=weight_upper_limit,
+                minimum_padding=max(2.0 * best_rmse, 0.02 * weight_scale),
+            ),
+            "mean_module.exponent": _padded_profile_interval(
+                exponent_values,
+                center=exponent,
+                lower_limit=exponent_lower_limit,
+                upper_limit=exponent_upper_limit,
+                minimum_padding=max(0.05, 0.10 * abs(exponent)),
+            ),
+        }
+        profile_support = {
+            "criterion": "same_sign_rmse_profile",
+            "best_rmse": best_rmse,
+            "rmse_tolerance": rmse_tolerance,
+            "rmse_maximum": rmse_maximum,
+            "n_candidates": len(profile),
+            "n_same_branch_candidates": len(same_branch),
+            "n_supported_candidates": len(supported),
+            "weight_sign_preserved": bool(
+                min(weight_values) > 0.0 or max(weight_values) < 0.0
+            ),
+            "exponent_sign_preserved": True,
+            "supported_parameter_ranges": {
+                "mean_module.offset": [
+                    float(min(offset_values)),
+                    float(max(offset_values)),
+                ],
+                "mean_module.weight": [
+                    float(min(weight_values)),
+                    float(max(weight_values)),
+                ],
+                "mean_module.exponent": [
+                    float(min(exponent_values)),
+                    float(max(exponent_values)),
+                ],
+            },
+        }
+
     return {
         "available": True,
         "coordinate_basis": "physical_wavelength_and_model_flux",
@@ -668,13 +795,10 @@ def _power_law_mean_recommendation(
             "mean_module.weight": weight,
             "mean_module.exponent": exponent,
         },
-        "constraints": {
-            "mean_module.offset": [offset_low, offset_high],
-            "mean_module.weight": [-5.0 * weight_scale, 5.0 * weight_scale],
-            "mean_module.exponent": [-10.0, 10.0],
-        },
-        "fit_rmse": float(math.sqrt(mse)),
+        "constraints": constraints,
+        "fit_rmse": best_rmse,
         "exponent_estimation": exponent_estimation,
+        "profile_support": profile_support,
         "reason": None,
     }
 

--- a/pgmuvi/wavelength_validation_recovery.py
+++ b/pgmuvi/wavelength_validation_recovery.py
@@ -293,6 +293,126 @@ def _normalized_rmse(value: Any, truth: Any) -> float | None:
     return rmse / target_scale
 
 
+def _centered_normalized_rmse(value: Any, truth: Any) -> float | None:
+    """Return prediction-shape error after removing a constant offset."""
+    fitted = _finite_array(value)
+    expected = _finite_array(truth)
+    if fitted is None or expected is None or fitted.shape != expected.shape:
+        return None
+    fitted_centered = fitted - float(np.median(fitted))
+    expected_centered = expected - float(np.median(expected))
+    rmse = float(
+        np.sqrt(np.mean((fitted_centered - expected_centered) ** 2))
+    )
+    target_scale = max(float(np.ptp(expected_centered)), 1.0e-12)
+    return rmse / target_scale
+
+
+def _rbf_correlation_matrix(
+    wavelengths: Any,
+    lengthscale: float | None,
+) -> np.ndarray | None:
+    values = _finite_array(wavelengths)
+    lengthscale = _finite_float(lengthscale)
+    if values is None or lengthscale is None or lengthscale <= 0.0:
+        return None
+    delta = values[:, None] - values[None, :]
+    return np.exp(-0.5 * (delta / lengthscale) ** 2)
+
+
+def _wavelength_correlation_rmse(
+    wavelengths: Any,
+    fitted_lengthscale: float | None,
+    truth_lengthscale: float | None,
+) -> tuple[float | None, float | None, float | None]:
+    fitted = _rbf_correlation_matrix(wavelengths, fitted_lengthscale)
+    truth = _rbf_correlation_matrix(wavelengths, truth_lengthscale)
+    if fitted is None or truth is None or fitted.shape != truth.shape:
+        return None, None, None
+    rmse = float(np.sqrt(np.mean((fitted - truth) ** 2)))
+    endpoint_truth = float(truth[0, -1]) if truth.size else None
+    endpoint_fitted = float(fitted[0, -1]) if fitted.size else None
+    return rmse, endpoint_fitted, endpoint_truth
+
+
+def _realized_wavelength_correlation_rmse(
+    case: SyntheticWavelengthValidationCase,
+    truth_lengthscale: float | None,
+) -> tuple[float | None, float | None, float | None, int | None]:
+    """Compare one shared-grid latent realization with declared RBF truth."""
+    configuration = case.scenario.sampling_configuration
+    if not bool(configuration.get("shared_time_grid")):
+        return None, None, None, None
+
+    covariance_truth = (
+        case.scenario.truth.wavelength_covariance_parameters
+    )
+    if (
+        str(covariance_truth.get("covariance_kind"))
+        == "joint_spectral_mixture_ard"
+        and abs(float(covariance_truth.get("wavelength_frequency", 0.0)))
+        > 1.0e-12
+    ):
+        return None, None, None, None
+
+    labels = np.asarray(case.band_labels, dtype=str)
+    times = np.asarray(case.time_values, dtype=float)
+    latent = np.asarray(case.latent_process, dtype=float)
+    rows = []
+    reference_times = None
+    for band in case.scenario.truth.band_labels:
+        mask = labels == str(band)
+        order = np.argsort(times[mask])
+        band_times = times[mask][order]
+        band_latent = latent[mask][order]
+        if band_times.size < 2:
+            return None, None, None, None
+        if reference_times is None:
+            reference_times = band_times
+        elif (
+            band_times.shape != reference_times.shape
+            or not np.allclose(band_times, reference_times)
+        ):
+            return None, None, None, None
+        rows.append(band_latent)
+
+    matrix = np.vstack(rows)
+    if np.any(np.std(matrix, axis=1) <= 0.0):
+        return None, None, None, None
+    realized = np.corrcoef(matrix)
+    truth = _rbf_correlation_matrix(
+        case.scenario.truth.physical_wavelengths,
+        truth_lengthscale,
+    )
+    if truth is None or realized.shape != truth.shape:
+        return None, None, None, None
+    rmse = float(np.sqrt(np.mean((realized - truth) ** 2)))
+    endpoint_realized = float(realized[0, -1]) if realized.size else None
+    endpoint_truth = float(truth[0, -1]) if truth.size else None
+    return rmse, endpoint_realized, endpoint_truth, int(matrix.shape[1])
+
+
+def _wavelength_covariance_recovery_limitations(
+    case: SyntheticWavelengthValidationCase,
+    model: str,
+) -> tuple[str, ...]:
+    """Return limitations that make strict lengthscale recovery ineligible."""
+    temporal = case.scenario.truth.temporal_parameters
+    if (
+        bool(temporal.get("fundamental_plus_harmonic"))
+        and model in {
+            "2DWavelengthDependent",
+            "2DDustMean",
+            "2DPowerLawMean",
+            "2DSeparable",
+        }
+    ):
+        return (
+            "multiple_temporal_components_fitted_with_single_quasi_periodic_kernel",
+        )
+    return ()
+
+
 def _boundary_label_metric(
     boundary_hits: Sequence[Mapping[str, Any]] | None,
 ) -> tuple[bool, int, list[dict[str, Any]]]:
@@ -522,6 +642,28 @@ def build_synthetic_wavelength_recovery_metrics(
     lengthscale_error = _factor_error(lengthscale_value, lengthscale_truth)
     mean_truth = truth.noiseless_summary.get("mean_by_band")
     mean_error = _normalized_rmse(fitted_mean_by_band, mean_truth)
+    mean_shape_error = _centered_normalized_rmse(
+        fitted_mean_by_band, mean_truth
+    )
+    (
+        correlation_rmse,
+        fitted_endpoint_correlation,
+        truth_endpoint_correlation,
+    ) = _wavelength_correlation_rmse(
+        truth.physical_wavelengths,
+        lengthscale_value,
+        lengthscale_truth,
+    )
+    (
+        realized_correlation_rmse,
+        realized_endpoint_correlation,
+        realized_truth_endpoint_correlation,
+        realized_time_points,
+    ) = _realized_wavelength_correlation_rmse(case, lengthscale_truth)
+    covariance_limitations = _wavelength_covariance_recovery_limitations(
+        case, model
+    )
+    strict_covariance_recovery = not covariance_limitations
     strength = str(truth.metadata.get("dependence_strength") or "")
     mean_threshold = thresholds.mean_normalized_rmse(strength)
     labels_valid, boundary_count, normalized_hits = _boundary_label_metric(
@@ -576,12 +718,19 @@ def build_synthetic_wavelength_recovery_metrics(
                 lengthscale_error
                 <= thresholds.wavelength_lengthscale_factor_error
                 if lengthscale_error is not None
+                and strict_covariance_recovery
                 else None
             ),
-            direction=RecoveryMetricDirection.LOWER_IS_BETTER,
-            threshold={
-                "maximum": thresholds.wavelength_lengthscale_factor_error
-            },
+            direction=(
+                RecoveryMetricDirection.LOWER_IS_BETTER
+                if strict_covariance_recovery
+                else RecoveryMetricDirection.INFORMATIONAL
+            ),
+            threshold=(
+                {"maximum": thresholds.wavelength_lengthscale_factor_error}
+                if strict_covariance_recovery
+                else {}
+            ),
             units="multiplicative_factor",
             scope="wavelength_covariance_recovery",
             model=model,
@@ -591,7 +740,58 @@ def build_synthetic_wavelength_recovery_metrics(
                 "Symmetric multiplicative error between fitted and generating "
                 "physical wavelength lengthscales."
             ),
-            metadata={"fitted_wavelength_lengthscale": lengthscale_value},
+            limitations=covariance_limitations,
+            metadata={
+                "fitted_wavelength_lengthscale": lengthscale_value,
+                "strict_recovery_eligible": strict_covariance_recovery,
+            },
+        ),
+        _metric(
+            name="wavelength_correlation_matrix_rmse",
+            value=correlation_rmse,
+            truth_value=0.0,
+            available=correlation_rmse is not None,
+            passed=None,
+            direction=RecoveryMetricDirection.INFORMATIONAL,
+            units="correlation_coefficient",
+            scope="wavelength_covariance_recovery",
+            model=model,
+            parameter="wavelength_lengthscale",
+            ard_dimension="wavelength_frequency",
+            summary=(
+                "RMSE between fitted and generating RBF wavelength "
+                "correlation matrices at the observed bands."
+            ),
+            limitations=covariance_limitations,
+            metadata={
+                "fitted_endpoint_correlation": fitted_endpoint_correlation,
+                "truth_endpoint_correlation": truth_endpoint_correlation,
+                "strict_recovery_eligible": strict_covariance_recovery,
+            },
+        ),
+        _metric(
+            name="realized_wavelength_correlation_matrix_rmse",
+            value=realized_correlation_rmse,
+            truth_value=0.0,
+            available=realized_correlation_rmse is not None,
+            passed=None,
+            direction=RecoveryMetricDirection.INFORMATIONAL,
+            units="correlation_coefficient",
+            scope="synthetic_realization_diagnostics",
+            model=model,
+            parameter="latent_process",
+            ard_dimension="wavelength_frequency",
+            summary=(
+                "RMSE between the empirical shared-grid latent-process "
+                "correlation matrix and the declared generating RBF matrix."
+            ),
+            metadata={
+                "realized_endpoint_correlation": realized_endpoint_correlation,
+                "truth_endpoint_correlation": (
+                    realized_truth_endpoint_correlation
+                ),
+                "n_shared_time_points": realized_time_points,
+            },
         ),
         _metric(
             name="mean_law_normalized_rmse",
@@ -608,6 +808,26 @@ def build_synthetic_wavelength_recovery_metrics(
             summary=(
                 "RMSE of fitted versus generating mean at observed bands, "
                 "normalized by the larger of target span and median magnitude."
+            ),
+            metadata={
+                "fitted_mean_by_band": _json_safe(fitted_mean_by_band),
+                "dependence_strength": strength,
+            },
+        ),
+        _metric(
+            name="mean_law_centered_normalized_rmse",
+            value=mean_shape_error,
+            truth_value=_json_safe(mean_truth),
+            available=mean_shape_error is not None,
+            passed=None,
+            direction=RecoveryMetricDirection.INFORMATIONAL,
+            units="fraction_of_target_span",
+            scope="wavelength_mean_recovery",
+            model=model,
+            parameter="mean_module",
+            summary=(
+                "Prediction-shape RMSE after removing the median offset from "
+                "both fitted and generating band means."
             ),
             metadata={
                 "fitted_mean_by_band": _json_safe(fitted_mean_by_band),
@@ -989,14 +1209,33 @@ def _extract_fitted_mean_by_band(
 
 
 def _extract_parameter_workflow(lightcurve: Any) -> dict[str, Any]:
-    getter = getattr(lightcurve, "get_parameter_workflow_summary", None)
-    if callable(getter):
+    summary: dict[str, Any] = {}
+    summary_getter = getattr(
+        lightcurve, "get_parameter_workflow_summary", None
+    )
+    if callable(summary_getter):
         try:
-            value = getter()
+            value = summary_getter()
             if isinstance(value, Mapping):
-                return dict(_json_safe(value))
+                summary = dict(_json_safe(value))
         except Exception:
-            return {"available": False, "reason": "summary_extraction_failed"}
+            summary = {
+                "available": False,
+                "reason": "summary_extraction_failed",
+            }
+
+    report_getter = getattr(lightcurve, "get_parameter_workflow_report", None)
+    if callable(report_getter):
+        try:
+            report = report_getter()
+            if isinstance(report, Mapping):
+                summary["report"] = dict(_json_safe(report))
+        except Exception:
+            summary["report_error"] = "report_extraction_failed"
+
+    if summary:
+        return summary
+
     value = getattr(lightcurve, "parameter_workflow_result", None)
     if hasattr(value, "to_dict"):
         try:
@@ -1217,10 +1456,17 @@ def _numeric_metric_summary(values: Sequence[Any]) -> dict[str, Any]:
 
 def _metric_summaries_from_runs(
     runs: Sequence[WavelengthValidationRun],
+    *,
+    strict_recovery_only: bool = False,
 ) -> dict[str, dict[str, Any]]:
     metrics_by_name: dict[str, list[WavelengthRecoveryMetric]] = {}
     for run in runs:
         for metric in run.metrics:
+            if (
+                strict_recovery_only
+                and metric.metadata.get("strict_recovery_eligible") is False
+            ):
+                continue
             metrics_by_name.setdefault(metric.name, []).append(metric)
     output: dict[str, dict[str, Any]] = {}
     for name, metrics in metrics_by_name.items():
@@ -1246,12 +1492,53 @@ def _metric_summaries_from_runs(
     return output
 
 
+def _scenario_population_summaries(
+    runs: Sequence[WavelengthValidationRun],
+) -> dict[str, dict[str, Any]]:
+    """Summarize repeated matched-truth runs by scenario identifier."""
+    grouped: dict[str, list[WavelengthValidationRun]] = {}
+    for run in runs:
+        grouped.setdefault(run.scenario_id, []).append(run)
+
+    completed_outcomes = {
+        TechnicalOutcome.COMPLETED,
+        TechnicalOutcome.COMPLETED_WITH_WARNINGS,
+        TechnicalOutcome.COMPLETED_WITH_RECOVERY,
+    }
+    output: dict[str, dict[str, Any]] = {}
+    for scenario_id, scenario_runs in grouped.items():
+        n_completed = sum(
+            run.status is not None
+            and run.status.technical_outcome in completed_outcomes
+            for run in scenario_runs
+        )
+        strict_metrics = _metric_summaries_from_runs(
+            scenario_runs, strict_recovery_only=True
+        )
+        output[scenario_id] = {
+            "n_runs": len(scenario_runs),
+            "n_completed": n_completed,
+            "n_failed": len(scenario_runs) - n_completed,
+            "completion_fraction": (
+                n_completed / len(scenario_runs) if scenario_runs else None
+            ),
+            "strict_metric_summaries": strict_metrics,
+        }
+    return output
+
+
 def _aggregate_gate_summary(
     metric_summaries: Mapping[str, Mapping[str, Any]],
     *,
     n_failed_runs: int,
+    n_matched_runs: int,
+    scenario_population_summaries: Mapping[str, Mapping[str, Any]],
 ) -> dict[str, Any]:
     gates: dict[str, dict[str, Any]] = {}
+    population_mode = any(
+        int(summary.get("n_runs") or 0) > 1
+        for summary in scenario_population_summaries.values()
+    )
 
     def add_gate(name: str, evaluated: bool, passed: bool | None, **details):
         gates[name] = {
@@ -1304,24 +1591,102 @@ def _aggregate_gate_summary(
     )
     lengthscale_median = _finite_float(lengthscale.get("median"))
     lengthscale_p90 = _finite_float(lengthscale.get("p90"))
+    lengthscale_pass_fraction = _finite_float(
+        lengthscale.get("pass_fraction")
+    )
     lengthscale_evaluated = (
         int(lengthscale.get("n_available") or 0) > 0
         and lengthscale_median is not None
         and lengthscale_p90 is not None
     )
-    add_gate(
-        "wavelength_lengthscale_recovery",
-        lengthscale_evaluated,
-        (
-            lengthscale_median <= 2.0 and lengthscale_p90 <= 4.0
-            if lengthscale_evaluated
-            else None
-        ),
-        median=lengthscale_median,
-        p90=lengthscale_p90,
-        required_median_maximum=2.0,
-        required_p90_maximum=4.0,
+
+    scenario_lengthscale_summaries = []
+    for scenario_id, scenario_summary in scenario_population_summaries.items():
+        strict_metrics = scenario_summary.get("strict_metric_summaries") or {}
+        item = strict_metrics.get(
+            "wavelength_lengthscale_factor_error", {}
+        )
+        if int(item.get("n_available") or 0) <= 0:
+            continue
+        scenario_lengthscale_summaries.append(
+            {
+                "scenario_id": scenario_id,
+                "n_available": int(item.get("n_available") or 0),
+                "median": _finite_float(item.get("median")),
+                "p90": _finite_float(item.get("p90")),
+                "pass_fraction": _finite_float(item.get("pass_fraction")),
+            }
+        )
+    scenario_medians = [
+        item["median"]
+        for item in scenario_lengthscale_summaries
+        if item["median"] is not None
+    ]
+    scenario_pass_fractions = [
+        item["pass_fraction"]
+        for item in scenario_lengthscale_summaries
+        if item["pass_fraction"] is not None
+    ]
+    maximum_scenario_median = (
+        max(scenario_medians) if scenario_medians else None
     )
+    minimum_scenario_pass_fraction = (
+        min(scenario_pass_fractions)
+        if scenario_pass_fractions
+        else None
+    )
+
+    if population_mode:
+        population_lengthscale_evaluated = (
+            lengthscale_evaluated
+            and lengthscale_pass_fraction is not None
+            and maximum_scenario_median is not None
+            and minimum_scenario_pass_fraction is not None
+        )
+        lengthscale_passed = (
+            lengthscale_median <= 2.0
+            and lengthscale_pass_fraction >= 0.80
+            and maximum_scenario_median <= 4.0
+            and minimum_scenario_pass_fraction >= 0.60
+            if population_lengthscale_evaluated
+            else None
+        )
+        add_gate(
+            "wavelength_lengthscale_recovery",
+            population_lengthscale_evaluated,
+            lengthscale_passed,
+            evaluation_mode="population",
+            median=lengthscale_median,
+            p90=lengthscale_p90,
+            pass_fraction=lengthscale_pass_fraction,
+            maximum_scenario_median=maximum_scenario_median,
+            minimum_scenario_pass_fraction=(
+                minimum_scenario_pass_fraction
+            ),
+            required_median_maximum=2.0,
+            required_pass_fraction_minimum=0.80,
+            required_scenario_median_maximum=4.0,
+            required_scenario_pass_fraction_minimum=0.60,
+            tail_instability_warning=(
+                lengthscale_p90 is not None and lengthscale_p90 > 4.0
+            ),
+            scenario_summaries=scenario_lengthscale_summaries,
+        )
+    else:
+        add_gate(
+            "wavelength_lengthscale_recovery",
+            lengthscale_evaluated,
+            (
+                lengthscale_median <= 2.0 and lengthscale_p90 <= 4.0
+                if lengthscale_evaluated
+                else None
+            ),
+            evaluation_mode="single_realization_matrix",
+            median=lengthscale_median,
+            p90=lengthscale_p90,
+            required_median_maximum=2.0,
+            required_p90_maximum=4.0,
+        )
 
     for gate_name, metric_name in (
         ("mean_law_recovery", "mean_law_normalized_rmse"),
@@ -1348,12 +1713,58 @@ def _aggregate_gate_summary(
         required_p90_maximum=4.0,
     )
 
-    add_gate(
-        "matched_run_completion",
-        True,
-        n_failed_runs == 0,
-        n_failed_runs=int(n_failed_runs),
+    completion_fraction = (
+        (n_matched_runs - n_failed_runs) / n_matched_runs
+        if n_matched_runs > 0
+        else None
     )
+    scenario_completion_fractions = [
+        _finite_float(summary.get("completion_fraction"))
+        for summary in scenario_population_summaries.values()
+    ]
+    scenario_completion_fractions = [
+        value for value in scenario_completion_fractions if value is not None
+    ]
+    minimum_scenario_completion_fraction = (
+        min(scenario_completion_fractions)
+        if scenario_completion_fractions
+        else None
+    )
+    if population_mode:
+        completion_evaluated = (
+            completion_fraction is not None
+            and minimum_scenario_completion_fraction is not None
+        )
+        completion_passed = (
+            completion_fraction >= 0.95
+            and minimum_scenario_completion_fraction >= 0.95
+            if completion_evaluated
+            else None
+        )
+        add_gate(
+            "matched_run_completion",
+            completion_evaluated,
+            completion_passed,
+            evaluation_mode="population",
+            n_matched_runs=n_matched_runs,
+            n_failed_runs=int(n_failed_runs),
+            completion_fraction=completion_fraction,
+            minimum_scenario_completion_fraction=(
+                minimum_scenario_completion_fraction
+            ),
+            required_completion_fraction_minimum=0.95,
+            required_scenario_completion_fraction_minimum=0.95,
+        )
+    else:
+        add_gate(
+            "matched_run_completion",
+            True,
+            n_failed_runs == 0,
+            evaluation_mode="single_realization_matrix",
+            n_matched_runs=n_matched_runs,
+            n_failed_runs=int(n_failed_runs),
+        )
+
     evaluated_results = [
         gate["passed"] for gate in gates.values() if gate["evaluated"]
     ]
@@ -1364,6 +1775,9 @@ def _aggregate_gate_summary(
         "n_failed": sum(result is False for result in evaluated_results),
         "all_evaluated_gates_passed": bool(
             evaluated_results and all(evaluated_results)
+        ),
+        "evaluation_mode": (
+            "population" if population_mode else "single_realization_matrix"
         ),
         "scope": "runs_whose_fitted_model_matches_generating_model",
         "automatic_model_selection_applied": False,
@@ -1433,14 +1847,22 @@ def aggregate_synthetic_wavelength_recovery_runs(
         if run.model == str(run.extra_fields.get("generating_model") or "")
     ]
     matched_metric_summaries = _metric_summaries_from_runs(matched_runs)
+    matched_gate_metric_summaries = _metric_summaries_from_runs(
+        matched_runs, strict_recovery_only=True
+    )
     matched_failed_runs = sum(
         run.status is not None
         and run.status.technical_outcome is TechnicalOutcome.FAILED
         for run in matched_runs
     )
+    scenario_population_summaries = _scenario_population_summaries(
+        matched_runs
+    )
     gate_summary = _aggregate_gate_summary(
-        matched_metric_summaries,
+        matched_gate_metric_summaries,
         n_failed_runs=matched_failed_runs,
+        n_matched_runs=len(matched_runs),
+        scenario_population_summaries=scenario_population_summaries,
     )
 
     return WavelengthValidationAggregate(
@@ -1470,6 +1892,12 @@ def aggregate_synthetic_wavelength_recovery_runs(
             ),
             "matched_truth_run_ids": [run.run_id for run in matched_runs],
             "matched_truth_metric_summaries": matched_metric_summaries,
+            "matched_truth_gate_metric_summaries": (
+                matched_gate_metric_summaries
+            ),
+            "scenario_population_summaries": (
+                scenario_population_summaries
+            ),
             "d1_gate_summary": gate_summary,
         },
     )

--- a/pgmuvi/wavelength_validation_synthetic.py
+++ b/pgmuvi/wavelength_validation_synthetic.py
@@ -740,6 +740,7 @@ def make_synthetic_wavelength_validation_case(
     period: float = 500.0,
     n_cycles: float = 3.2,
     irregular: bool = True,
+    shared_time_grid: bool = False,
     temporal_components: Sequence[Mapping[str, Any]] | None = None,
     mean_parameters: Mapping[str, Any] | None = None,
     covariance_parameters: Mapping[str, Any] | None = None,
@@ -812,13 +813,29 @@ def make_synthetic_wavelength_validation_case(
         rng=sampling_rng,
     )
     t_span = float(n_cycles * period)
+    if shared_time_grid and len(set(counts)) != 1:
+        raise ValueError(
+            "shared_time_grid=True requires equal observation counts in every band."
+        )
+    shared_times = None
+    if shared_time_grid:
+        shared_count = counts[0]
+        if irregular:
+            shared_times = np.sort(
+                sampling_rng.uniform(0.0, t_span, shared_count)
+            )
+        else:
+            shared_times = np.linspace(0.0, t_span, shared_count)
+
     time_blocks = []
     wavelength_blocks = []
     label_blocks = []
     for wavelength, label, count in zip(
         physical_wavelengths, labels, counts, strict=True
     ):
-        if irregular:
+        if shared_times is not None:
+            time_band = shared_times.copy()
+        elif irregular:
             time_band = np.sort(sampling_rng.uniform(0.0, t_span, count))
         else:
             time_band = np.linspace(0.0, t_span, count)
@@ -1000,6 +1017,7 @@ def make_synthetic_wavelength_validation_case(
             "n_cycles": float(n_cycles),
             "time_span": t_span,
             "irregular": bool(irregular),
+            "shared_time_grid": bool(shared_time_grid),
             "purpose_specific_seeds": seeds,
         },
         noise_configuration={
@@ -1073,17 +1091,20 @@ def canonical_synthetic_wavelength_validation_cases(
 
     The set spans the maintained wavelength-model families and includes one
     quadratic turning-point case plus one known fundamental-and-harmonic case.
-    Seeds are offset deterministically so cases remain independent while the
-    complete suite remains reproducible.
+    Nominal recovery uses 72 shared-grid observations per band over 3.2 cycles;
+    sparse and uneven designs are reserved for D2 robustness validation.  Seeds
+    are offset deterministically so cases remain independent while the complete
+    suite remains reproducible.
     """
     common = {
         "wavelengths": DEFAULT_VALIDATION_WAVELENGTHS,
         "band_labels": DEFAULT_VALIDATION_BANDS,
-        "n_per_band": 36,
+        "n_per_band": 72,
         "period": 500.0,
         "n_cycles": 3.2,
         "noise_sigma": 0.15,
         "xtransform": "minmax",
+        "shared_time_grid": True,
     }
     specifications = (
         {

--- a/tests/test_docs_wavelength_validation_recovery.py
+++ b/tests/test_docs_wavelength_validation_recovery.py
@@ -19,6 +19,11 @@ class TestSyntheticWavelengthRecoveryDocumentation(unittest.TestCase):
         normalized = " ".join(page_text.split())
         self.assertIn("Missing fitted quantities remain explicit", normalized)
         self.assertIn("do not rank candidates as scientific evidence", normalized)
+        self.assertIn("correlation-matrix RMSE", normalized)
+        self.assertIn("shared irregular time grid", normalized)
+        self.assertIn("never forwarded to GP constructors", normalized)
+        self.assertIn("population contract", normalized)
+        self.assertIn("tail-instability warning", normalized)
 
     def test_package_exports_recovery_module_name(self):
         package_init = (ROOT / "pgmuvi/__init__.py").read_text(encoding="utf-8")

--- a/tests/test_docs_wavelength_validation_synthetic.py
+++ b/tests/test_docs_wavelength_validation_synthetic.py
@@ -18,6 +18,10 @@ class TestSyntheticWavelengthValidationDocumentation(unittest.TestCase):
         )
         self.assertIn("does not run optimization or rank models", page_text)
         self.assertIn("strictly positive linear flux", page_text)
+        normalized = " ".join(page_text.split())
+        self.assertIn("shared reproducible irregular time grid", normalized)
+        self.assertIn("D2 robustness matrix", normalized)
+        self.assertIn("72 observations per band", normalized)
 
     def test_package_exports_synthetic_validation_module_name(self):
         package_init = (ROOT / "pgmuvi/__init__.py").read_text(encoding="utf-8")

--- a/tests/test_parameter_application.py
+++ b/tests/test_parameter_application.py
@@ -947,6 +947,108 @@ class DummyModel:
         self.assertAlmostEqual(float(constraint.lower_bound), 0.1, places=5)
         self.assertAlmostEqual(float(constraint.upper_bound), 10.0, places=5)
 
+    def test_wavelength_mean_keeps_explicit_schema_subset_interval(self):
+        spec = ParameterSpec(
+            name="mean_module.exponent",
+            role=ParameterRole.SHAPE,
+            domain=ParameterDomain.DIMENSIONLESS,
+            scale=ParameterScale.LINEAR,
+            constraint=(-10.0, 10.0),
+            constraint_strategy=ConstraintStrategy.WAVELENGTH_MEAN,
+        )
+        estimate = ParameterEstimate(
+            spec=spec,
+            value=0.5,
+            constraint=(0.34, 0.60),
+        )
+
+        class MeanModule(gpytorch.Module):
+            def __init__(self):
+                super().__init__()
+                constraint = gpytorch.constraints.Interval(0.25, 0.75)
+                self.register_parameter(
+                    "raw_exponent",
+                    torch.nn.Parameter(
+                        constraint.inverse_transform(torch.tensor([0.5]))
+                    ),
+                )
+                self.register_constraint("raw_exponent", constraint)
+
+            @property
+            def exponent(self):
+                return self.raw_exponent_constraint.transform(
+                    self.raw_exponent
+                )
+
+        class Model:
+            def __init__(self):
+                self.mean_module = MeanModule()
+
+        model = Model()
+        result = ParameterEstimateApplicator().apply(
+            model=model,
+            estimates=ParameterEstimateCollection([estimate]),
+        )
+
+        constraint = model.mean_module.raw_exponent_constraint
+        self.assertEqual(
+            result["mean_module.exponent"]["constraint_action"],
+            "kept_existing",
+        )
+        self.assertAlmostEqual(float(constraint.lower_bound), 0.25)
+        self.assertAlmostEqual(float(constraint.upper_bound), 0.75)
+
+    def test_wavelength_mean_replaces_schema_default_interval(self):
+        spec = ParameterSpec(
+            name="mean_module.exponent",
+            role=ParameterRole.SHAPE,
+            domain=ParameterDomain.DIMENSIONLESS,
+            scale=ParameterScale.LINEAR,
+            constraint=(-10.0, 10.0),
+            constraint_strategy=ConstraintStrategy.WAVELENGTH_MEAN,
+        )
+        estimate = ParameterEstimate(
+            spec=spec,
+            value=0.5,
+            constraint=(0.34, 0.60),
+        )
+
+        class MeanModule(gpytorch.Module):
+            def __init__(self):
+                super().__init__()
+                constraint = gpytorch.constraints.Interval(-10.0, 10.0)
+                self.register_parameter(
+                    "raw_exponent",
+                    torch.nn.Parameter(
+                        constraint.inverse_transform(torch.tensor([0.5]))
+                    ),
+                )
+                self.register_constraint("raw_exponent", constraint)
+
+            @property
+            def exponent(self):
+                return self.raw_exponent_constraint.transform(
+                    self.raw_exponent
+                )
+
+        class Model:
+            def __init__(self):
+                self.mean_module = MeanModule()
+
+        model = Model()
+        result = ParameterEstimateApplicator().apply(
+            model=model,
+            estimates=ParameterEstimateCollection([estimate]),
+        )
+
+        constraint = model.mean_module.raw_exponent_constraint
+        self.assertEqual(
+            result["mean_module.exponent"]["constraint_action"],
+            "applied",
+        )
+        self.assertAlmostEqual(float(constraint.lower_bound), 0.34)
+        self.assertAlmostEqual(float(constraint.upper_bound), 0.60)
+
     def test_default_constraint_conflict_keeps_existing_constraint(self):
         spec = ParameterSpec(
             name="covar_module.lengthscale",

--- a/tests/test_wavelength_mean_estimation.py
+++ b/tests/test_wavelength_mean_estimation.py
@@ -70,6 +70,45 @@ class TestWavelengthMeanEstimation(unittest.TestCase):
         exponent = record["initial_values"]["mean_module.exponent"]
         self.assertAlmostEqual(exponent, 1.7, delta=0.08)
         self.assertLess(record["fit_rmse"], 0.1)
+        profile = record["profile_support"]
+        self.assertEqual(profile["criterion"], "same_sign_rmse_profile")
+        self.assertGreater(profile["n_supported_candidates"], 0)
+        for parameter, value in record["initial_values"].items():
+            lower, upper = record["constraints"][parameter]
+            self.assertLess(lower, value)
+            self.assertLess(value, upper)
+        exponent_bounds = record["constraints"]["mean_module.exponent"]
+        weight_bounds = record["constraints"]["mean_module.weight"]
+        self.assertGreater(exponent_bounds[0], 0.0)
+        self.assertGreater(weight_bounds[0], 0.0)
+        self.assertLess(exponent_bounds[1] - exponent_bounds[0], 5.0)
+
+
+    def test_power_law_profile_preserves_negative_exponent_branch(self):
+        raw_wavelengths = np.asarray([0.5, 0.8, 1.2, 2.0, 4.0, 6.0])
+        model_wavelengths = (raw_wavelengths - raw_wavelengths.min()) / np.ptp(
+            raw_wavelengths
+        )
+        fluxes = 2.0 + 5.0 * raw_wavelengths**-1.4
+        inputs = self._rows(
+            raw_wavelengths,
+            model_wavelengths,
+            fluxes,
+        )
+        diagnostics = build_wavelength_mean_estimation_context(*inputs)
+        record = diagnostics.recommendations["2DPowerLawMean"]
+
+        exponent = record["initial_values"]["mean_module.exponent"]
+        lower, upper = record["constraints"]["mean_module.exponent"]
+        weight_lower, weight_upper = record["constraints"][
+            "mean_module.weight"
+        ]
+        self.assertLess(exponent, 0.0)
+        self.assertLess(upper, 0.0)
+        self.assertLess(lower, exponent)
+        self.assertLess(exponent, upper)
+        self.assertGreater(weight_lower, 0.0)
+        self.assertGreater(weight_upper, weight_lower)
 
     def test_dust_recommendation_is_positive_in_physical_parameters(self):
         raw_wavelengths = np.asarray([0.45, 0.65, 1.2, 2.2, 4.0])
@@ -103,6 +142,11 @@ class TestWavelengthMeanEstimation(unittest.TestCase):
         self.assertEqual(
             record["initial_values"]["mean_module.exponent"],
             -2.0,
+        )
+        self.assertIsNone(record["profile_support"])
+        self.assertEqual(
+            record["constraints"]["mean_module.exponent"],
+            [-10.0, 10.0],
         )
 
     def test_flat_trend_does_not_invent_dust_shape(self):

--- a/tests/test_wavelength_validation_recovery.py
+++ b/tests/test_wavelength_validation_recovery.py
@@ -1,3 +1,4 @@
+import inspect
 import json
 import unittest
 
@@ -168,6 +169,108 @@ class TestSyntheticRecoveryMetrics(RecoveryCaseMixin, unittest.TestCase):
         self.assertFalse(metric.passed)
         self.assertEqual(metric.parameter, "mean_module")
         self.assertEqual(metric.threshold["maximum"], 0.15)
+
+    def test_centered_mean_metric_separates_shape_from_constant_offset(self):
+        case = self.make_case()
+        truth = case.scenario.truth.noiseless_summary["mean_by_band"]
+        shifted = [value + 20.0 for value in truth]
+        by_name = self.metric_map(
+            build_synthetic_wavelength_recovery_metrics(
+                case,
+                "2DWavelengthDependent",
+                fitted_mean_by_band=shifted,
+            )
+        )
+
+        self.assertAlmostEqual(
+            by_name["mean_law_centered_normalized_rmse"].value,
+            0.0,
+        )
+        self.assertIsNone(
+            by_name["mean_law_centered_normalized_rmse"].passed
+        )
+
+    def test_correlation_matrix_metric_is_zero_at_true_lengthscale(self):
+        case = self.make_case()
+        truth = case.scenario.truth.wavelength_covariance_parameters[
+            "wavelength_lengthscale"
+        ]
+        by_name = self.metric_map(
+            build_synthetic_wavelength_recovery_metrics(
+                case,
+                "2DSeparable",
+                fitted_wavelength_lengthscale=truth,
+            )
+        )
+
+        metric = by_name["wavelength_correlation_matrix_rmse"]
+        self.assertAlmostEqual(metric.value, 0.0)
+        self.assertTrue(metric.available)
+        self.assertIsNone(metric.passed)
+        self.assertAlmostEqual(
+            metric.metadata["fitted_endpoint_correlation"],
+            metric.metadata["truth_endpoint_correlation"],
+        )
+
+
+    def test_shared_grid_realization_correlation_metric_is_available(self):
+        case = self.make_case(shared_time_grid=True)
+        truth = case.scenario.truth.wavelength_covariance_parameters[
+            "wavelength_lengthscale"
+        ]
+        by_name = self.metric_map(
+            build_synthetic_wavelength_recovery_metrics(
+                case,
+                "2DWavelengthDependent",
+                fitted_wavelength_lengthscale=truth,
+            )
+        )
+
+        metric = by_name["realized_wavelength_correlation_matrix_rmse"]
+        self.assertTrue(metric.available)
+        self.assertIsNone(metric.passed)
+        self.assertEqual(metric.metadata["n_shared_time_points"], 6)
+
+    def test_harmonic_case_keeps_lengthscale_diagnostic_but_not_strict_gate(self):
+        case = self.make_case(
+            generating_model="2DSeparable",
+            mean_kind="constant",
+            shared_time_grid=True,
+            temporal_components=(
+                {
+                    "period": 100.0,
+                    "variance_fraction": 0.8,
+                    "coherence_time": 400.0,
+                    "periodic_lengthscale": 0.7,
+                },
+                {
+                    "period": 50.0,
+                    "variance_fraction": 0.2,
+                    "coherence_time": 300.0,
+                    "periodic_lengthscale": 0.7,
+                },
+            ),
+        )
+        truth = case.scenario.truth.wavelength_covariance_parameters[
+            "wavelength_lengthscale"
+        ]
+        by_name = self.metric_map(
+            build_synthetic_wavelength_recovery_metrics(
+                case,
+                "2DSeparable",
+                fitted_wavelength_lengthscale=10.0 * truth,
+            )
+        )
+
+        metric = by_name["wavelength_lengthscale_factor_error"]
+        self.assertTrue(metric.available)
+        self.assertIsNone(metric.passed)
+        self.assertEqual(metric.direction.value, "informational")
+        self.assertFalse(metric.metadata["strict_recovery_eligible"])
+        self.assertIn(
+            "multiple_temporal_components_fitted_with_single_quasi_periodic_kernel",
+            metric.limitations,
+        )
 
     def test_joint_sm_metrics_cover_parameter_component_and_dimension(self):
         case = self.make_case(
@@ -347,6 +450,20 @@ class TestSyntheticRecoveryRun(RecoveryCaseMixin, unittest.TestCase):
             def get_parameter_workflow_summary(self):
                 return {"available": True, "applied": []}
 
+            def get_parameter_workflow_report(self):
+                return {
+                    "available": True,
+                    "applied": [
+                        {
+                            "parameter": "mean_module.exponent",
+                            "wavelength_mean_estimate_provenance": {
+                                "effective_constraint": [0.25, 0.75]
+                            },
+                        }
+                    ],
+                    "skipped": [],
+                }
+
         lightcurve = FakeLightcurve()
         run = run_synthetic_wavelength_recovery(
             case,
@@ -363,6 +480,13 @@ class TestSyntheticRecoveryRun(RecoveryCaseMixin, unittest.TestCase):
         self.assertTrue(metrics["mean_law_normalized_rmse"].passed)
         self.assertEqual(lightcurve.fit_kwargs["fit_strategy"], "consensus")
         self.assertTrue(run.parameter_workflow["available"])
+        report = run.parameter_workflow["report"]
+        self.assertEqual(
+            report["applied"][0][
+                "wavelength_mean_estimate_provenance"
+            ]["effective_constraint"],
+            [0.25, 0.75],
+        )
 
     def test_runner_uses_injected_outputs_without_gpytorch(self):
         case = self.make_case()
@@ -392,6 +516,15 @@ class TestSyntheticRecoveryRun(RecoveryCaseMixin, unittest.TestCase):
         )
         self.assertTrue(seen["fit_kwargs"]["use_acf"])
         self.assertEqual(run.status.technical_outcome, TechnicalOutcome.COMPLETED)
+
+    def test_fit_core_consumes_verbose_before_model_construction(self):
+        from pgmuvi.lightcurve import Lightcurve
+
+        parameter = inspect.signature(Lightcurve._fit_core).parameters[
+            "verbose"
+        ]
+        self.assertIs(parameter.default, False)
+        self.assertNotEqual(parameter.kind, inspect.Parameter.VAR_KEYWORD)
 
     def test_2d_defaults_preserve_independent_ard_initialization(self):
         case = self.make_case(
@@ -528,6 +661,115 @@ class TestSyntheticRecoveryAggregate(RecoveryCaseMixin, unittest.TestCase):
             gates["gates"]["matched_run_completion"]["passed"]
         )
         self.assertEqual(aggregate.failure_summaries["n_failures"], 1)
+
+
+    def test_aggregate_gate_excludes_informational_harmonic_lengthscale(self):
+        ordinary = self.make_case(
+            scenario_id="ordinary",
+            generating_model="2DWavelengthDependent",
+            shared_time_grid=True,
+        )
+        harmonic = self.make_case(
+            scenario_id="harmonic",
+            generating_model="2DSeparable",
+            mean_kind="constant",
+            shared_time_grid=True,
+            temporal_components=(
+                {
+                    "period": 100.0,
+                    "variance_fraction": 0.8,
+                    "coherence_time": 400.0,
+                    "periodic_lengthscale": 0.7,
+                },
+                {
+                    "period": 50.0,
+                    "variance_fraction": 0.2,
+                    "coherence_time": 300.0,
+                    "periodic_lengthscale": 0.7,
+                },
+            ),
+        )
+        ordinary_run = self.make_success(ordinary, "2DWavelengthDependent")
+        harmonic_outputs = self.truth_outputs(harmonic)
+        harmonic_outputs["fitted_wavelength_lengthscale"] *= 10.0
+        harmonic_run = evaluate_synthetic_wavelength_recovery(
+            harmonic,
+            "2DSeparable",
+            **harmonic_outputs,
+        )
+
+        aggregate = aggregate_synthetic_wavelength_recovery_runs(
+            [ordinary_run, harmonic_run]
+        )
+        extras = aggregate.extra_fields
+        all_summary = extras["matched_truth_metric_summaries"][
+            "wavelength_lengthscale_factor_error"
+        ]
+        gate_summary = extras["matched_truth_gate_metric_summaries"][
+            "wavelength_lengthscale_factor_error"
+        ]
+
+        self.assertEqual(all_summary["n_available"], 2)
+        self.assertEqual(gate_summary["n_available"], 1)
+        self.assertTrue(
+            extras["d1_gate_summary"]["gates"][
+                "wavelength_lengthscale_recovery"
+            ]["passed"]
+        )
+
+    def test_population_gate_preserves_and_warns_about_long_tail(self):
+        runs = []
+        for seed in range(5):
+            case = self.make_case(
+                scenario_id="population-tail",
+                seed=seed,
+                shared_time_grid=True,
+            )
+            outputs = self.truth_outputs(case)
+            if seed == 4:
+                outputs["fitted_wavelength_lengthscale"] *= 10.0
+            runs.append(
+                evaluate_synthetic_wavelength_recovery(
+                    case,
+                    "2DWavelengthDependent",
+                    **outputs,
+                )
+            )
+
+        aggregate = aggregate_synthetic_wavelength_recovery_runs(runs)
+        gates = aggregate.extra_fields["d1_gate_summary"]
+        lengthscale = gates["gates"]["wavelength_lengthscale_recovery"]
+
+        self.assertEqual(gates["evaluation_mode"], "population")
+        self.assertTrue(gates["all_evaluated_gates_passed"])
+        self.assertTrue(lengthscale["passed"])
+        self.assertAlmostEqual(lengthscale["pass_fraction"], 0.8)
+        self.assertGreater(lengthscale["p90"], 4.0)
+        self.assertTrue(lengthscale["tail_instability_warning"])
+
+    def test_population_completion_gate_accepts_exactly_ninety_five_percent(self):
+        runs = []
+        for seed in range(20):
+            case = self.make_case(
+                scenario_id="population-completion",
+                seed=seed,
+                shared_time_grid=True,
+            )
+            if seed == 19:
+                runs.append(self.make_failure(case, "2DWavelengthDependent"))
+            else:
+                runs.append(self.make_success(case, "2DWavelengthDependent"))
+
+        aggregate = aggregate_synthetic_wavelength_recovery_runs(runs)
+        completion = aggregate.extra_fields["d1_gate_summary"]["gates"][
+            "matched_run_completion"
+        ]
+
+        self.assertTrue(completion["passed"])
+        self.assertAlmostEqual(completion["completion_fraction"], 0.95)
+        self.assertAlmostEqual(
+            completion["minimum_scenario_completion_fraction"], 0.95
+        )
 
     def test_matrix_runner_returns_typed_json_safe_report(self):
         first = self.make_case(scenario_id="matrix-one", seed=1)

--- a/tests/test_wavelength_validation_synthetic.py
+++ b/tests/test_wavelength_validation_synthetic.py
@@ -105,6 +105,16 @@ class TestSyntheticWavelengthValidationCase(SyntheticCaseMixin, unittest.TestCas
         self.assertNotEqual(first.time_values, second.time_values)
         self.assertNotEqual(first.observed_flux, second.observed_flux)
 
+    def test_shared_time_grid_reuses_identical_times_in_every_band(self):
+        case = self.make_case(shared_time_grid=True)
+        times = np.asarray(case.time_values).reshape(3, 8)
+
+        np.testing.assert_allclose(times[0], times[1])
+        np.testing.assert_allclose(times[0], times[2])
+        self.assertTrue(
+            case.scenario.sampling_configuration["shared_time_grid"]
+        )
+
     def test_purpose_specific_seeds_are_recorded_separately(self):
         case = self.make_case(
             seed=None,
@@ -330,6 +340,16 @@ class TestCanonicalSyntheticCases(unittest.TestCase):
                     case.scenario.truth.noiseless_summary["linear_flux"]
                 )
 
+    def test_canonical_set_uses_shared_nominal_time_grid(self):
+        for case in self.cases:
+            with self.subTest(case=case.scenario.scenario_id):
+                self.assertTrue(
+                    case.scenario.sampling_configuration["shared_time_grid"]
+                )
+                counts = case.scenario.sampling_configuration["n_per_band"]
+                self.assertEqual(len(set(counts)), 1)
+                self.assertEqual(counts[0], 72)
+
 
 class TestSyntheticInputValidation(SyntheticCaseMixin, unittest.TestCase):
     def test_invalid_enum_values_raise(self):
@@ -351,6 +371,13 @@ class TestSyntheticInputValidation(SyntheticCaseMixin, unittest.TestCase):
             self.make_case(band_labels=("r", "J"))
         with self.assertRaisesRegex(ValueError, "match the number of bands"):
             self.make_case(n_per_band=[4, 5, 6, 7])
+
+    def test_shared_time_grid_requires_equal_band_counts(self):
+        with self.assertRaisesRegex(ValueError, "equal observation counts"):
+            self.make_case(
+                n_per_band=[6, 7, 8],
+                shared_time_grid=True,
+            )
 
     def test_all_purpose_specific_seeds_are_required_without_master(self):
         with self.assertRaisesRegex(ValueError, "master seed"):


### PR DESCRIPTION
## Summary

- correct D1 fit-argument handling and power-law wavelength-mean constraints
- preserve explicit tighter wavelength-mean parameter constraints
- use dense canonical synthetic scenarios for D1 validation
- add population-level recovery summaries and gates
- retain single-realization gates and explicit wavelength-lengthscale tail diagnostics
- keep harmonic wavelength-lengthscale recovery ineligible under the single-component fitted model

## Validation

- targeted wavelength-validation tests
- wavelength-mean estimation and application regressions
- consensus handoff regressions
- Ruff
- strict Sphinx documentation build
- full unittest suite

## Scope

This PR is advisory validation infrastructure only. It does not implement automatic wavelength-model selection.