### PR TITLE
Add wavelength robustness validation framework

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -68,4 +68,5 @@ Data, diagnostics, and validation
    pgmuvi.wavelength_validation
    pgmuvi.wavelength_validation_synthetic
    pgmuvi.wavelength_validation_recovery
+   pgmuvi.wavelength_validation_robustness
    pgmuvi.upload_validation

--- a/docs/source/future_work.rst
+++ b/docs/source/future_work.rst
@@ -75,11 +75,15 @@ Completed wavelength-derived constraint tranche (PR121--PR125)
     pressure into model-selection evidence.
 
 **TBD[wavelength-constraint-validation]**
-    Validate the wavelength-derived initialization and constraint tranche with
-    synthetic recovery, sparse and uneven band coverage, missing bands, large
-    wavelength gaps, weak and strong wavelength dependence, supported
-    non-monotonic cases, seed stability, constraint-ceiling diagnostics,
-    consensus periodic or quasi-periodic time kernels, and real LPV sources.
+    D1 nominal synthetic recovery and the core D2 robustness/failure-boundary
+    scenario, runner, and aggregation framework are implemented.  Complete the
+    multi-seed D2 calibration for sparse and uneven band coverage, missing
+    bands, large wavelength gaps, weak and strong wavelength dependence,
+    supported non-monotonic cases, seed stability, constraint-ceiling
+    diagnostics, and consensus quasi-periodic time kernels.  Then add the
+    maintained wavelength-constraint Jupyter notebook covering derivation,
+    application, diagnostics, mean-versus-covariance constraints, and tested
+    failure boundaries before proceeding to representative real LPV sources.
     Successful optimization alone is not sufficient validation.
 
 Wavelength-model extensions
@@ -105,6 +109,14 @@ Wavelength-model extensions
 
 Documentation tutorial extensions
 ---------------------------------
+
+**TBD[wavelength-constraint-notebook]**
+    Add a maintained Jupyter notebook after the D2 multi-seed robustness
+    calibration is complete.  The notebook must demonstrate wavelength-scale
+    derivation, coordinate transformation, constraint application, fitted
+    boundary diagnostics, the distinction between wavelength-dependent mean
+    and covariance constraints, and the empirically tested D2 failure
+    boundaries.
 
 **TBD[batch-notebook]**
     Add a maintained notebook for the batch wavelength-advisory workflow.

--- a/docs/source/notebook_status.rst
+++ b/docs/source/notebook_status.rst
@@ -81,6 +81,13 @@ workflow is implemented, tested, and has documented convergence and posterior-
 predictive diagnostics.  Do not restore the deleted notebook verbatim; it used
 stale installation, parameter-setting, likelihood, and plotting patterns.
 
+**TBD[wavelength-constraint-notebook]:** after the D2 multi-seed robustness and
+failure-boundary calibration is complete, add a maintained public notebook that
+shows how wavelength-kernel scales and bounds are derived, transformed, applied,
+and diagnosed.  It must distinguish covariance constraints from wavelength-
+dependent mean constraints and explain the tested sparse/noisy failure
+boundaries before it is added to the Tutorials toctree.
+
 Notebook maintenance rules
 --------------------------
 

--- a/docs/source/pgmuvi.wavelength_validation.rst
+++ b/docs/source/pgmuvi.wavelength_validation.rst
@@ -17,7 +17,10 @@ Unknown fields are retained under ``extra_fields`` so later validation stages
 can extend the schema without discarding information.  Non-finite numerical
 values are normalized to ``None`` during serialization.  Synthetic scenarios
 must carry an explicit truth record, while observed D3 scenarios may omit truth
-and instead rely on input checksums and provenance.
+and instead rely on input checksums and provenance.  D1 execution is provided
+by :mod:`pgmuvi.wavelength_validation_recovery`; the controlled D2 robustness
+and failure-boundary layer is provided by
+:mod:`pgmuvi.wavelength_validation_robustness`.
 
 .. automodule:: pgmuvi.wavelength_validation
    :members:

--- a/docs/source/pgmuvi.wavelength_validation_recovery.rst
+++ b/docs/source/pgmuvi.wavelength_validation_recovery.rst
@@ -89,7 +89,9 @@ irregular time grid spanning 3.2 periods.  This prevents finite-sampling phase
 differences from being misidentified as wavelength-dependent structure and
 provides enough within-cycle information for population-level wavelength-scale
 recovery.  Independent, 36-point, uneven, and longer-but-sparser band sampling
-are reserved for the D2 robustness matrix.
+are implemented as controlled scenarios in
+:mod:`pgmuvi.wavelength_validation_robustness`; D2 aggregates do not reuse the
+frozen D1 gates.
 
 The maintained LPV defaults are:
 

--- a/docs/source/pgmuvi.wavelength_validation_robustness.rst
+++ b/docs/source/pgmuvi.wavelength_validation_robustness.rst
@@ -1,0 +1,70 @@
+Synthetic wavelength robustness and failure boundaries
+======================================================
+
+.. automodule:: pgmuvi.wavelength_validation_robustness
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Scientific scope
+----------------
+
+This module implements the D2 scenario, execution, expected-failure, and
+aggregation framework.  It reuses the maintained D1 fit and recovery-extraction
+path so robustness experiments exercise the same wavelength initialization,
+constraints, consensus defaults, and ARD diagnostics as nominal recovery.
+It does not reuse the D1 population gates as D2 acceptance criteria.
+
+The canonical controlled perturbations cover:
+
+* independent versus shared per-band time grids;
+* 36-point sparse sampling and longer-but-sparser baselines;
+* uneven per-band observation counts;
+* missing blue-edge, red-edge, and interior bands;
+* large wavelength gaps;
+* heteroscedastic and high-noise measurements;
+* weak and strong wavelength dependence;
+* sparse independent sampling for the full ``2D`` spectral-mixture ARD model;
+  and
+* an explicit insufficient-per-band-sampling failure boundary.
+
+Every case preserves the generating truth and identifies its robustness axis,
+severity, and paired reference scenario.  The default matrix fits each case only
+with its generating model.  An explicit ``models`` argument requests a
+case-by-model cross product; it is never interpreted as automatic selection.
+
+Failure semantics
+-----------------
+
+A scenario may carry a
+:class:`pgmuvi.wavelength_validation.WavelengthValidationFailureExpectation`.
+The D2 runner compares the actual failure code, execution stage, status
+dimensions, and acceptable exception types with that contract.  A matched
+expected failure remains a failed and comparison-ineligible attempt; it is not
+relabeled as a successful fit.  Failures in ordinary robustness scenarios are
+recorded separately as unexpected failures.
+
+Aggregation boundary
+--------------------
+
+D2 aggregates report completion, recovery metrics, expected-failure matches,
+unexpected failures, and summaries by perturbation axis, severity, and model.
+The initial framework deliberately marks empirical failure boundaries as not yet
+calibrated.  The multi-seed validation tranche will establish those boundaries
+without weakening the frozen D1 recovery gates.
+
+Documentation notebook plan
+---------------------------
+
+After the empirical D2 boundaries are established, add a maintained Jupyter
+notebook that demonstrates wavelength-kernel scale derivation, coordinate
+transformation, constraint application, fitted boundary diagnostics, the
+distinction between wavelength mean and covariance constraints, and the tested
+sparse/noisy failure boundaries.  The notebook must be registered in the public
+Tutorials toctree and in ``notebook_status.rst``.
+
+Model-selection boundary
+------------------------
+
+Robustness reports are advisory validation artifacts.  They do not rank models,
+set ``selected_model``, install a winner, or apply automatic model selection.

--- a/docs/source/pgmuvi.wavelength_validation_synthetic.rst
+++ b/docs/source/pgmuvi.wavelength_validation_synthetic.rst
@@ -31,5 +31,7 @@ Canonical D1 cases use 72 observations per band on a shared reproducible
 irregular time grid spanning 3.2 generating periods.  The denser nominal design
 is required because six-band wavelength-lengthscale recovery is driven more by
 within-cycle sampling density than by extending a sparse baseline.  Independent,
-36-point, uneven, and longer-but-sparser designs belong to the later D2
-robustness matrix.
+36-point, uneven, and longer-but-sparser designs are constructed by the D2
+robustness matrix framework in
+:mod:`pgmuvi.wavelength_validation_robustness`; their empirical multi-seed
+boundaries remain a separate validation run.

--- a/pgmuvi/__init__.py
+++ b/pgmuvi/__init__.py
@@ -31,5 +31,6 @@ __all__ = [
     "wavelength_status",
     "wavelength_validation",
     "wavelength_validation_recovery",
+    "wavelength_validation_robustness",
     "wavelength_validation_synthetic",
 ]

--- a/pgmuvi/wavelength_validation_robustness.py
+++ b/pgmuvi/wavelength_validation_robustness.py
@@ -1,0 +1,1286 @@
+"""Synthetic D2 robustness and failure-boundary validation.
+
+This module promotes truth-preserving synthetic cases into the D2 validation
+phase, executes matched-truth or explicit case-by-model robustness matrices,
+and records expected failures separately from unexpected technical failures.
+It deliberately reuses the maintained D1 fitting and recovery extraction path
+without reusing the D1 aggregate gates as D2 acceptance criteria.
+
+The D2 outputs remain advisory.  They describe where wavelength-parameter
+recovery, constraint diagnostics, or fitting cease to be reliable; they do not
+rank models, install a winner, or perform automatic model selection.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field, replace
+from enum import Enum
+import math
+from typing import Any
+
+import numpy as np
+
+from .wavelength_status import (
+    ComparisonEligibility,
+    DiagnosticValidity,
+    ExecutionStage,
+    ScientificUsability,
+    TechnicalOutcome,
+)
+from .wavelength_validation import (
+    RecoveryMetricDirection,
+    WavelengthRecoveryMetric,
+    WavelengthValidationAggregate,
+    WavelengthValidationFailureExpectation,
+    WavelengthValidationPhase,
+    WavelengthValidationRun,
+)
+from .wavelength_validation_recovery import (
+    SUPPORTED_SYNTHETIC_RECOVERY_MODELS,
+    SyntheticWavelengthRecoveryThresholds,
+    run_synthetic_wavelength_recovery,
+)
+from .wavelength_validation_synthetic import (
+    DEFAULT_VALIDATION_BANDS,
+    DEFAULT_VALIDATION_WAVELENGTHS,
+    SyntheticWavelengthValidationCase,
+    make_synthetic_wavelength_validation_case,
+)
+
+SYNTHETIC_WAVELENGTH_ROBUSTNESS_SCHEMA_VERSION = (
+    "pgmuvi-synthetic-wavelength-robustness-v1"
+)
+
+_LightcurveFactory = Callable[[SyntheticWavelengthValidationCase], Any]
+_SyntheticFitRunner = Callable[
+    [Any, Mapping[str, Any], SyntheticWavelengthValidationCase], Any
+]
+
+__all__ = [
+    "SYNTHETIC_WAVELENGTH_ROBUSTNESS_SCHEMA_VERSION",
+    "SyntheticWavelengthRobustnessAxis",
+    "SyntheticWavelengthRobustnessReport",
+    "SyntheticWavelengthRobustnessSeverity",
+    "SyntheticWavelengthRobustnessSpecification",
+    "aggregate_synthetic_wavelength_robustness_runs",
+    "canonical_synthetic_wavelength_robustness_cases",
+    "canonical_synthetic_wavelength_robustness_specifications",
+    "make_synthetic_wavelength_robustness_case",
+    "run_synthetic_wavelength_robustness",
+    "run_synthetic_wavelength_robustness_matrix",
+]
+
+
+class _StringEnum(str, Enum):
+    def __str__(self) -> str:
+        return self.value
+
+
+class SyntheticWavelengthRobustnessAxis(_StringEnum):
+    """Single controlled perturbation represented by a D2 scenario."""
+
+    REFERENCE = "reference"
+    INDEPENDENT_TIME_GRIDS = "independent_time_grids"
+    SPARSE_SAMPLING = "sparse_sampling"
+    UNEVEN_BAND_COUNTS = "uneven_band_counts"
+    LONGER_SPARSE_BASELINE = "longer_sparse_baseline"
+    MISSING_BLUE_EDGE_BAND = "missing_blue_edge_band"
+    MISSING_RED_EDGE_BAND = "missing_red_edge_band"
+    MISSING_INTERIOR_BAND = "missing_interior_band"
+    LARGE_WAVELENGTH_GAP = "large_wavelength_gap"
+    HETEROSCEDASTIC_NOISE = "heteroscedastic_noise"
+    HIGH_NOISE = "high_noise"
+    WEAK_WAVELENGTH_DEPENDENCE = "weak_wavelength_dependence"
+    STRONG_WAVELENGTH_DEPENDENCE = "strong_wavelength_dependence"
+    JOINT_SM_SPARSE_ARD = "joint_sm_sparse_ard"
+    INSUFFICIENT_PER_BAND_SAMPLING = "insufficient_per_band_sampling"
+
+
+class SyntheticWavelengthRobustnessSeverity(_StringEnum):
+    """Expected qualitative difficulty of a D2 perturbation."""
+
+    REFERENCE = "reference"
+    MILD = "mild"
+    CHALLENGING = "challenging"
+    BOUNDARY = "boundary"
+    INVALID = "invalid"
+
+
+def _coerce_enum(enum_type, value: Any, *, field_name: str):
+    if isinstance(value, enum_type):
+        return value
+    try:
+        return enum_type(str(value))
+    except (TypeError, ValueError) as exc:
+        allowed = ", ".join(item.value for item in enum_type)
+        raise ValueError(f"{field_name} must be one of: {allowed}.") from exc
+
+
+def _json_safe(value: Any) -> Any:
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if isinstance(value, Enum):
+        return value.value
+    if hasattr(value, "to_dict") and callable(value.to_dict):
+        return _json_safe(value.to_dict())
+    if isinstance(value, Mapping):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, Sequence) and not isinstance(
+        value, (str, bytes, bytearray)
+    ):
+        return [_json_safe(item) for item in value]
+    item = getattr(value, "item", None)
+    if callable(item):
+        try:
+            return _json_safe(item())
+        except (TypeError, ValueError, RuntimeError):
+            pass
+    tolist = getattr(value, "tolist", None)
+    if callable(tolist):
+        try:
+            return _json_safe(tolist())
+        except (TypeError, ValueError, RuntimeError):
+            pass
+    return str(value)
+
+
+def _mapping_copy(value: Mapping[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {}
+    return {str(key): _json_safe(item) for key, item in value.items()}
+
+
+def _deduplicated_strings(values: Sequence[Any]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(str(item) for item in values))
+
+
+def _as_expected_failure(
+    value: WavelengthValidationFailureExpectation | Mapping[str, Any] | None,
+) -> WavelengthValidationFailureExpectation | None:
+    if value is None or isinstance(value, WavelengthValidationFailureExpectation):
+        return value
+    if isinstance(value, Mapping):
+        return WavelengthValidationFailureExpectation.from_mapping(value)
+    raise TypeError("expected_failure must be a failure expectation, mapping, or None")
+
+
+@dataclass(frozen=True)
+class SyntheticWavelengthRobustnessSpecification:
+    """Declarative generator specification for one D2 scenario."""
+
+    scenario_id: str
+    axis: SyntheticWavelengthRobustnessAxis
+    severity: SyntheticWavelengthRobustnessSeverity
+    description: str
+    generator_configuration: Mapping[str, Any]
+    reference_scenario_id: str | None = None
+    expected_failure: WavelengthValidationFailureExpectation | None = None
+    tags: tuple[str, ...] = ()
+    schema_version: str = SYNTHETIC_WAVELENGTH_ROBUSTNESS_SCHEMA_VERSION
+    extra_fields: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        scenario_id = str(self.scenario_id or "").strip()
+        description = str(self.description or "").strip()
+        if not scenario_id or not description:
+            raise ValueError("scenario_id and description must be non-empty.")
+        object.__setattr__(self, "scenario_id", scenario_id)
+        object.__setattr__(self, "description", description)
+        object.__setattr__(
+            self,
+            "axis",
+            _coerce_enum(
+                SyntheticWavelengthRobustnessAxis,
+                self.axis,
+                field_name="axis",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "severity",
+            _coerce_enum(
+                SyntheticWavelengthRobustnessSeverity,
+                self.severity,
+                field_name="severity",
+            ),
+        )
+        configuration = _mapping_copy(self.generator_configuration)
+        for required in ("generating_model", "mean_kind", "covariance_kind"):
+            if not str(configuration.get(required) or "").strip():
+                raise ValueError(
+                    f"generator_configuration requires {required!r}."
+                )
+        object.__setattr__(self, "generator_configuration", configuration)
+        reference = (
+            str(self.reference_scenario_id).strip()
+            if self.reference_scenario_id is not None
+            else None
+        )
+        object.__setattr__(self, "reference_scenario_id", reference or None)
+        object.__setattr__(
+            self,
+            "expected_failure",
+            _as_expected_failure(self.expected_failure),
+        )
+        object.__setattr__(
+            self,
+            "tags",
+            _deduplicated_strings(self.tags),
+        )
+        object.__setattr__(self, "schema_version", str(self.schema_version))
+        object.__setattr__(self, "extra_fields", _mapping_copy(self.extra_fields))
+
+    @classmethod
+    def from_mapping(
+        cls, payload: Mapping[str, Any]
+    ) -> SyntheticWavelengthRobustnessSpecification:
+        """Reconstruct a specification while retaining unknown fields."""
+        if not isinstance(payload, Mapping):
+            raise TypeError("payload must be a mapping")
+        known = {
+            "schema_version",
+            "scenario_id",
+            "axis",
+            "severity",
+            "description",
+            "generator_configuration",
+            "reference_scenario_id",
+            "expected_failure",
+            "tags",
+            "extra_fields",
+        }
+        extras = _mapping_copy(payload.get("extra_fields"))
+        for key, value in payload.items():
+            if key not in known:
+                extras[str(key)] = _json_safe(value)
+        return cls(
+            scenario_id=str(payload.get("scenario_id") or ""),
+            axis=_coerce_enum(
+                SyntheticWavelengthRobustnessAxis,
+                payload.get("axis"),
+                field_name="axis",
+            ),
+            severity=_coerce_enum(
+                SyntheticWavelengthRobustnessSeverity,
+                payload.get("severity"),
+                field_name="severity",
+            ),
+            description=str(payload.get("description") or ""),
+            generator_configuration=payload.get("generator_configuration") or {},
+            reference_scenario_id=payload.get("reference_scenario_id"),
+            expected_failure=_as_expected_failure(payload.get("expected_failure")),
+            tags=tuple(payload.get("tags") or ()),
+            schema_version=str(
+                payload.get("schema_version")
+                or SYNTHETIC_WAVELENGTH_ROBUSTNESS_SCHEMA_VERSION
+            ),
+            extra_fields=extras,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a stable JSON-safe specification."""
+        return {
+            "schema_version": self.schema_version,
+            "scenario_id": self.scenario_id,
+            "axis": self.axis.value,
+            "severity": self.severity.value,
+            "description": self.description,
+            "generator_configuration": _mapping_copy(
+                self.generator_configuration
+            ),
+            "reference_scenario_id": self.reference_scenario_id,
+            "expected_failure": (
+                self.expected_failure.to_dict()
+                if self.expected_failure is not None
+                else None
+            ),
+            "tags": list(self.tags),
+            "extra_fields": _mapping_copy(self.extra_fields),
+        }
+
+
+def make_synthetic_wavelength_robustness_case(
+    specification: SyntheticWavelengthRobustnessSpecification | Mapping[str, Any],
+    *,
+    seed: int = 0,
+) -> SyntheticWavelengthValidationCase:
+    """Build one truth-preserving D2 case from a declarative specification."""
+    if not isinstance(specification, SyntheticWavelengthRobustnessSpecification):
+        specification = SyntheticWavelengthRobustnessSpecification.from_mapping(
+            specification
+        )
+    configuration = dict(specification.generator_configuration)
+    configuration.update(
+        {
+            "scenario_id": specification.scenario_id,
+            "description": specification.description,
+            "seed": int(seed),
+        }
+    )
+    case = make_synthetic_wavelength_validation_case(**configuration)
+    scenario = case.scenario
+    tags = _deduplicated_strings(
+        (
+            "d2",
+            "synthetic",
+            specification.axis.value,
+            specification.severity.value,
+            *(item for item in scenario.tags if item != "d1"),
+            *specification.tags,
+        )
+    )
+    metadata = dict(scenario.metadata)
+    metadata.update(
+        {
+            "robustness_axis": specification.axis.value,
+            "robustness_severity": specification.severity.value,
+            "reference_scenario_id": specification.reference_scenario_id,
+            "robustness_schema_version": (
+                SYNTHETIC_WAVELENGTH_ROBUSTNESS_SCHEMA_VERSION
+            ),
+        }
+    )
+    sampling = dict(scenario.sampling_configuration)
+    sampling.update(
+        {
+            "robustness_axis": specification.axis.value,
+            "robustness_severity": specification.severity.value,
+            "reference_scenario_id": specification.reference_scenario_id,
+        }
+    )
+    fit_configuration = dict(scenario.fit_configuration)
+    fit_configuration.update(
+        {
+            "validation_phase": (
+                WavelengthValidationPhase.D2_ROBUSTNESS_FAILURE_BOUNDARY.value
+            ),
+            "selection_performed": False,
+        }
+    )
+    provenance = scenario.provenance
+    if provenance is not None:
+        provenance_configuration = dict(provenance.configuration)
+        provenance_configuration.update(
+            {
+                "robustness_schema_version": (
+                    SYNTHETIC_WAVELENGTH_ROBUSTNESS_SCHEMA_VERSION
+                ),
+                "robustness_axis": specification.axis.value,
+                "robustness_severity": specification.severity.value,
+            }
+        )
+        provenance = replace(
+            provenance,
+            source_identifier=specification.scenario_id,
+            configuration=provenance_configuration,
+        )
+    promoted = replace(
+        scenario,
+        phase=WavelengthValidationPhase.D2_ROBUSTNESS_FAILURE_BOUNDARY,
+        description=specification.description,
+        sampling_configuration=sampling,
+        fit_configuration=fit_configuration,
+        expected_failure=specification.expected_failure,
+        tags=tags,
+        provenance=provenance,
+        metadata=metadata,
+        extra_fields={
+            **dict(scenario.extra_fields),
+            **dict(specification.extra_fields),
+        },
+    )
+    return replace(
+        case,
+        scenario=promoted,
+        lightcurve_configuration={
+            **dict(case.lightcurve_configuration),
+            "name": specification.scenario_id,
+        },
+    )
+
+
+def _base_configuration(**updates: Any) -> dict[str, Any]:
+    configuration = {
+        "generating_model": "2DSeparable",
+        "mean_kind": "constant",
+        "covariance_kind": "separable_quasi_periodic_rbf",
+        "strength": "moderate",
+        "wavelengths": DEFAULT_VALIDATION_WAVELENGTHS,
+        "band_labels": DEFAULT_VALIDATION_BANDS,
+        "n_per_band": 72,
+        "period": 500.0,
+        "n_cycles": 3.2,
+        "irregular": True,
+        "shared_time_grid": True,
+        "noise_sigma": 0.15,
+        "heteroscedastic_fraction": 0.0,
+        "xtransform": "minmax",
+    }
+    configuration.update(updates)
+    return configuration
+
+
+def canonical_synthetic_wavelength_robustness_specifications(
+) -> tuple[SyntheticWavelengthRobustnessSpecification, ...]:
+    """Return the canonical controlled D2 perturbation specifications."""
+    reference_id = "d2-reference-separable-moderate"
+    insufficient_sampling = WavelengthValidationFailureExpectation(
+        failure_code="synthetic_recovery_fit_failed",
+        stage=ExecutionStage.OPTIMIZATION,
+        acceptable_exception_types=(
+            "FitError",
+            "PSDError",
+            "RuntimeError",
+            "ValueError",
+        ),
+        rationale=(
+            "Two rows per band are below the maintained wavelength-estimation "
+            "and consensus-quality requirements; the matched separable fit is "
+            "expected to fail cleanly rather than produce recovery evidence."
+        ),
+        diagnostics={
+            "applicable_models": ["2DSeparable"],
+            "boundary_kind": "insufficient_per_band_sampling",
+        },
+    )
+    definitions = (
+        (
+            reference_id,
+            SyntheticWavelengthRobustnessAxis.REFERENCE,
+            SyntheticWavelengthRobustnessSeverity.REFERENCE,
+            "Dense shared-grid separable reference for paired D2 comparisons.",
+            _base_configuration(),
+            None,
+        ),
+        (
+            "d2-independent-time-grids",
+            SyntheticWavelengthRobustnessAxis.INDEPENDENT_TIME_GRIDS,
+            SyntheticWavelengthRobustnessSeverity.MILD,
+            "Dense independent irregular time grids across wavelength bands.",
+            _base_configuration(shared_time_grid=False),
+            None,
+        ),
+        (
+            "d2-sparse-shared-grid",
+            SyntheticWavelengthRobustnessAxis.SPARSE_SAMPLING,
+            SyntheticWavelengthRobustnessSeverity.CHALLENGING,
+            "Thirty-six shared-grid observations per band over 3.2 periods.",
+            _base_configuration(
+                generating_model="2DWavelengthDependent",
+                mean_kind="quadratic",
+                n_per_band=36,
+            ),
+            None,
+        ),
+        (
+            "d2-uneven-band-counts",
+            SyntheticWavelengthRobustnessAxis.UNEVEN_BAND_COUNTS,
+            SyntheticWavelengthRobustnessSeverity.CHALLENGING,
+            "Strongly uneven observation counts on independent band grids.",
+            _base_configuration(
+                generating_model="2DDustMean",
+                mean_kind="dust",
+                strength="strong",
+                n_per_band=(72, 54, 42, 30, 24, 18),
+                shared_time_grid=False,
+            ),
+            None,
+        ),
+        (
+            "d2-longer-sparse-baseline",
+            SyntheticWavelengthRobustnessAxis.LONGER_SPARSE_BASELINE,
+            SyntheticWavelengthRobustnessSeverity.CHALLENGING,
+            "Thirty-six independent observations per band over 6.4 periods.",
+            _base_configuration(
+                generating_model="2DPowerLawMean",
+                mean_kind="power_law",
+                n_per_band=36,
+                n_cycles=6.4,
+                shared_time_grid=False,
+            ),
+            None,
+        ),
+        (
+            "d2-missing-blue-edge-band",
+            SyntheticWavelengthRobustnessAxis.MISSING_BLUE_EDGE_BAND,
+            SyntheticWavelengthRobustnessSeverity.MILD,
+            "Dense sampling after removal of the shortest-wavelength band.",
+            _base_configuration(
+                wavelengths=DEFAULT_VALIDATION_WAVELENGTHS[1:],
+                band_labels=DEFAULT_VALIDATION_BANDS[1:],
+            ),
+            None,
+        ),
+        (
+            "d2-missing-red-edge-band",
+            SyntheticWavelengthRobustnessAxis.MISSING_RED_EDGE_BAND,
+            SyntheticWavelengthRobustnessSeverity.MILD,
+            "Dense sampling after removal of the longest-wavelength band.",
+            _base_configuration(
+                wavelengths=DEFAULT_VALIDATION_WAVELENGTHS[:-1],
+                band_labels=DEFAULT_VALIDATION_BANDS[:-1],
+            ),
+            None,
+        ),
+        (
+            "d2-missing-interior-band",
+            SyntheticWavelengthRobustnessAxis.MISSING_INTERIOR_BAND,
+            SyntheticWavelengthRobustnessSeverity.CHALLENGING,
+            "Turning-point mean recovery after removal of an interior band.",
+            _base_configuration(
+                generating_model="2DWavelengthDependent",
+                mean_kind="quadratic",
+                strength="strong",
+                turning_point=True,
+                wavelengths=(0.55, 0.80, 1.25, 3.40, 4.60),
+                band_labels=("V", "I", "J", "W1", "W2"),
+            ),
+            None,
+        ),
+        (
+            "d2-large-wavelength-gap",
+            SyntheticWavelengthRobustnessAxis.LARGE_WAVELENGTH_GAP,
+            SyntheticWavelengthRobustnessSeverity.BOUNDARY,
+            "Four-band dust-mean case with a large J-to-W2 wavelength gap.",
+            _base_configuration(
+                generating_model="2DDustMean",
+                mean_kind="dust",
+                strength="strong",
+                wavelengths=(0.55, 0.80, 1.25, 4.60),
+                band_labels=("V", "I", "J", "W2"),
+            ),
+            None,
+        ),
+        (
+            "d2-heteroscedastic-noise",
+            SyntheticWavelengthRobustnessAxis.HETEROSCEDASTIC_NOISE,
+            SyntheticWavelengthRobustnessSeverity.CHALLENGING,
+            "Power-law mean with strongly heteroscedastic reported errors.",
+            _base_configuration(
+                generating_model="2DPowerLawMean",
+                mean_kind="power_law",
+                heteroscedastic_fraction=1.0,
+            ),
+            None,
+        ),
+        (
+            "d2-high-noise",
+            SyntheticWavelengthRobustnessAxis.HIGH_NOISE,
+            SyntheticWavelengthRobustnessSeverity.BOUNDARY,
+            "Quadratic wavelength mean with three-times nominal noise.",
+            _base_configuration(
+                generating_model="2DWavelengthDependent",
+                mean_kind="quadratic",
+                noise_sigma=0.45,
+            ),
+            None,
+        ),
+        (
+            "d2-weak-wavelength-dependence",
+            SyntheticWavelengthRobustnessAxis.WEAK_WAVELENGTH_DEPENDENCE,
+            SyntheticWavelengthRobustnessSeverity.BOUNDARY,
+            "Weak separable wavelength covariance and nearly constant mean.",
+            _base_configuration(strength="weak"),
+            None,
+        ),
+        (
+            "d2-strong-wavelength-dependence",
+            SyntheticWavelengthRobustnessAxis.STRONG_WAVELENGTH_DEPENDENCE,
+            SyntheticWavelengthRobustnessSeverity.CHALLENGING,
+            "Strong dust mean and short wavelength-correlation scale.",
+            _base_configuration(
+                generating_model="2DDustMean",
+                mean_kind="dust",
+                strength="strong",
+            ),
+            None,
+        ),
+        (
+            "d2-joint-sm-sparse-independent",
+            SyntheticWavelengthRobustnessAxis.JOINT_SM_SPARSE_ARD,
+            SyntheticWavelengthRobustnessSeverity.CHALLENGING,
+            "Joint spectral-mixture ARD case with sparse independent grids.",
+            _base_configuration(
+                generating_model="2D",
+                covariance_kind="joint_spectral_mixture_ard",
+                n_per_band=36,
+                shared_time_grid=False,
+            ),
+            None,
+        ),
+        (
+            "d2-insufficient-per-band-sampling",
+            SyntheticWavelengthRobustnessAxis.INSUFFICIENT_PER_BAND_SAMPLING,
+            SyntheticWavelengthRobustnessSeverity.INVALID,
+            "Two-band, two-row-per-band consensus failure boundary.",
+            _base_configuration(
+                wavelengths=(0.80, 3.40),
+                band_labels=("I", "W1"),
+                n_per_band=2,
+                shared_time_grid=False,
+            ),
+            insufficient_sampling,
+        ),
+    )
+    return tuple(
+        SyntheticWavelengthRobustnessSpecification(
+            scenario_id=scenario_id,
+            axis=axis,
+            severity=severity,
+            description=description,
+            generator_configuration=configuration,
+            reference_scenario_id=(
+                None
+                if axis is SyntheticWavelengthRobustnessAxis.REFERENCE
+                else reference_id
+            ),
+            expected_failure=expected_failure,
+        )
+        for (
+            scenario_id,
+            axis,
+            severity,
+            description,
+            configuration,
+            expected_failure,
+        ) in definitions
+    )
+
+
+def canonical_synthetic_wavelength_robustness_cases(
+    *, seed: int = 0
+) -> tuple[SyntheticWavelengthValidationCase, ...]:
+    """Build one deterministic case for every canonical D2 perturbation."""
+    return tuple(
+        make_synthetic_wavelength_robustness_case(
+            specification,
+            seed=int(seed) + index,
+        )
+        for index, specification in enumerate(
+            canonical_synthetic_wavelength_robustness_specifications()
+        )
+    )
+
+
+def _as_case(value: Any) -> SyntheticWavelengthValidationCase:
+    if isinstance(value, SyntheticWavelengthValidationCase):
+        case = value
+    elif isinstance(value, Mapping):
+        case = SyntheticWavelengthValidationCase.from_mapping(value)
+    else:
+        raise TypeError("case must be a synthetic validation case or mapping")
+    if (
+        case.scenario.phase
+        is not WavelengthValidationPhase.D2_ROBUSTNESS_FAILURE_BOUNDARY
+    ):
+        raise ValueError("D2 robustness runners require a D2 scenario.")
+    return case
+
+
+def _is_failed(run: WavelengthValidationRun) -> bool:
+    return bool(
+        run.status is not None
+        and run.status.technical_outcome is TechnicalOutcome.FAILED
+    )
+
+
+def _expectation_applies(
+    expectation: WavelengthValidationFailureExpectation,
+    model: str,
+) -> bool:
+    models = expectation.diagnostics.get("applicable_models")
+    if not models:
+        return True
+    return str(model) in {str(item) for item in models}
+
+
+def _evaluate_failure_expectation(
+    case: SyntheticWavelengthValidationCase,
+    run: WavelengthValidationRun,
+) -> dict[str, Any]:
+    expectation = case.scenario.expected_failure
+    actual_stage = (
+        run.failure.stage
+        if run.failure is not None
+        else (
+            run.status.execution_stage
+            if run.status is not None
+            else ExecutionStage.UNKNOWN
+        )
+    )
+    actual_technical = (
+        run.status.technical_outcome
+        if run.status is not None
+        else TechnicalOutcome.NOT_ATTEMPTED
+    )
+    actual_diagnostic = (
+        run.status.diagnostic_validity
+        if run.status is not None
+        else DiagnosticValidity.NOT_EVALUATED
+    )
+    actual_usability = (
+        run.status.scientific_usability
+        if run.status is not None
+        else ScientificUsability.NOT_EVALUATED
+    )
+    actual_eligibility = (
+        run.status.comparison_eligibility
+        if run.status is not None
+        else ComparisonEligibility.NOT_EVALUATED
+    )
+    if expectation is None:
+        return {
+            "expected": False,
+            "applicable": False,
+            "matched": None,
+            "unexpected_failure": _is_failed(run),
+            "actual_failure_code": (
+                run.failure.failure_code if run.failure is not None else None
+            ),
+            "actual_failure_stage": actual_stage.value,
+            "actual_exception_type": (
+                run.failure.exception_type if run.failure is not None else None
+            ),
+        }
+
+    applicable = _expectation_applies(expectation, run.model)
+    if not applicable:
+        return {
+            "expected": True,
+            "applicable": False,
+            "matched": None,
+            "unexpected_failure": _is_failed(run),
+            "expected_failure": expectation.to_dict(),
+            "actual_failure_code": (
+                run.failure.failure_code if run.failure is not None else None
+            ),
+            "actual_failure_stage": actual_stage.value,
+            "actual_exception_type": (
+                run.failure.exception_type if run.failure is not None else None
+            ),
+        }
+
+    actual_code = run.failure.failure_code if run.failure is not None else None
+    actual_exception = (
+        run.failure.exception_type if run.failure is not None else None
+    )
+    checks = {
+        "failure_code": actual_code == expectation.failure_code,
+        "stage": actual_stage is expectation.stage,
+        "technical_outcome": actual_technical is expectation.technical_outcome,
+        "diagnostic_validity": (
+            actual_diagnostic is expectation.diagnostic_validity
+        ),
+        "scientific_usability": (
+            actual_usability is expectation.scientific_usability
+        ),
+        "comparison_eligibility": (
+            actual_eligibility is expectation.comparison_eligibility
+        ),
+        "exception_type": (
+            not expectation.acceptable_exception_types
+            or actual_exception in expectation.acceptable_exception_types
+        ),
+    }
+    matched = all(checks.values())
+    return {
+        "expected": True,
+        "applicable": True,
+        "matched": matched,
+        "unexpected_failure": False,
+        "checks": checks,
+        "expected_failure": expectation.to_dict(),
+        "actual_failure_code": actual_code,
+        "actual_failure_stage": actual_stage.value,
+        "actual_exception_type": actual_exception,
+    }
+
+
+def _annotate_robustness_run(
+    case: SyntheticWavelengthValidationCase,
+    run: WavelengthValidationRun,
+) -> WavelengthValidationRun:
+    evaluation = _evaluate_failure_expectation(case, run)
+    if evaluation["expected"] and evaluation["applicable"]:
+        metric = WavelengthRecoveryMetric(
+            name="expected_failure_contract_matched",
+            value=evaluation["matched"],
+            truth_value=True,
+            available=True,
+            passed=bool(evaluation["matched"]),
+            direction=RecoveryMetricDirection.EXACT_MATCH,
+            scope="d2_failure_boundary",
+            model=run.model,
+            summary="Whether the classified failure matched the D2 contract.",
+            provenance={
+                "robustness_schema_version": (
+                    SYNTHETIC_WAVELENGTH_ROBUSTNESS_SCHEMA_VERSION
+                )
+            },
+        )
+    else:
+        absent = not bool(evaluation["unexpected_failure"])
+        metric = WavelengthRecoveryMetric(
+            name="unexpected_technical_failure_absent",
+            value=absent,
+            truth_value=True,
+            available=True,
+            passed=absent,
+            direction=RecoveryMetricDirection.EXACT_MATCH,
+            scope="d2_robustness",
+            model=run.model,
+            summary="Whether a non-expected D2 attempt avoided technical failure.",
+            provenance={
+                "robustness_schema_version": (
+                    SYNTHETIC_WAVELENGTH_ROBUSTNESS_SCHEMA_VERSION
+                )
+            },
+        )
+    scenario = case.scenario
+    return replace(
+        run,
+        metrics=(*run.metrics, metric),
+        notes=(*run.notes, "D2 robustness annotation applied."),
+        extra_fields={
+            **dict(run.extra_fields),
+            "validation_phase": (
+                WavelengthValidationPhase.D2_ROBUSTNESS_FAILURE_BOUNDARY.value
+            ),
+            "robustness_schema_version": (
+                SYNTHETIC_WAVELENGTH_ROBUSTNESS_SCHEMA_VERSION
+            ),
+            "robustness_axis": scenario.metadata.get("robustness_axis"),
+            "robustness_severity": scenario.metadata.get("robustness_severity"),
+            "reference_scenario_id": scenario.metadata.get(
+                "reference_scenario_id"
+            ),
+            "expected_failure_evaluation": evaluation,
+            "generating_model": scenario.truth.generating_model,
+        },
+    )
+
+
+def run_synthetic_wavelength_robustness(
+    case: SyntheticWavelengthValidationCase | Mapping[str, Any],
+    model: str | None = None,
+    *,
+    fit_kwargs: Mapping[str, Any] | None = None,
+    thresholds: SyntheticWavelengthRecoveryThresholds | Mapping[str, Any] | None = None,
+    lightcurve_factory: _LightcurveFactory | None = None,
+    fit_runner: _SyntheticFitRunner | None = None,
+    stop_on_error: bool = False,
+) -> WavelengthValidationRun:
+    """Execute and annotate one D2 synthetic robustness attempt."""
+    case = _as_case(case)
+    resolved_model = str(
+        model or case.scenario.truth.generating_model or ""
+    ).strip()
+    run = run_synthetic_wavelength_recovery(
+        case,
+        resolved_model,
+        fit_kwargs=fit_kwargs,
+        thresholds=thresholds,
+        lightcurve_factory=lightcurve_factory,
+        fit_runner=fit_runner,
+        stop_on_error=stop_on_error,
+    )
+    return _annotate_robustness_run(case, run)
+
+
+def _finite_float(value: Any) -> float | None:
+    try:
+        output = float(value)
+    except (TypeError, ValueError):
+        return None
+    return output if math.isfinite(output) else None
+
+
+def _metric_summaries(
+    runs: Sequence[WavelengthValidationRun],
+) -> dict[str, dict[str, Any]]:
+    grouped: dict[str, list[WavelengthRecoveryMetric]] = {}
+    for run in runs:
+        for metric in run.metrics:
+            grouped.setdefault(metric.name, []).append(metric)
+    output: dict[str, dict[str, Any]] = {}
+    for name, metrics in grouped.items():
+        available = [metric for metric in metrics if metric.available]
+        passed = [metric for metric in available if metric.passed is True]
+        failed = [metric for metric in available if metric.passed is False]
+        numeric = []
+        for metric in available:
+            if isinstance(metric.value, bool):
+                continue
+            value = _finite_float(metric.value)
+            if value is not None:
+                numeric.append(value)
+        summary: dict[str, Any] = {
+            "n_reported": len(metrics),
+            "n_available": len(available),
+            "n_unavailable": len(metrics) - len(available),
+            "n_passed": len(passed),
+            "n_failed": len(failed),
+            "pass_fraction": (
+                len(passed) / (len(passed) + len(failed))
+                if passed or failed
+                else None
+            ),
+        }
+        if numeric:
+            array = np.asarray(numeric, dtype=float)
+            summary.update(
+                {
+                    "minimum": float(np.min(array)),
+                    "median": float(np.median(array)),
+                    "maximum": float(np.max(array)),
+                    "p90": float(np.percentile(array, 90.0)),
+                }
+            )
+        output[name] = summary
+    return output
+
+
+def _group_summary(
+    runs: Sequence[WavelengthValidationRun],
+) -> dict[str, Any]:
+    completed_outcomes = {
+        TechnicalOutcome.COMPLETED,
+        TechnicalOutcome.COMPLETED_WITH_WARNINGS,
+        TechnicalOutcome.COMPLETED_WITH_RECOVERY,
+    }
+    n_completed = sum(
+        run.status is not None
+        and run.status.technical_outcome in completed_outcomes
+        for run in runs
+    )
+    evaluations = [
+        run.extra_fields.get("expected_failure_evaluation") or {}
+        for run in runs
+    ]
+    n_expected = sum(
+        bool(item.get("expected")) and bool(item.get("applicable"))
+        for item in evaluations
+    )
+    n_expected_matched = sum(item.get("matched") is True for item in evaluations)
+    n_expected_mismatched = sum(
+        item.get("matched") is False for item in evaluations
+    )
+    n_unexpected_failures = sum(
+        bool(item.get("unexpected_failure")) for item in evaluations
+    )
+    return {
+        "n_runs": len(runs),
+        "n_completed": n_completed,
+        "n_failed": len(runs) - n_completed,
+        "completion_fraction": n_completed / len(runs) if runs else None,
+        "n_expected_failure_contracts": n_expected,
+        "n_expected_failures_matched": n_expected_matched,
+        "n_expected_failures_mismatched": n_expected_mismatched,
+        "n_unexpected_failures": n_unexpected_failures,
+        "metric_summaries": _metric_summaries(runs),
+    }
+
+
+def aggregate_synthetic_wavelength_robustness_runs(
+    runs: Sequence[WavelengthValidationRun | Mapping[str, Any]],
+    *,
+    aggregate_id: str = "d2-synthetic-wavelength-robustness",
+) -> WavelengthValidationAggregate:
+    """Aggregate D2 runs without importing or weakening D1 gates."""
+    normalized = []
+    for run in runs:
+        if isinstance(run, WavelengthValidationRun):
+            normalized_run = run
+        elif isinstance(run, Mapping):
+            normalized_run = WavelengthValidationRun.from_mapping(run)
+        else:
+            raise TypeError("runs must contain validation runs or mappings")
+        phase = str(normalized_run.extra_fields.get("validation_phase") or "")
+        if phase != WavelengthValidationPhase.D2_ROBUSTNESS_FAILURE_BOUNDARY.value:
+            raise ValueError("D2 aggregates require D2-annotated robustness runs.")
+        normalized.append(normalized_run)
+
+    status_counts: dict[str, int] = {}
+    failures_by_stage: dict[str, int] = {}
+    failures_by_code: dict[str, int] = {}
+    by_model: dict[str, list[WavelengthValidationRun]] = {}
+    by_axis: dict[str, list[WavelengthValidationRun]] = {}
+    by_severity: dict[str, list[WavelengthValidationRun]] = {}
+    for run in normalized:
+        technical = (
+            run.status.technical_outcome.value
+            if run.status is not None
+            else "not_evaluated"
+        )
+        status_counts[technical] = status_counts.get(technical, 0) + 1
+        if run.failure is not None:
+            stage = run.failure.stage.value
+            code = run.failure.failure_code
+            failures_by_stage[stage] = failures_by_stage.get(stage, 0) + 1
+            failures_by_code[code] = failures_by_code.get(code, 0) + 1
+        by_model.setdefault(run.model, []).append(run)
+        axis = str(run.extra_fields.get("robustness_axis") or "unclassified")
+        severity = str(
+            run.extra_fields.get("robustness_severity") or "unclassified"
+        )
+        by_axis.setdefault(axis, []).append(run)
+        by_severity.setdefault(severity, []).append(run)
+
+    axis_summaries = {
+        name: _group_summary(group) for name, group in by_axis.items()
+    }
+    severity_summaries = {
+        name: _group_summary(group) for name, group in by_severity.items()
+    }
+    model_summaries = {
+        name: _group_summary(group) for name, group in by_model.items()
+    }
+    overall = _group_summary(normalized)
+    return WavelengthValidationAggregate(
+        aggregate_id=aggregate_id,
+        phase=WavelengthValidationPhase.D2_ROBUSTNESS_FAILURE_BOUNDARY,
+        scenario_ids=tuple(
+            dict.fromkeys(run.scenario_id for run in normalized)
+        ),
+        run_ids=tuple(run.run_id for run in normalized),
+        n_runs=len(normalized),
+        status_counts=status_counts,
+        metric_summaries=_metric_summaries(normalized),
+        model_summaries=model_summaries,
+        failure_summaries={
+            "by_stage": failures_by_stage,
+            "by_code": failures_by_code,
+            "n_failures": sum(failures_by_stage.values()),
+            "n_expected_failure_contracts": overall[
+                "n_expected_failure_contracts"
+            ],
+            "n_expected_failures_matched": overall[
+                "n_expected_failures_matched"
+            ],
+            "n_expected_failures_mismatched": overall[
+                "n_expected_failures_mismatched"
+            ],
+            "n_unexpected_failures": overall["n_unexpected_failures"],
+        },
+        notes=(
+            "D2 summaries describe robustness and failure boundaries; they are "
+            "not D1 recovery gates or automatic model-selection evidence.",
+        ),
+        automatic_model_selection_applied=False,
+        extra_fields={
+            "robustness_schema_version": (
+                SYNTHETIC_WAVELENGTH_ROBUSTNESS_SCHEMA_VERSION
+            ),
+            "axis_summaries": axis_summaries,
+            "severity_summaries": severity_summaries,
+            "overall_summary": overall,
+            "d2_boundary_summary": {
+                "empirical_boundaries_calibrated": False,
+                "d1_gates_reused_as_d2_gates": False,
+                "d1_thresholds_available_as_descriptive_metrics": True,
+                "automatic_model_selection_applied": False,
+            },
+        },
+    )
+
+
+@dataclass(frozen=True)
+class SyntheticWavelengthRobustnessReport:
+    """Typed collection of D2 runs and their failure-aware aggregate."""
+
+    report_id: str
+    cases: tuple[SyntheticWavelengthValidationCase, ...]
+    runs: tuple[WavelengthValidationRun, ...]
+    aggregate: WavelengthValidationAggregate
+    schema_version: str = SYNTHETIC_WAVELENGTH_ROBUSTNESS_SCHEMA_VERSION
+    notes: tuple[str, ...] = ()
+    advisory_only: bool = True
+    automatic_model_selection_applied: bool = False
+    extra_fields: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        report_id = str(self.report_id or "").strip()
+        if not report_id:
+            raise ValueError("report_id must be non-empty.")
+        object.__setattr__(self, "report_id", report_id)
+        normalized_cases = tuple(_as_case(case) for case in self.cases)
+        object.__setattr__(self, "cases", normalized_cases)
+        normalized_runs = []
+        for run in self.runs:
+            if isinstance(run, WavelengthValidationRun):
+                normalized_runs.append(run)
+            elif isinstance(run, Mapping):
+                normalized_runs.append(WavelengthValidationRun.from_mapping(run))
+            else:
+                raise TypeError("runs must contain validation run records")
+        object.__setattr__(self, "runs", tuple(normalized_runs))
+        if not isinstance(self.aggregate, WavelengthValidationAggregate):
+            object.__setattr__(
+                self,
+                "aggregate",
+                WavelengthValidationAggregate.from_mapping(self.aggregate),
+            )
+        if (
+            self.aggregate.phase
+            is not WavelengthValidationPhase.D2_ROBUSTNESS_FAILURE_BOUNDARY
+        ):
+            raise ValueError("Robustness reports require a D2 aggregate.")
+        if self.aggregate.n_runs != len(self.runs):
+            raise ValueError("aggregate.n_runs must match the number of runs.")
+        object.__setattr__(self, "schema_version", str(self.schema_version))
+        object.__setattr__(
+            self,
+            "notes",
+            tuple(str(item) for item in self.notes),
+        )
+        if self.advisory_only is not True:
+            raise ValueError("Robustness reports must remain advisory-only.")
+        if self.automatic_model_selection_applied is not False:
+            raise ValueError("Robustness reports cannot select a model.")
+        object.__setattr__(self, "extra_fields", _mapping_copy(self.extra_fields))
+
+    @classmethod
+    def from_mapping(
+        cls, payload: Mapping[str, Any]
+    ) -> SyntheticWavelengthRobustnessReport:
+        """Reconstruct a D2 report while retaining unknown fields."""
+        if not isinstance(payload, Mapping):
+            raise TypeError("payload must be a mapping")
+        known = {
+            "schema_version",
+            "report_id",
+            "cases",
+            "runs",
+            "aggregate",
+            "notes",
+            "advisory_only",
+            "automatic_model_selection_applied",
+            "extra_fields",
+        }
+        extras = _mapping_copy(payload.get("extra_fields"))
+        for key, value in payload.items():
+            if key not in known:
+                extras[str(key)] = _json_safe(value)
+        return cls(
+            report_id=str(payload.get("report_id") or ""),
+            cases=tuple(
+                SyntheticWavelengthValidationCase.from_mapping(item)
+                if isinstance(item, Mapping)
+                else item
+                for item in payload.get("cases") or ()
+            ),
+            runs=tuple(
+                WavelengthValidationRun.from_mapping(item)
+                if isinstance(item, Mapping)
+                else item
+                for item in payload.get("runs") or ()
+            ),
+            aggregate=WavelengthValidationAggregate.from_mapping(
+                payload.get("aggregate") or {}
+            ),
+            schema_version=str(
+                payload.get("schema_version")
+                or SYNTHETIC_WAVELENGTH_ROBUSTNESS_SCHEMA_VERSION
+            ),
+            notes=tuple(payload.get("notes") or ()),
+            advisory_only=payload.get("advisory_only", True),
+            automatic_model_selection_applied=payload.get(
+                "automatic_model_selection_applied", False
+            ),
+            extra_fields=extras,
+        )
+
+    def to_dict(self, *, include_observations: bool = True) -> dict[str, Any]:
+        """Return a stable JSON-safe D2 report envelope."""
+        return {
+            "schema_version": self.schema_version,
+            "report_id": self.report_id,
+            "cases": [
+                case.to_dict(include_observations=include_observations)
+                for case in self.cases
+            ],
+            "runs": [run.to_dict() for run in self.runs],
+            "aggregate": self.aggregate.to_dict(),
+            "notes": list(self.notes),
+            "advisory_only": True,
+            "automatic_model_selection_applied": False,
+            "extra_fields": _mapping_copy(self.extra_fields),
+        }
+
+
+def run_synthetic_wavelength_robustness_matrix(
+    cases: Sequence[SyntheticWavelengthValidationCase | Mapping[str, Any]],
+    *,
+    models: Sequence[str] | None = None,
+    fit_kwargs: Mapping[str, Any] | None = None,
+    per_model_fit_kwargs: Mapping[str, Mapping[str, Any]] | None = None,
+    thresholds: SyntheticWavelengthRecoveryThresholds | Mapping[str, Any] | None = None,
+    lightcurve_factory: _LightcurveFactory | None = None,
+    fit_runner: _SyntheticFitRunner | None = None,
+    stop_on_error: bool = False,
+    report_id: str = "d2-synthetic-wavelength-robustness",
+) -> SyntheticWavelengthRobustnessReport:
+    """Execute a failure-aware D2 matrix without model selection.
+
+    By default each case is fitted only with its generating model.  Passing
+    ``models`` requests an explicit case-by-model cross product.
+    """
+    normalized_cases = tuple(_as_case(case) for case in cases)
+    if not normalized_cases:
+        raise ValueError("cases must contain at least one D2 synthetic case.")
+    resolved_models = None
+    if models is not None:
+        resolved_models = tuple(str(model) for model in models)
+        if not resolved_models:
+            raise ValueError("models must contain at least one model.")
+        unsupported = [
+            model
+            for model in resolved_models
+            if model not in SUPPORTED_SYNTHETIC_RECOVERY_MODELS
+        ]
+        if unsupported:
+            raise ValueError(
+                "Unsupported synthetic robustness model(s): "
+                + ", ".join(unsupported)
+            )
+    per_model_fit_kwargs = dict(per_model_fit_kwargs or {})
+    runs = []
+    for case in normalized_cases:
+        case_models = (
+            resolved_models
+            if resolved_models is not None
+            else (case.scenario.truth.generating_model,)
+        )
+        for model in case_models:
+            model_configuration = dict(fit_kwargs or {})
+            model_configuration.update(
+                dict(per_model_fit_kwargs.get(model) or {})
+            )
+            runs.append(
+                run_synthetic_wavelength_robustness(
+                    case,
+                    model,
+                    fit_kwargs=model_configuration,
+                    thresholds=thresholds,
+                    lightcurve_factory=lightcurve_factory,
+                    fit_runner=fit_runner,
+                    stop_on_error=stop_on_error,
+                )
+            )
+    aggregate = aggregate_synthetic_wavelength_robustness_runs(
+        runs,
+        aggregate_id=report_id,
+    )
+    return SyntheticWavelengthRobustnessReport(
+        report_id=report_id,
+        cases=normalized_cases,
+        runs=tuple(runs),
+        aggregate=aggregate,
+        notes=(
+            "D2 completion, recovery, boundary, and expected-failure summaries "
+            "are descriptive validation outputs; no winner is installed.",
+        ),
+    )

--- a/tests/test_docs_wavelength_validation_robustness.py
+++ b/tests/test_docs_wavelength_validation_robustness.py
@@ -1,0 +1,54 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class TestSyntheticWavelengthRobustnessDocumentation(unittest.TestCase):
+    def test_robustness_module_is_in_public_api(self):
+        api = (ROOT / "docs/source/api.rst").read_text(encoding="utf-8")
+        page = ROOT / "docs/source/pgmuvi.wavelength_validation_robustness.rst"
+
+        self.assertIn("pgmuvi.wavelength_validation_robustness", api)
+        self.assertTrue(page.exists())
+        page_text = page.read_text(encoding="utf-8")
+        self.assertIn(
+            "automodule:: pgmuvi.wavelength_validation_robustness",
+            page_text,
+        )
+        normalized = " ".join(page_text.split())
+        self.assertIn("does not reuse the D1 population gates", normalized)
+        self.assertIn("expected failure remains a failed", normalized)
+        self.assertIn("empirical failure boundaries as not yet calibrated", normalized)
+        self.assertIn("maintained Jupyter notebook", normalized)
+        self.assertIn("do not rank models", normalized)
+
+    def test_package_exports_robustness_module_name(self):
+        package_init = (ROOT / "pgmuvi/__init__.py").read_text(encoding="utf-8")
+        self.assertIn('"wavelength_validation_robustness"', package_init)
+
+    def test_future_work_tracks_d2_calibration_and_notebook(self):
+        future = (ROOT / "docs/source/future_work.rst").read_text(
+            encoding="utf-8"
+        )
+        normalized = " ".join(future.split())
+
+        self.assertIn("core D2 robustness/failure-boundary", normalized)
+        self.assertIn("multi-seed D2 calibration", normalized)
+        self.assertIn("wavelength-constraint Jupyter notebook", normalized)
+
+    def test_notebook_status_tracks_constraint_walkthrough(self):
+        status = (ROOT / "docs/source/notebook_status.rst").read_text(
+            encoding="utf-8"
+        )
+        normalized = " ".join(status.split())
+
+        self.assertIn("TBD[wavelength-constraint-notebook]", status)
+        self.assertIn("wavelength-kernel scales and bounds", normalized)
+        self.assertIn("covariance constraints", normalized)
+        self.assertIn("sparse/noisy failure boundaries", normalized)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wavelength_validation_robustness.py
+++ b/tests/test_wavelength_validation_robustness.py
@@ -1,0 +1,488 @@
+import json
+import unittest
+
+from pgmuvi.wavelength_status import (
+    AttemptDisposition,
+    ComparisonEligibility,
+    DiagnosticValidity,
+    ExecutionStage,
+    ScientificUsability,
+    TechnicalOutcome,
+    WavelengthAttemptStatus,
+)
+from pgmuvi.wavelength_validation import WavelengthValidationPhase
+from pgmuvi.wavelength_validation_recovery import (
+    evaluate_synthetic_wavelength_recovery,
+)
+from pgmuvi.wavelength_validation_robustness import (
+    SYNTHETIC_WAVELENGTH_ROBUSTNESS_SCHEMA_VERSION,
+    SyntheticWavelengthRobustnessAxis,
+    SyntheticWavelengthRobustnessReport,
+    SyntheticWavelengthRobustnessSeverity,
+    SyntheticWavelengthRobustnessSpecification,
+    aggregate_synthetic_wavelength_robustness_runs,
+    canonical_synthetic_wavelength_robustness_cases,
+    canonical_synthetic_wavelength_robustness_specifications,
+    make_synthetic_wavelength_robustness_case,
+    run_synthetic_wavelength_robustness,
+    run_synthetic_wavelength_robustness_matrix,
+)
+from pgmuvi.wavelength_validation_synthetic import (
+    DEFAULT_VALIDATION_CANDIDATES,
+    make_synthetic_wavelength_validation_case,
+)
+
+
+class RobustnessCaseMixin:
+    def make_specification(self, **overrides):
+        kwargs = {
+            "scenario_id": "d2-test-sparse",
+            "axis": "sparse_sampling",
+            "severity": "challenging",
+            "description": "Small deterministic D2 test case.",
+            "generator_configuration": {
+                "generating_model": "2DWavelengthDependent",
+                "mean_kind": "quadratic",
+                "covariance_kind": "separable_quasi_periodic_rbf",
+                "strength": "strong",
+                "wavelengths": (0.6, 1.0, 2.0),
+                "band_labels": ("r", "J", "K"),
+                "n_per_band": 6,
+                "period": 100.0,
+                "n_cycles": 3.0,
+                "noise_sigma": 0.05,
+                "shared_time_grid": True,
+            },
+            "reference_scenario_id": "d2-test-reference",
+        }
+        kwargs.update(overrides)
+        return SyntheticWavelengthRobustnessSpecification(**kwargs)
+
+    def make_case(self, **overrides):
+        seed = overrides.pop("seed", 17)
+        specification = self.make_specification(**overrides)
+        return make_synthetic_wavelength_robustness_case(
+            specification,
+            seed=seed,
+        )
+
+    def truth_outputs(self, case):
+        truth = case.scenario.truth
+        return {
+            "fitted_period": truth.temporal_parameters["fundamental_period"],
+            "fitted_wavelength_lengthscale": (
+                truth.wavelength_covariance_parameters[
+                    "wavelength_lengthscale"
+                ]
+            ),
+            "fitted_mean_by_band": truth.noiseless_summary["mean_by_band"],
+            "boundary_hits": [],
+            "diagnostics": {"source": "test_hook"},
+            "parameter_workflow": {"available": True},
+        }
+
+
+class TestRobustnessSpecifications(RobustnessCaseMixin, unittest.TestCase):
+    def test_specification_round_trip_is_json_safe(self):
+        specification = self.make_specification()
+        payload = specification.to_dict()
+        payload["future_field"] = {"retained": True}
+        rebuilt = SyntheticWavelengthRobustnessSpecification.from_mapping(
+            payload
+        )
+
+        self.assertEqual(rebuilt.extra_fields["future_field"], {"retained": True})
+        json.dumps(rebuilt.to_dict(), allow_nan=False)
+
+    def test_specification_requires_generator_model_and_families(self):
+        with self.assertRaisesRegex(ValueError, "generating_model"):
+            self.make_specification(generator_configuration={})
+
+    def test_case_is_promoted_to_d2_without_changing_truth_arrays(self):
+        specification = self.make_specification()
+        case = make_synthetic_wavelength_robustness_case(specification, seed=3)
+        direct = make_synthetic_wavelength_validation_case(
+            scenario_id=specification.scenario_id,
+            description=specification.description,
+            seed=3,
+            **dict(specification.generator_configuration),
+        )
+
+        self.assertEqual(case.time_values, direct.time_values)
+        self.assertEqual(case.observed_flux, direct.observed_flux)
+        self.assertEqual(
+            case.scenario.phase,
+            WavelengthValidationPhase.D2_ROBUSTNESS_FAILURE_BOUNDARY,
+        )
+        self.assertEqual(
+            case.scenario.metadata["robustness_axis"], "sparse_sampling"
+        )
+        self.assertEqual(
+            case.scenario.metadata["reference_scenario_id"],
+            "d2-test-reference",
+        )
+        self.assertIn("d2", case.scenario.tags)
+        self.assertNotIn("d1", case.scenario.tags)
+        self.assertFalse(case.scenario.fit_configuration["selection_performed"])
+
+    def test_case_round_trip_preserves_d2_phase_and_expectation(self):
+        specifications = canonical_synthetic_wavelength_robustness_specifications()
+        failure_specification = next(
+            item for item in specifications if item.expected_failure is not None
+        )
+        case = make_synthetic_wavelength_robustness_case(
+            failure_specification,
+            seed=11,
+        )
+        rebuilt = type(case).from_mapping(case.to_dict())
+
+        self.assertEqual(
+            rebuilt.scenario.phase,
+            WavelengthValidationPhase.D2_ROBUSTNESS_FAILURE_BOUNDARY,
+        )
+        self.assertEqual(
+            rebuilt.scenario.expected_failure.failure_code,
+            "synthetic_recovery_fit_failed",
+        )
+        json.dumps(rebuilt.to_dict(), allow_nan=False)
+
+
+class TestCanonicalRobustnessCases(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.specifications = (
+            canonical_synthetic_wavelength_robustness_specifications()
+        )
+        cls.cases = canonical_synthetic_wavelength_robustness_cases(seed=101)
+
+    def test_canonical_set_has_unique_ids_and_all_declared_axes(self):
+        identifiers = [item.scenario_id for item in self.specifications]
+        axes = {item.axis for item in self.specifications}
+
+        self.assertEqual(len(identifiers), len(set(identifiers)))
+        self.assertIn(SyntheticWavelengthRobustnessAxis.REFERENCE, axes)
+        self.assertIn(
+            SyntheticWavelengthRobustnessAxis.INSUFFICIENT_PER_BAND_SAMPLING,
+            axes,
+        )
+        self.assertIn(SyntheticWavelengthRobustnessAxis.LARGE_WAVELENGTH_GAP, axes)
+        self.assertIn(SyntheticWavelengthRobustnessAxis.JOINT_SM_SPARSE_ARD, axes)
+
+    def test_canonical_set_covers_maintained_models_only(self):
+        models = {
+            case.scenario.truth.generating_model for case in self.cases
+        }
+
+        self.assertEqual(models, set(DEFAULT_VALIDATION_CANDIDATES))
+        self.assertNotIn("2DAchromatic", models)
+
+    def test_canonical_cases_are_d2_positive_linear_flux(self):
+        for case in self.cases:
+            with self.subTest(case=case.scenario.scenario_id):
+                self.assertEqual(
+                    case.scenario.phase,
+                    WavelengthValidationPhase.D2_ROBUSTNESS_FAILURE_BOUNDARY,
+                )
+                self.assertGreater(min(case.observed_flux), 0.0)
+                self.assertTrue(
+                    case.scenario.truth.noiseless_summary["linear_flux"]
+                )
+
+    def test_expected_failure_is_reserved_for_invalid_boundary(self):
+        expected = [
+            case for case in self.cases if case.scenario.expected_failure is not None
+        ]
+
+        self.assertEqual(len(expected), 1)
+        case = expected[0]
+        self.assertEqual(
+            case.scenario.metadata["robustness_severity"],
+            SyntheticWavelengthRobustnessSeverity.INVALID.value,
+        )
+        self.assertEqual(
+            case.scenario.sampling_configuration["n_per_band"], [2, 2]
+        )
+
+
+class TestRobustnessRun(RobustnessCaseMixin, unittest.TestCase):
+    def test_successful_nonfailure_case_gets_d2_annotation(self):
+        case = self.make_case()
+        run = run_synthetic_wavelength_robustness(
+            case,
+            lightcurve_factory=lambda _: object(),
+            fit_runner=lambda _lc, _kwargs, item: self.truth_outputs(item),
+        )
+        by_name = {metric.name: metric for metric in run.metrics}
+        evaluation = run.extra_fields["expected_failure_evaluation"]
+
+        self.assertEqual(run.model, "2DWavelengthDependent")
+        self.assertFalse(evaluation["expected"])
+        self.assertFalse(evaluation["unexpected_failure"])
+        self.assertTrue(
+            by_name["unexpected_technical_failure_absent"].passed
+        )
+        self.assertEqual(
+            run.extra_fields["validation_phase"],
+            WavelengthValidationPhase.D2_ROBUSTNESS_FAILURE_BOUNDARY.value,
+        )
+
+    def test_matching_expected_failure_remains_failed_and_is_classified(self):
+        specification = next(
+            item
+            for item in canonical_synthetic_wavelength_robustness_specifications()
+            if item.expected_failure is not None
+        )
+        case = make_synthetic_wavelength_robustness_case(specification, seed=5)
+
+        def fail(_lightcurve, _fit_kwargs, _case):
+            raise RuntimeError("deliberate consensus failure")
+
+        run = run_synthetic_wavelength_robustness(
+            case,
+            lightcurve_factory=lambda _: object(),
+            fit_runner=fail,
+        )
+        evaluation = run.extra_fields["expected_failure_evaluation"]
+        metric = {item.name: item for item in run.metrics}[
+            "expected_failure_contract_matched"
+        ]
+
+        self.assertEqual(
+            run.status.technical_outcome,
+            TechnicalOutcome.FAILED,
+        )
+        self.assertTrue(evaluation["matched"])
+        self.assertTrue(metric.passed)
+
+    def test_mismatched_failure_stage_is_preserved(self):
+        specification = next(
+            item
+            for item in canonical_synthetic_wavelength_robustness_specifications()
+            if item.expected_failure is not None
+        )
+        case = make_synthetic_wavelength_robustness_case(specification, seed=5)
+
+        def fail_factory(_case):
+            raise RuntimeError("construction failed")
+
+        run = run_synthetic_wavelength_robustness(
+            case,
+            lightcurve_factory=fail_factory,
+        )
+        evaluation = run.extra_fields["expected_failure_evaluation"]
+
+        self.assertFalse(evaluation["matched"])
+        self.assertFalse(evaluation["checks"]["stage"])
+        self.assertEqual(run.failure.stage, ExecutionStage.SETUP)
+
+    def test_d1_case_is_rejected_by_d2_runner(self):
+        d1_case = make_synthetic_wavelength_validation_case(
+            scenario_id="d1-not-d2",
+            generating_model="2DSeparable",
+            mean_kind="constant",
+            covariance_kind="separable_quasi_periodic_rbf",
+            wavelengths=(0.6, 1.0, 2.0),
+            band_labels=("r", "J", "K"),
+            n_per_band=4,
+            period=100.0,
+            n_cycles=3.0,
+            seed=1,
+        )
+
+        with self.assertRaisesRegex(ValueError, "require a D2 scenario"):
+            run_synthetic_wavelength_robustness(d1_case)
+
+    def test_explicit_nonapplicable_failure_contract_uses_ordinary_semantics(self):
+        specification = next(
+            item
+            for item in canonical_synthetic_wavelength_robustness_specifications()
+            if item.expected_failure is not None
+        )
+        case = make_synthetic_wavelength_robustness_case(specification, seed=5)
+        status = WavelengthAttemptStatus(
+            disposition=AttemptDisposition.ATTEMPTED,
+            execution_stage=ExecutionStage.COMPLETED,
+            technical_outcome=TechnicalOutcome.COMPLETED,
+            diagnostic_validity=DiagnosticValidity.VALID,
+            scientific_usability=ScientificUsability.USABLE,
+            comparison_eligibility=ComparisonEligibility.ELIGIBLE,
+        )
+
+        run = run_synthetic_wavelength_robustness(
+            case,
+            model="2D",
+            lightcurve_factory=lambda _: object(),
+            fit_runner=lambda _lc, _kwargs, _case: {
+                **self.truth_outputs(case),
+                "status": status,
+            },
+        )
+        evaluation = run.extra_fields["expected_failure_evaluation"]
+
+        self.assertTrue(evaluation["expected"])
+        self.assertFalse(evaluation["applicable"])
+        self.assertIsNone(evaluation["matched"])
+        self.assertFalse(evaluation["unexpected_failure"])
+
+
+class TestRobustnessAggregate(RobustnessCaseMixin, unittest.TestCase):
+    def make_success(self, case):
+        return run_synthetic_wavelength_robustness(
+            case,
+            lightcurve_factory=lambda _: object(),
+            fit_runner=lambda _lc, _kwargs, item: self.truth_outputs(item),
+        )
+
+    def test_aggregate_rejects_unannotated_d1_run(self):
+        d1_case = make_synthetic_wavelength_validation_case(
+            scenario_id="d1-aggregate-rejection",
+            generating_model="2DWavelengthDependent",
+            mean_kind="quadratic",
+            covariance_kind="separable_quasi_periodic_rbf",
+            strength="strong",
+            wavelengths=(0.6, 1.0, 2.0),
+            band_labels=("r", "J", "K"),
+            n_per_band=6,
+            period=100.0,
+            n_cycles=3.0,
+            noise_sigma=0.05,
+            seed=4,
+        )
+        run = evaluate_synthetic_wavelength_recovery(
+            d1_case,
+            "2DWavelengthDependent",
+            **self.truth_outputs(d1_case),
+        )
+
+        with self.assertRaisesRegex(ValueError, "D2-annotated"):
+            aggregate_synthetic_wavelength_robustness_runs([run])
+
+    def test_aggregate_reports_axes_without_d1_gate_summary(self):
+        first = self.make_case()
+        second = self.make_case(
+            scenario_id="d2-test-noise",
+            axis="high_noise",
+            severity="boundary",
+        )
+        aggregate = aggregate_synthetic_wavelength_robustness_runs(
+            [self.make_success(first), self.make_success(second)]
+        )
+        extras = aggregate.extra_fields
+
+        self.assertEqual(
+            aggregate.phase,
+            WavelengthValidationPhase.D2_ROBUSTNESS_FAILURE_BOUNDARY,
+        )
+        self.assertIn("sparse_sampling", extras["axis_summaries"])
+        self.assertIn("high_noise", extras["axis_summaries"])
+        self.assertFalse(
+            extras["d2_boundary_summary"]["empirical_boundaries_calibrated"]
+        )
+        self.assertFalse(
+            extras["d2_boundary_summary"]["d1_gates_reused_as_d2_gates"]
+        )
+        self.assertNotIn("d1_gate_summary", extras)
+        self.assertFalse(aggregate.automatic_model_selection_applied)
+
+    def test_aggregate_separates_expected_and_unexpected_failures(self):
+        ordinary = self.make_case()
+
+        def fail(_lightcurve, _fit_kwargs, _case):
+            raise RuntimeError("unexpected")
+
+        unexpected = run_synthetic_wavelength_robustness(
+            ordinary,
+            lightcurve_factory=lambda _: object(),
+            fit_runner=fail,
+        )
+        specification = next(
+            item
+            for item in canonical_synthetic_wavelength_robustness_specifications()
+            if item.expected_failure is not None
+        )
+        expected_case = make_synthetic_wavelength_robustness_case(
+            specification,
+            seed=8,
+        )
+        expected = run_synthetic_wavelength_robustness(
+            expected_case,
+            lightcurve_factory=lambda _: object(),
+            fit_runner=fail,
+        )
+        aggregate = aggregate_synthetic_wavelength_robustness_runs(
+            [unexpected, expected]
+        )
+
+        self.assertEqual(
+            aggregate.failure_summaries["n_expected_failures_matched"], 1
+        )
+        self.assertEqual(aggregate.failure_summaries["n_unexpected_failures"], 1)
+        self.assertEqual(aggregate.failure_summaries["n_failures"], 2)
+
+    def test_matrix_defaults_to_each_generating_model(self):
+        first = self.make_case()
+        second = self.make_case(
+            scenario_id="d2-test-dust",
+            axis="uneven_band_counts",
+            generator_configuration={
+                **dict(self.make_specification().generator_configuration),
+                "generating_model": "2DDustMean",
+                "mean_kind": "dust",
+            },
+        )
+
+        report = run_synthetic_wavelength_robustness_matrix(
+            [first, second],
+            lightcurve_factory=lambda _: object(),
+            fit_runner=lambda _lc, _kwargs, case: self.truth_outputs(case),
+            report_id="matched-model-report",
+        )
+
+        self.assertEqual(len(report.runs), 2)
+        self.assertEqual(
+            {run.model for run in report.runs},
+            {"2DWavelengthDependent", "2DDustMean"},
+        )
+
+    def test_explicit_models_request_cross_product(self):
+        case = self.make_case()
+        report = run_synthetic_wavelength_robustness_matrix(
+            [case],
+            models=("2DWavelengthDependent", "2DSeparable"),
+            lightcurve_factory=lambda _: object(),
+            fit_runner=lambda _lc, _kwargs, item: self.truth_outputs(item),
+        )
+
+        self.assertEqual(len(report.runs), 2)
+
+    def test_report_round_trip_preserves_unknown_fields(self):
+        case = self.make_case()
+        run = self.make_success(case)
+        aggregate = aggregate_synthetic_wavelength_robustness_runs([run])
+        report = SyntheticWavelengthRobustnessReport(
+            report_id="round-trip",
+            cases=(case,),
+            runs=(run,),
+            aggregate=aggregate,
+        )
+        payload = report.to_dict()
+        payload["future_report_field"] = {"retained": True}
+        rebuilt = SyntheticWavelengthRobustnessReport.from_mapping(payload)
+
+        self.assertEqual(
+            rebuilt.extra_fields["future_report_field"], {"retained": True}
+        )
+        self.assertEqual(
+            rebuilt.schema_version,
+            SYNTHETIC_WAVELENGTH_ROBUSTNESS_SCHEMA_VERSION,
+        )
+        self.assertFalse(rebuilt.automatic_model_selection_applied)
+        json.dumps(rebuilt.to_dict(), allow_nan=False)
+
+    def test_empty_matrix_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "at least one"):
+            run_synthetic_wavelength_robustness_matrix([])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add typed D2 robustness specifications and truth-preserving synthetic cases;
- define canonical sparse, uneven, missing-band, large-gap, noisy, weak/strong-dependence, and joint-ARD scenarios;
- add matched-model and optional cross-model robustness execution;
- preserve classified expected failures and distinguish them from unexpected technical failures;
- add D2-specific, failure-aware aggregation without reusing or weakening D1 recovery gates;
- expose and document the new public validation module;
- register the remaining multi-seed calibration and dedicated wavelength-constraint notebook as future work.

## Validation

- targeted D2 robustness tests passed;
- existing wavelength-validation regression tests passed;
- Ruff passed;
- strict Sphinx documentation build passed;
- complete unittest suite passed after fixing the TBD-marker registry entry.

## Scientific boundary

These outputs remain advisory validation artifacts. They do not rank models, select a winner, or install a fitted model automatically.