### PR TITLE
Execute and document wavelength robustness calibration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,6 @@ debug*.txt
 *.orig
 *.rej
 pgmuvi_current*.zip
+
+# Local synthetic-validation and calibration outputs
+validation_outputs/

--- a/docs/source/future_work.rst
+++ b/docs/source/future_work.rst
@@ -119,6 +119,12 @@ Documentation tutorial extensions
     and covariance constraints, and the empirically tested D2 failure
     boundaries.
 
+**D2 evidence available:** a canonical 20-seed, 420-run robustness
+calibration has now established the empirical cases that the notebook must
+explain, including uneven-band-count and longer-sparse-baseline failure
+boundaries, large-wavelength-gap degradation, reproducible invalid-sampling
+failure, and joint-``2D`` ARD boundary pressure.
+
 **TBD[batch-notebook]**
     Add a maintained notebook for the batch wavelength-advisory workflow.
     The current command-line walkthrough and deterministic preparation script

--- a/docs/source/notebook_status.rst
+++ b/docs/source/notebook_status.rst
@@ -88,6 +88,13 @@ and diagnosed.  It must distinguish covariance constraints from wavelength-
 dependent mean constraints and explain the tested sparse/noisy failure
 boundaries before it is added to the Tutorials toctree.
 
+**D2 calibration prerequisite completed:** the canonical 20-seed,
+420-run robustness calibration is now recorded in
+:mod:`pgmuvi.wavelength_validation_robustness_calibration`.  The notebook
+itself remains outstanding and should use those empirical robust,
+degraded, failure-boundary, and expected-failure-boundary results without
+turning them into automatic model-selection rules.
+
 Notebook maintenance rules
 --------------------------
 

--- a/docs/source/pgmuvi.wavelength_validation_robustness_calibration.rst
+++ b/docs/source/pgmuvi.wavelength_validation_robustness_calibration.rst
@@ -1,6 +1,53 @@
 Synthetic wavelength robustness calibration
 ===========================================
 
+Twenty-seed empirical calibration
+---------------------------------
+
+PR133 executed the canonical D2 robustness matrix for base seeds 0 through 19:
+420 canonical runs spanning seven truth-matched references, thirteen
+scientifically valid perturbations, and one explicit invalid-sampling
+scenario.  The run completed with 393 completed fits and 27 recorded
+failures.
+
+Twenty failures came from
+``d2-insufficient-per-band-sampling``.  Every one matched the declared
+expected-failure contract.  The remaining seven failures were structured
+consensus-stage rejections rather than optimizer crashes: six occurred for
+base seed 7 and one for base seed 10.  Their preserved diagnostics report
+either ``insufficient_consensus_inliers`` or ``no_accepted_bands``.
+
+The empirical advisory classifications were:
+
+* seven reference populations;
+* ten robust perturbations;
+* one degraded perturbation, ``d2-large-wavelength-gap``;
+* two failure boundaries, ``d2-uneven-band-counts`` and
+  ``d2-longer-sparse-baseline``; and
+* one reproducible expected-failure boundary,
+  ``d2-insufficient-per-band-sampling``.
+
+The longer sparse baseline is primarily a period-recovery boundary: only
+4 of 20 runs passed the configured period criterion.  Uneven per-band
+counts are primarily a wavelength-lengthscale recovery boundary: only 8
+of 19 completed runs passed that criterion.  A large wavelength gap is
+measurably degraded but remains below the configured failure-boundary
+threshold.
+
+For the joint ``2D`` spectral-mixture reference and sparse perturbation,
+both temporal and wavelength ARD parameters were near their configured
+bounds in every run while recovery remained robust.  Boundary pressure is
+therefore reported separately and must not be interpreted as recovery
+failure or as evidence for achromatic variability.
+
+These results are advisory evidence only.  They do not perform automatic
+model selection.  Generated run records and reports remain local under
+``validation_outputs/`` and are intentionally excluded from version
+control.  The maintained wavelength-constraint notebook remains the next
+documentation step and should explain these empirical boundaries alongside
+constraint provenance, initialization, fitted values, and distances from
+bounds.
+
 .. automodule:: pgmuvi.wavelength_validation_robustness_calibration
    :members:
    :undoc-members:

--- a/pgmuvi/wavelength_validation_recovery.py
+++ b/pgmuvi/wavelength_validation_recovery.py
@@ -1296,6 +1296,19 @@ def _failure_record(
     stage: ExecutionStage,
     substage: str,
 ) -> WavelengthFailureRecord:
+    exception_type = exception.__class__
+    exception_mro = tuple(
+        item.__name__ for item in exception_type.__mro__
+    )
+    diagnostics = {
+        "exception_type": exception_type.__name__,
+        "exception_module": exception_type.__module__,
+        "exception_qualname": exception_type.__qualname__,
+        "exception_mro": list(exception_mro),
+    }
+    structured = getattr(exception, "failure_diagnostics", None)
+    if isinstance(structured, Mapping):
+        diagnostics["structured_failure_diagnostics"] = _json_safe(structured)
     return WavelengthFailureRecord(
         failure_code=(
             "synthetic_recovery_fit_failed"
@@ -1304,9 +1317,9 @@ def _failure_record(
         ),
         stage=stage,
         substage=substage,
-        exception_type=exception.__class__.__name__,
+        exception_type=exception_type.__name__,
         message=str(exception),
-        diagnostics={"exception_type": exception.__class__.__name__},
+        diagnostics=diagnostics,
         traceback_reference=None,
     )
 

--- a/pgmuvi/wavelength_validation_robustness.py
+++ b/pgmuvi/wavelength_validation_robustness.py
@@ -789,6 +789,32 @@ def _expectation_applies(
     return str(model) in {str(item) for item in models}
 
 
+def _exception_type_matches_expectation(
+    run: WavelengthValidationRun,
+    acceptable_exception_types: Sequence[str],
+) -> bool:
+    """Match serialized exception names with captured subclass provenance."""
+    acceptable = {str(item) for item in acceptable_exception_types}
+    if not acceptable:
+        return True
+    if run.failure is None:
+        return False
+    actual = str(run.failure.exception_type or "")
+    if actual in acceptable:
+        return True
+    diagnostics = run.failure.diagnostics
+    hierarchy = (
+        diagnostics.get("exception_mro")
+        if isinstance(diagnostics, Mapping)
+        else None
+    )
+    if not isinstance(hierarchy, Sequence) or isinstance(
+        hierarchy, (str, bytes, bytearray)
+    ):
+        return False
+    return any(str(item) in acceptable for item in hierarchy)
+
+
 def _evaluate_failure_expectation(
     case: SyntheticWavelengthValidationCase,
     run: WavelengthValidationRun,
@@ -872,9 +898,8 @@ def _evaluate_failure_expectation(
         "comparison_eligibility": (
             actual_eligibility is expectation.comparison_eligibility
         ),
-        "exception_type": (
-            not expectation.acceptable_exception_types
-            or actual_exception in expectation.acceptable_exception_types
+        "exception_type": _exception_type_matches_expectation(
+            run, expectation.acceptable_exception_types
         ),
     }
     matched = all(checks.values())
@@ -888,6 +913,12 @@ def _evaluate_failure_expectation(
         "actual_failure_code": actual_code,
         "actual_failure_stage": actual_stage.value,
         "actual_exception_type": actual_exception,
+        "actual_exception_mro": (
+            list(run.failure.diagnostics.get("exception_mro") or ())
+            if run.failure is not None
+            and isinstance(run.failure.diagnostics, Mapping)
+            else []
+        ),
     }
 
 

--- a/tests/test_docs_wavelength_validation_robustness_empirical.py
+++ b/tests/test_docs_wavelength_validation_robustness_empirical.py
@@ -1,0 +1,55 @@
+"""Documentation contract for the PR133 empirical D2 calibration."""
+
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class TestWavelengthRobustnessEmpiricalDocumentation(unittest.TestCase):
+    def test_empirical_calibration_is_recorded(self):
+        text = (
+            ROOT
+            / "docs"
+            / "source"
+            / "pgmuvi.wavelength_validation_robustness_calibration.rst"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("Twenty-seed empirical calibration", text)
+        self.assertIn("420 canonical runs", text)
+        self.assertIn("393 completed fits", text)
+        self.assertIn("d2-uneven-band-counts", text)
+        self.assertIn("d2-longer-sparse-baseline", text)
+        self.assertIn("d2-large-wavelength-gap", text)
+        self.assertIn("advisory evidence only", text)
+        self.assertIn("validation_outputs/", text)
+
+    def test_notebook_todo_retains_calibration_context(self):
+        notebook_status = (
+            ROOT / "docs" / "source" / "notebook_status.rst"
+        ).read_text(encoding="utf-8")
+        future_work = (
+            ROOT / "docs" / "source" / "future_work.rst"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn(
+            "TBD[wavelength-constraint-notebook]",
+            notebook_status,
+        )
+        self.assertIn("canonical 20-seed", notebook_status)
+        self.assertIn(
+            "TBD[wavelength-constraint-notebook]",
+            future_work,
+        )
+        self.assertIn("canonical 20-seed", future_work)
+
+    def test_generated_validation_outputs_are_ignored(self):
+        patterns = (
+            ROOT / ".gitignore"
+        ).read_text(encoding="utf-8").splitlines()
+        self.assertIn("validation_outputs/", patterns)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wavelength_validation_recovery.py
+++ b/tests/test_wavelength_validation_recovery.py
@@ -566,6 +566,41 @@ class TestSyntheticRecoveryRun(RecoveryCaseMixin, unittest.TestCase):
         self.assertEqual(run.status.execution_stage, ExecutionStage.OPTIMIZATION)
         self.assertEqual(run.failure.exception_type, "RuntimeError")
 
+    def test_fit_exception_preserves_structured_failure_diagnostics(self):
+        case = self.make_case()
+
+        class ConsensusLikeError(RuntimeError):
+            def __init__(self):
+                super().__init__("consensus rejected")
+                self.failure_diagnostics = {
+                    "reason": "insufficient_consensus_inliers",
+                    "accepted_bands": ("J",),
+                    "nonfinite_value": float("nan"),
+                }
+
+        def fail(*_args):
+            raise ConsensusLikeError()
+
+        run = run_synthetic_wavelength_recovery(
+            case,
+            "2DSeparable",
+            lightcurve_factory=lambda _: object(),
+            fit_runner=fail,
+        )
+
+        diagnostics = run.failure.diagnostics
+        structured = diagnostics["structured_failure_diagnostics"]
+
+        self.assertEqual(run.failure.exception_type, "ConsensusLikeError")
+        self.assertIn("RuntimeError", diagnostics["exception_mro"])
+        self.assertEqual(
+            structured["reason"],
+            "insufficient_consensus_inliers",
+        )
+        self.assertEqual(structured["accepted_bands"], ["J"])
+        self.assertIsNone(structured["nonfinite_value"])
+        json.dumps(run.to_dict(), allow_nan=False)
+
     def test_stop_on_error_reraises_fit_exception(self):
         case = self.make_case()
 

--- a/tests/test_wavelength_validation_robustness.py
+++ b/tests/test_wavelength_validation_robustness.py
@@ -254,6 +254,60 @@ class TestRobustnessRun(RobustnessCaseMixin, unittest.TestCase):
         self.assertTrue(evaluation["matched"])
         self.assertTrue(metric.passed)
 
+    def test_runtime_subclass_matches_expected_base_exception(self):
+        specification = next(
+            item
+            for item in canonical_synthetic_wavelength_robustness_specifications()
+            if item.expected_failure is not None
+        )
+        case = make_synthetic_wavelength_robustness_case(specification, seed=5)
+
+        class SpecializedRuntimeError(RuntimeError):
+            pass
+
+        def fail(_lightcurve, _fit_kwargs, _case):
+            raise SpecializedRuntimeError("specialized consensus failure")
+
+        run = run_synthetic_wavelength_robustness(
+            case,
+            lightcurve_factory=lambda _: object(),
+            fit_runner=fail,
+        )
+        evaluation = run.extra_fields["expected_failure_evaluation"]
+
+        self.assertTrue(evaluation["matched"])
+        self.assertTrue(evaluation["checks"]["exception_type"])
+        self.assertEqual(
+            evaluation["actual_exception_type"], "SpecializedRuntimeError"
+        )
+        self.assertIn("RuntimeError", evaluation["actual_exception_mro"])
+        self.assertEqual(
+            run.failure.diagnostics["exception_mro"][:2],
+            ["SpecializedRuntimeError", "RuntimeError"],
+        )
+
+    def test_unrelated_exception_does_not_match_expected_runtime_error(self):
+        specification = next(
+            item
+            for item in canonical_synthetic_wavelength_robustness_specifications()
+            if item.expected_failure is not None
+        )
+        case = make_synthetic_wavelength_robustness_case(specification, seed=5)
+
+        def fail(_lightcurve, _fit_kwargs, _case):
+            raise KeyError("unrelated failure")
+
+        run = run_synthetic_wavelength_robustness(
+            case,
+            lightcurve_factory=lambda _: object(),
+            fit_runner=fail,
+        )
+        evaluation = run.extra_fields["expected_failure_evaluation"]
+
+        self.assertFalse(evaluation["matched"])
+        self.assertFalse(evaluation["checks"]["exception_type"])
+        self.assertNotIn("RuntimeError", evaluation["actual_exception_mro"])
+
     def test_mismatched_failure_stage_is_preserved(self):
         specification = next(
             item


### PR DESCRIPTION
## Summary

- preserve structured `ConsensusFitError` diagnostics in synthetic recovery records
- match expected-failure contracts through exception inheritance
- execute the canonical 20-seed D2 robustness calibration
- document empirical robust, degraded, failure-boundary, and expected-failure-boundary results
- exclude generated `validation_outputs/` artifacts from version control
- retain the dedicated wavelength-constraint notebook as the next documentation step

## Empirical calibration

The canonical population contains 420 runs across 20 base seeds.

- 393 completed fits
- 27 recorded failures
- 20/20 intended insufficient-sampling failures matched their contracts
- 7 unexpected consensus-stage rejections
- 7 reference populations
- 10 robust perturbations
- 1 degraded perturbation
- 2 empirical failure boundaries
- 1 expected-failure boundary

The calibrated scientific boundaries are:

- `d2-uneven-band-counts`
- `d2-longer-sparse-baseline`

`d2-large-wavelength-gap` is measurably degraded but remains below the configured failure-boundary threshold.

Joint `2D` recovery remains robust despite systematic temporal and wavelength ARD boundary pressure, which is reported separately from recovery classification.

## Validation

- targeted recovery tests
- targeted robustness tests
- targeted robustness-calibration tests
- documentation contract tests
- Ruff CI-equivalent check
- strict Sphinx documentation build
- full unittest suite

This PR is stacked on `pr132-calibrate-wavelength-robustness-boundaries`.
