### PR TITLE
Add representative real-LPV wavelength validation protocol

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -68,6 +68,7 @@ Data, diagnostics, and validation
    pgmuvi.wavelength_validation
    pgmuvi.wavelength_validation_synthetic
    pgmuvi.wavelength_validation_recovery
+   pgmuvi.wavelength_validation_real_lpv
    pgmuvi.wavelength_validation_robustness
    pgmuvi.wavelength_validation_robustness_calibration
    pgmuvi.upload_validation

--- a/docs/source/future_work.rst
+++ b/docs/source/future_work.rst
@@ -76,16 +76,30 @@ Completed wavelength-derived constraint tranche (PR121--PR125)
 
 **TBD[wavelength-constraint-validation]**
     D1 nominal recovery, the canonical 20-seed D2 robustness calibration, and
-    the maintained wavelength-constraint notebook are complete.  The remaining
-    validation step is D3 application to representative real LPV sources across
-    the maintained model families, with source-level period evidence, fit
-    quality, residual wavelength structure, constraint diagnostics, warnings,
-    and failure semantics reported together.  Successful optimization alone is
-    not sufficient validation, and D3 must remain advisory rather than define
-    an automatic model-selection rule.
+    the maintained wavelength-constraint notebook are complete.  D3
+    representative observed-LPV validation infrastructure is now implemented
+    as a failure-aware, non-selecting reporting layer over the maintained
+    advisory workflow.  The remaining work is to execute and review the D3
+    validation on a representative source set across the maintained model
+    families.  Source-level period evidence, fit quality, residual wavelength
+    structure, constraint diagnostics, warnings, and failure semantics must be
+    reported together.  Successful optimization alone is not sufficient
+    validation, and D3 must remain advisory rather than define an automatic
+    model-selection rule.  Instrument-specific treatment of observational
+    channels sharing one physical wavelength remains
+    ``TBD[instrument-channel-calibration]``.
 
 Wavelength-model extensions
 ---------------------------
+
+**TBD[instrument-channel-calibration]**
+    Add an explicit, tested calibration model for multiple observational channels
+    that share one physical wavelength but have instrument-dependent offsets,
+    scales, throughput differences, or noise properties.  Current wavelength
+    diagnostics preserve the separate channel identities and flag the shared
+    wavelength, but they do not estimate or apply a calibration correction.  Any
+    public calibration API introduced before implementation must raise
+    ``NotImplementedError`` rather than silently approximating a correction.
 
 **TBD[multi-periodic-wavelength-models]**
     Add a documented and validated multi-periodic workflow beyond the current

--- a/docs/source/howto/index.rst
+++ b/docs/source/howto/index.rst
@@ -19,6 +19,7 @@ Each guide is focused on a single workflow and assumes you have already read the
    wavelength_models
    wavelength_advisory
    wavelength_advisory_batch
+   representative_lpv_validation
    legacy_wavelength_candidates
    priors_constraints
    multiband

--- a/docs/source/howto/loading_data.rst
+++ b/docs/source/howto/loading_data.rst
@@ -14,8 +14,8 @@ The validation sequence
 
 A reliable input workflow has five distinct stages:
 
-1. identify the time, measurement, uncertainty, wavelength, and band-label
-   columns;
+1. identify the time, measurement, uncertainty, physical-wavelength, and
+   observational-channel label columns;
 2. construct a 1-D or 2-D :class:`~pgmuvi.lightcurve.Lightcurve`;
 3. inspect rows removed because of non-finite values;
 4. decide whether non-positive fluxes or uncertainties are scientifically
@@ -49,7 +49,7 @@ diagnostics.
 For a multiband light curve, ``xdata`` must have shape ``(N, 2)``:
 
 * column 0 contains time;
-* column 1 contains a numeric wavelength coordinate; and
+* column 1 contains a numeric physical wavelength coordinate; and
 * ``ydata`` and ``yerr`` remain one-dimensional arrays of length ``N``.
 
 For example::
@@ -57,8 +57,14 @@ For example::
     xdata = np.column_stack([times, wavelengths_um])
     lc = Lightcurve(xdata, fluxes, errors, band=band_labels)
 
-String band labels are metadata for reporting and plotting.  They do not replace
-the numeric wavelength coordinate used by the GP.
+An observational-channel label identifies the instrument, detector, filter, or
+data stream used for an observation.  Observational-channel labels are metadata
+for reporting, grouping, and diagnostics; they do not replace the numeric physical
+wavelength coordinate used by the GP.  In particular, multiple observational
+channels may share one physical wavelength.  Lightcurve.band is retained as the
+legacy attribute, while
+:attr:`~pgmuvi.lightcurve.Lightcurve.observational_channel_labels` exposes the
+preferred terminology.
 
 CSV input contract
 ------------------
@@ -85,7 +91,7 @@ loader searches the following aliases in order:
    * - Numeric wavelength
      - ``wavelength``, ``wave``, ``wl``, ``lambda``, ``freq``, ``frequency``,
        ``channel``
-   * - String band label
+   * - Observational-channel label
      - ``band``, ``filter``, ``filtername``, ``filter_name``
 
 A minimal single-band file is therefore::
@@ -107,8 +113,8 @@ Use explicit names when the file uses project-specific headers::
         yerrcol="relative_flux_error",
     )
 
-A multiband file should include both numeric wavelengths and, optionally,
-human-readable labels::
+A multiwavelength file should include numeric physical wavelengths and may also
+include human-readable observational-channel labels::
 
     mjd,wavelength_um,band,flux,flux_error
     59000.0,0.55,V,1.02,0.03
@@ -136,19 +142,21 @@ numeric wavelength value produces a 1-D light curve.
    for ``2DWavelengthDependent``, ``2DDustMean``, ``2DPowerLawMean``, and other
    workflows whose interpretation depends on wavelength.
 
-Band labels and mixed-band input
---------------------------------
+Observational-channel labels and mixed-channel input
+------------------------------------------------------
 
-A recognised string band column is handled independently of the numeric
-wavelength column.  For 2-D data, the labels are stored row by row in
-``lc.band``.  For 1-D data, a single distinct non-empty label is stored as the
-single-band label.
+A recognised string label column is handled independently of the numeric
+physical-wavelength column.  For 2-D data, observational-channel labels are
+stored row by row in ``lc.band`` and exposed through
+``lc.observational_channel_labels``.  For 1-D data, a single distinct non-empty
+label is stored as the single-channel label.  The legacy ``band`` name remains
+part of the public input and serialization contract.
 
-If a nominally 1-D file contains several distinct string labels but no usable
-numeric wavelength coordinate, :meth:`~pgmuvi.lightcurve.Lightcurve.from_csv`
-leaves ``lc.band`` unset and warns that the mixed-band input was not promoted to
-2-D.  Fix the file by supplying a numeric wavelength column rather than ignoring
-the warning.
+If a nominally 1-D file contains several distinct observational-channel labels
+but no usable numeric physical-wavelength coordinate,
+:meth:`~pgmuvi.lightcurve.Lightcurve.from_csv` leaves ``lc.band`` unset and warns
+that the mixed-channel input was not promoted to 2-D.  Fix the file by supplying
+a numeric physical-wavelength column rather than ignoring the warning.
 
 Finite-value filtering
 ----------------------

--- a/docs/source/howto/multiband.rst
+++ b/docs/source/howto/multiband.rst
@@ -1,8 +1,8 @@
 Multiwavelength (2D) Analysis
 ==============================
 
-This guide explains how to fit GP models to light curves observed simultaneously in
-multiple photometric bands or across a range of wavelengths.
+This guide explains how to fit GP models to light curves observed through
+multiple observational channels or across a range of physical wavelengths.
 
 .. contents:: On this page
    :local:
@@ -11,30 +11,32 @@ multiple photometric bands or across a range of wavelengths.
 Overview
 --------
 
-When a source is observed in multiple bands, ``pgmuvi`` can fit a **2D Gaussian
-process** whose inputs are ``(time, wavelength)``.  The model captures:
+When a source is observed in multiple observational channels, ``pgmuvi`` can
+fit a **2D Gaussian process** whose inputs are ``(time, wavelength)``.  The model
+captures:
 
-* the temporal variability structure (periods, noise) shared across bands,
-* the wavelength dependence of variability amplitude and coherence,
-* band-specific noise levels.
+* the temporal variability structure shared across observational channels;
+* the wavelength dependence of variability amplitude and coherence; and
+* the measurement-noise information supplied with each observation.
 
-This is more informative than fitting each band independently because the model
-borrows statistical strength across bands, particularly when some bands have sparse
-coverage.
+This is more informative than fitting each observational channel independently
+because the model borrows statistical strength across physical wavelengths,
+particularly when some channels have sparse coverage.
 
 Data Format for 2D Models
 --------------------------
 
 For 2D / multiband fitting, ``xdata`` must have shape ``(N, 2)`` where:
 
-* column 0 is the **observation time** (same unit across all observations),
-* column 1 is the **wavelength or band identifier** and **must be numeric**.
-  Use the effective wavelength (e.g., in microns or nanometres) for
-  wavelength-dependent (separable 2D) kernels, or integer band codes
-  (0, 1, 2 …) for generic categorical band identification.
-  A physically meaningful numeric wavelength is strongly recommended for
-  separable 2D kernels so that the kernel can learn the correct wavelength
-  scaling.
+* column 0 is the **observation time** (same unit across all observations); and
+* column 1 is the **numeric physical wavelength coordinate**.
+
+Use an effective wavelength in a documented physical unit for wavelength-dependent
+models.  An observational channel is a separate string identifier for an
+instrument/filter/data-stream combination.  The distinction matters:
+observational-channel labels do not replace the numeric physical wavelength
+coordinate, and multiple observational
+channels may legitimately share one physical wavelength.
 
   .. note::
 
@@ -50,16 +52,18 @@ For 2D / multiband fitting, ``xdata`` must have shape ``(N, 2)`` where:
      :class:`~pgmuvi.lightcurve.Lightcurve` constructor itself still requires
      numeric ``xdata``; passing string arrays directly will raise an error.
 
-Human-readable band labels (e.g. ``"V"``, ``"R"``) can be stored separately in
-the :attr:`~pgmuvi.lightcurve.Lightcurve.band` attribute for labelling plots,
-but they play no role in the GP computation.
+Human-readable observational-channel labels can be stored separately in the
+legacy :attr:`~pgmuvi.lightcurve.Lightcurve.band` attribute and read through
+:attr:`~pgmuvi.lightcurve.Lightcurve.observational_channel_labels`.  The labels
+are used for reporting, grouping, and channel-level diagnostics, but the GP
+receives the numeric physical wavelength coordinate.
 
-All bands are stacked into a single array::
+All observations are stacked into a single array::
 
     import numpy as np
     import pgmuvi
 
-    # Two bands: times_b0/b1, fluxes_b0/b1, errors_b0/b1
+    # Two observational channels at two physical wavelengths
     times_all  = np.concatenate([times_b0,  times_b1])
     fluxes_all = np.concatenate([fluxes_b0, fluxes_b1])
     errors_all = np.concatenate([errors_b0, errors_b1])
@@ -82,27 +86,39 @@ The fitting workflow is the same as in 1D::
 
     lc.fit(model="2D")
 
-For heterogeneous band sampling (e.g., one band has far more observations than
-others), consider using the best-band initialisation option::
+For heterogeneous channel sampling (for example, one observational channel has
+far more observations than the others), consider using the legacy best-band
+initialisation option::
 
     lc.fit(model="2D", use_best_band_init=True)
 
-This uses a 1-D Lomb–Scargle on the most densely sampled band instead of the
-multiband periodogram to seed the spectral-mixture kernel frequencies.  This
-can substantially improve frequency initialisation when one band has far more
-observations than the others.
+This uses a 1-D Lomb–Scargle calculation on the most densely sampled
+observational channel instead of the multiwavelength periodogram to seed the
+spectral-mixture kernel frequencies.  This can improve frequency initialisation
+when one channel has far more observations than the others.
 
-Assessing Sampling Quality per Band
--------------------------------------
+Assessing sampling quality per observational channel
+------------------------------------------------------
 
-Because each band may have a different cadence, it is important to assess data quality
-per band before fitting::
+Because each observational channel may have a different cadence, assess data
+quality per channel before fitting.  The existing method name is retained for
+backward compatibility::
 
     lc.assess_sampling_quality_per_band()
 
-You can then filter out bands that have insufficient coverage::
+You can then filter out observational channels that have insufficient coverage
+using the existing compatibility method::
 
     lc = lc.filter_well_sampled_bands(min_points=20)
+
+.. warning::
+
+   **TBD[instrument-channel-calibration]:** PGMUVI does not currently estimate
+   additive offsets, multiplicative scales, or other instrument-channel
+   calibration corrections when multiple observational channels share one
+   physical wavelength.  Preserve the separate channel labels.  No silent
+   calibration or wavelength reassignment is performed; an explicit calibration
+   model is future work.
 
 Visualising 2D Results
 -----------------------

--- a/docs/source/howto/representative_lpv_validation.rst
+++ b/docs/source/howto/representative_lpv_validation.rst
@@ -1,0 +1,214 @@
+Representative observed-LPV validation
+==========================================
+
+The D3 workflow applies the maintained wavelength-advisory machinery to a
+representative observed LPV and collects the evidence needed to inspect the
+fit without claiming known physical truth.
+
+The public example source is
+``examples/data/10131+3049.csv``.  It is loaded and fitted in linear flux.
+
+Data-coordinate contract
+------------------------
+
+An observational channel identifies an instrument, filter, or data stream.
+A physical wavelength is the numeric wavelength coordinate used by the GP.
+
+For this source, multiple observational channels may share one physical
+wavelength.  D3 preserves those channel identities and does not average,
+merge, calibrate, correct, or reassign their measurements or wavelength
+coordinates.
+
+Instrument-specific calibration is not implemented.  That work remains
+``TBD[instrument-channel-calibration]``.  No calibration correction is
+silently approximated.
+
+Maintained candidate set
+------------------------
+
+The representative LPV candidate set is:
+
+* ``2DWavelengthDependent``
+* ``2DDustMean``
+* ``2DPowerLawMean``
+* ``2DSeparable``
+* ``2D`` as the structurally different joint spectral-mixture baseline
+
+The preferred LPV configuration for the separable families uses
+``fit_strategy="consensus"``,
+``time_kernel_type="quasi_periodic"``, and
+``learn_additional_noise=True``.
+
+Run one representative-source report
+------------------------------------
+
+Load the public source and execute the maintained D3 wrapper::
+
+    from pgmuvi.lightcurve import Lightcurve
+    from pgmuvi.wavelength_validation_real_lpv import (
+        run_representative_lpv_validation,
+    )
+
+    lightcurve = Lightcurve.from_csv(
+        "examples/data/10131+3049.csv",
+        check_sampling=False,
+        max_samples=None,
+        max_samples_per_band=None,
+    )
+
+    report = run_representative_lpv_validation(
+        lightcurve,
+        source_id="10131+3049",
+        description="Representative public LPV validation source.",
+        workflow_kwargs={
+            "base_fit_kwargs": {
+                "training_iter": 500,
+                "miniter": 100,
+            },
+        },
+    )
+
+    payload = report.to_dict()
+
+The wrapper reuses isolated advisory candidate fits.  It does not mutate the
+input light curve's retained fit state.
+
+Run an ordered source manifest
+------------------------------
+
+``RepresentativeLPVSourceSpecification`` defines one manifest row.  Every row
+records:
+
+* a unique ``source_id``;
+* the source path;
+* a description;
+* the source's representative sample role;
+* the reason it was selected;
+* a nonnegative seed; and
+* optional JSON-safe metadata.
+
+Manifest order is preserved.  Duplicate source identifiers are rejected.
+The nonnegative seed is applied across source loading and advisory execution.
+Python, NumPy, and PyTorch random-number-generator states are restored after
+each source, so the batch does not leave the caller's RNG streams advanced.
+
+``run_representative_lpv_validation_batch`` executes the same advisory
+single-source wrapper for each manifest entry::
+
+    from pgmuvi.wavelength_validation_real_lpv import (
+        RepresentativeLPVSourceSpecification,
+        run_representative_lpv_validation_batch,
+    )
+
+    manifest = [
+        RepresentativeLPVSourceSpecification(
+            source_id="10131+3049",
+            source_path="examples/data/10131+3049.csv",
+            description="Representative public LPV validation source.",
+            sample_role="public_validation_source",
+            selection_reason=(
+                "Public multiwavelength LPV with broad wavelength coverage."
+            ),
+            seed=0,
+        ),
+    ]
+
+    batch_report = run_representative_lpv_validation_batch(
+        manifest,
+        output_root="validation_outputs/d3_real_lpv",
+    )
+
+    batch_payload = batch_report.to_dict()
+
+A source-loading failure or advisory-workflow failure is recorded for that
+source and does not abort later manifest entries.  Each source result records a
+deterministic intended directory of the form
+``validation_outputs/d3_real_lpv/sources/<source_id>`` and a corresponding
+``report.json`` path.
+
+The protocol runner does not create those directories or write report files.
+It reports ``writes_outputs=False``.  The batch envelope retains the exact
+workflow configuration and compact runtime provenance, including Python,
+NumPy, PyTorch, GPyTorch, and package-version information.
+
+After the batch has completed,
+``export_representative_lpv_batch_report`` may serialize the already-computed
+payload::
+
+    from pgmuvi.wavelength_validation_real_lpv import (
+        export_representative_lpv_batch_report,
+    )
+
+    export_manifest = export_representative_lpv_batch_report(
+        batch_report,
+        "validation_outputs/d3_real_lpv",
+    )
+
+The export layer writes strict JSON, a compact source-summary CSV, one
+``source_result.json`` per source, and either ``report.json`` or
+``failure.json`` for each source.  Filesystem path components are sanitized.
+Exporting does not rerun fits or alter any scientific conclusion.
+
+Command-line runner
+-------------------
+
+The maintained command-line entry point is
+``scripts/run_representative_lpv_validation.py``.  The committed public
+manifest and workflow configuration can first be validated without fitting::
+
+    PYTHONPATH=. python3 scripts/run_representative_lpv_validation.py \
+        --manifest examples/validation/d3_representative_lpv_manifest.json \
+        --workflow-config examples/validation/d3_representative_lpv_workflow.json \
+        --validate-manifest-only
+
+The validation-only mode loads and validates the manifest, resolves relative
+source paths against the manifest location, and writes no outputs.
+
+A later D3 execution may use the same files without
+``--validate-manifest-only``::
+
+    PYTHONPATH=. python3 scripts/run_representative_lpv_validation.py \
+        --manifest examples/validation/d3_representative_lpv_manifest.json \
+        --workflow-config examples/validation/d3_representative_lpv_workflow.json \
+        --output-root validation_outputs/d3_real_lpv
+
+Source failures remain recorded rather than aborting later sources.  The
+optional ``--fail-on-source-failure`` flag returns status 2 after all sources
+have been attempted and the reports have been emitted.
+
+The batch protocol also performs no automatic model selection, does not install
+a model, and does not automatically apply wavelength-derived constraints or
+initialization.  Those values remain evidence recorded by the underlying
+candidate fits.
+
+Evidence recorded
+-----------------
+
+The D3 report records:
+
+* period and consensus evidence by model;
+* training-space fit quality;
+* residual wavelength structure;
+* wavelength-derived constraint and boundary diagnostics;
+* warnings; and
+* structured failures.
+
+The observed source has no truth record, so the report creates no
+truth-recovery metric or truth-recovery gate.
+
+Interpretation boundary
+-----------------------
+
+A top-ranked model is descriptive evidence from the available comparative
+fit-quality diagnostics.  The workflow does not install or select that model.
+It performs no automatic model selection.
+
+The report therefore always retains:
+
+* ``advisory_only=True``;
+* ``automatic_model_selection_applied=False``; and
+* ``selected_model=None``.
+
+A successful optimization is not, by itself, validation.  Period evidence,
+residual structure, constraint pressure, warning state, and failed attempts
+must be reviewed together before drawing a scientific conclusion.

--- a/docs/source/pgmuvi.wavelength_estimation.rst
+++ b/docs/source/pgmuvi.wavelength_estimation.rst
@@ -4,13 +4,25 @@ pgmuvi.wavelength_estimation
 This module builds the shared wavelength-estimation context used by the
 parameter workflow.  It records:
 
-* usable and excluded bands;
+* usable and excluded observational channels;
 * total wavelength span and adjacent wavelength spacings;
 * the largest wavelength gap and spacing irregularity;
-* robust per-band median, scatter, and multiple quantile amplitudes;
+* robust per-observational-channel median, scatter, and quantile amplitudes;
 * fractional and uncertainty-corrected amplitude summaries;
 * monotonicity indicators for median flux, amplitude, and scatter; and
+* the number of observational channels and distinct physical wavelengths; and
 * an auditable wavelength-length-scale value and interval.
+
+Observational channels are identified independently of their numeric physical
+wavelengths.  Multiple channels may share one wavelength, so channel-level
+summaries and distinct physical wavelengths are reported separately.
+
+**TBD[instrument-channel-calibration]:** No instrument-channel calibration is
+performed.  When two or more usable observational channels share a physical
+wavelength, PGMUVI preserves their channel-level diagnostics but excludes that
+uncalibrated wavelength from cross-wavelength trend summaries and
+wavelength-mean fits.  It does not silently combine flux summaries, infer
+offsets or scales, or assign artificial wavelength differences.
 
 The diagnostics retain the length-scale recommendation in the **raw
 wavelength coordinate** and also record the corresponding value and interval in
@@ -32,7 +44,7 @@ dimension-aware spectral-mixture ARD layer documented in
 :mod:`pgmuvi.spectral_mixture_ard`.
 
 The same module now builds model-ready wavelength-mean recommendations from
-robust per-band median fluxes.  ``GuessStrategy.WAVELENGTH_MEAN`` and
+robust per-observational-channel median fluxes.  ``GuessStrategy.WAVELENGTH_MEAN`` and
 ``ConstraintStrategy.WAVELENGTH_MEAN`` initialize and constrain:
 
 * the quadratic bias and coefficients in ``2DWavelengthDependent``;
@@ -49,7 +61,7 @@ physical interpretation.  Every affected mean parameter uses a registered
 GPyTorch raw-parameter interval, so the reported bounds remain active during
 optimization.
 
-For three or more non-flat bands, the power-law recommendation now retains the
+For three or more non-flat physical-wavelength evidence points, the power-law recommendation now retains the
 full exponent-profile fit and converts its same-sign, near-optimal support into
 finite data-derived intervals for offset, signed amplitude, and exponent.  This
 prevents the covariance from absorbing a clearly resolved static wavelength
@@ -58,10 +70,10 @@ flat solution.  The profile criterion, supported parameter ranges, padded
 active intervals, and effective registered constraints remain available in
 parameter-workflow provenance.
 
-With only two usable bands, the power-law exponent is not identifiable jointly
+With only two usable physical-wavelength evidence points, the power-law exponent is not identifiable jointly
 with its offset and amplitude.  The estimator therefore keeps the documented
 ``-2`` default and fits only the linear coefficients instead of selecting an
-arbitrary grid endpoint.  An exactly flat band-median trend is not promoted to
+arbitrary grid endpoint.  An exactly flat wavelength-median trend is not promoted to
 a dust-shape estimate, and neither under-identified case receives a fabricated
 profile interval.
 

--- a/docs/source/pgmuvi.wavelength_validation_real_lpv.rst
+++ b/docs/source/pgmuvi.wavelength_validation_real_lpv.rst
@@ -1,0 +1,7 @@
+Representative observed-LPV wavelength validation
+=================================================
+
+.. automodule:: pgmuvi.wavelength_validation_real_lpv
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/examples/validation/d3_representative_lpv_manifest.json
+++ b/examples/validation/d3_representative_lpv_manifest.json
@@ -1,0 +1,17 @@
+{
+  "sources": [
+    {
+      "source_id": "10131+3049",
+      "source_path": "../data/10131+3049.csv",
+      "description": "Public representative multiwavelength LPV validation source.",
+      "sample_role": "public_validation_source",
+      "selection_reason": "Public LPV with broad wavelength coverage, 17 observational channels, 16 physical wavelengths, and two observational channels sharing one physical wavelength.",
+      "seed": 0,
+      "metadata": {
+        "flux_domain": "linear",
+        "instrument_channel_calibration": "not_implemented",
+        "instrument_channel_calibration_marker": "TBD[instrument-channel-calibration]"
+      }
+    }
+  ]
+}

--- a/examples/validation/d3_representative_lpv_workflow.json
+++ b/examples/validation/d3_representative_lpv_workflow.json
@@ -1,0 +1,11 @@
+{
+  "base_fit_kwargs": {
+    "training_iter": 500,
+    "miniter": 100,
+    "fit_strategy": "consensus",
+    "time_kernel_type": "quasi_periodic",
+    "learn_additional_noise": true
+  },
+  "make_text_report": true,
+  "make_plots": false
+}

--- a/pgmuvi/__init__.py
+++ b/pgmuvi/__init__.py
@@ -30,6 +30,7 @@ __all__ = [
     "wavelength_results",
     "wavelength_status",
     "wavelength_validation",
+    "wavelength_validation_real_lpv",
     "wavelength_validation_recovery",
     "wavelength_validation_robustness",
     "wavelength_validation_robustness_calibration",

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -3516,6 +3516,18 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         return self.xdata.shape[-1] if self.xdata.dim() > 1 else 1
 
     @property
+    def observational_channel_labels(self):
+        """Return observational-channel labels for the retained observations.
+
+        ``band`` remains the legacy storage attribute and constructor keyword.
+        An observational channel identifies an instrument/filter/data-stream
+        combination and is distinct from the numeric physical wavelength in
+        ``xdata[:, 1]``. Multiple observational channels may therefore share
+        one physical wavelength.
+        """
+        return self.band
+
+    @property
     def magnitudes(self):
         pass
 
@@ -10132,16 +10144,21 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 if isinstance(uncertainty_values, torch.Tensor):
                     uncertainty_values = uncertainty_values.detach().cpu().numpy()
 
-            band_labels = None
+            observational_channel_labels = None
             if self.band is not None and len(self.band) == flux_values_all.size:
-                band_labels = np.asarray(self.band, dtype=str)
+                observational_channel_labels = np.asarray(
+                    self.band,
+                    dtype=str,
+                )
 
             wavelength_diagnostics, band_diagnostics = (
                 build_wavelength_estimation_context(
                     wavelengths=input_values[:, 1],
                     fluxes=flux_values_all,
                     uncertainties=uncertainty_values,
-                    band_labels=band_labels,
+                    observational_channel_labels=(
+                        observational_channel_labels
+                    ),
                 )
             )
             wavelength_diagnostics = (
@@ -10163,7 +10180,9 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                     raw_wavelengths=input_values[:, 1],
                     model_wavelengths=model_wavelengths,
                     model_fluxes=model_fluxes,
-                    band_labels=band_labels,
+                    observational_channel_labels=(
+                        observational_channel_labels
+                    ),
                 )
             )
             mean_metadata = dict(wavelength_mean_diagnostics.metadata)

--- a/pgmuvi/parameter_context.py
+++ b/pgmuvi/parameter_context.py
@@ -170,7 +170,12 @@ class WavelengthMeanEstimationDiagnostics:
     @property
     def n_usable_observational_channels(self) -> int:
         """Return the number of usable observational channels."""
-        return self.n_usable_bands
+        metadata_count = self.metadata.get(
+            "n_usable_observational_channels"
+        )
+        if metadata_count is None:
+            return self.n_usable_bands
+        return int(metadata_count)
 
 
 @dataclass(frozen=True)

--- a/pgmuvi/parameter_context.py
+++ b/pgmuvi/parameter_context.py
@@ -28,7 +28,12 @@ class LightcurveDiagnostics:
 
 @dataclass(frozen=True)
 class BandDiagnostics:
-    """Diagnostics for one band in a multiband light curve."""
+    """Diagnostics for one observational channel in a multiband light curve.
+
+    ``band`` is retained as the legacy serialized field name for backward
+    compatibility. It identifies an observational channel, not necessarily a
+    unique physical wavelength.
+    """
 
     band: str
     wavelength: float | None = None
@@ -52,6 +57,16 @@ class BandDiagnostics:
     noise_corrected_half_amplitude_q05_q95: float | None = None
     noise_corrected_half_amplitude_q10_q90: float | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def observational_channel(self) -> str:
+        """Return the observational-channel identifier."""
+        return self.band
+
+
+# Preferred public name. ``BandDiagnostics`` remains the serialized and import
+# compatibility name used by existing callers.
+ObservationalChannelDiagnostics = BandDiagnostics
 
 
 WAVELENGTH_ESTIMATION_SCHEMA_VERSION = "pgmuvi-wavelength-estimation-v2"
@@ -108,6 +123,21 @@ class WavelengthEstimationDiagnostics:
         """Return a JSON-safe dictionary representation."""
         return asdict(self)
 
+    @property
+    def n_usable_observational_channels(self) -> int:
+        """Return the number of usable observational channels."""
+        return self.n_usable_bands
+
+    @property
+    def min_points_per_observational_channel(self) -> int:
+        """Return the minimum retained points per observational channel."""
+        return self.min_points_per_band
+
+    @property
+    def excluded_observational_channels(self) -> tuple[str, ...]:
+        """Return observational channels excluded from wavelength evidence."""
+        return self.excluded_bands
+
 
 WAVELENGTH_MEAN_ESTIMATION_SCHEMA_VERSION = "pgmuvi-wavelength-mean-estimation-v1"
 
@@ -137,6 +167,11 @@ class WavelengthMeanEstimationDiagnostics:
         """Return a JSON-safe dictionary representation."""
         return asdict(self)
 
+    @property
+    def n_usable_observational_channels(self) -> int:
+        """Return the number of usable observational channels."""
+        return self.n_usable_bands
+
 
 @dataclass(frozen=True)
 class ConsensusDiagnostics:
@@ -165,13 +200,34 @@ class ParameterEstimationContext:
     spectral_mixture_ard_diagnostics: dict[str, Any] | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
 
-    def bands(self) -> list[str]:
-        """Return the available band names."""
+    @property
+    def observational_channel_diagnostics(
+        self,
+    ) -> dict[str, BandDiagnostics]:
+        """Return diagnostics keyed by observational-channel identifier."""
+        return self.band_diagnostics
+
+    def observational_channels(self) -> list[str]:
+        """Return the available observational-channel identifiers."""
         return list(self.band_diagnostics.keys())
 
-    def get_band(self, band: str) -> BandDiagnostics:
-        """Return diagnostics for one band."""
+    def get_observational_channel(
+        self,
+        observational_channel: str,
+    ) -> BandDiagnostics:
+        """Return diagnostics for one observational channel."""
         try:
-            return self.band_diagnostics[band]
+            return self.band_diagnostics[observational_channel]
         except KeyError as exc:
-            raise KeyError(f"No diagnostics found for band {band!r}.") from exc
+            raise KeyError(
+                "No diagnostics found for observational channel "
+                f"{observational_channel!r}."
+            ) from exc
+
+    def bands(self) -> list[str]:
+        """Return observational-channel identifiers using the legacy name."""
+        return self.observational_channels()
+
+    def get_band(self, band: str) -> BandDiagnostics:
+        """Return observational-channel diagnostics using the legacy name."""
+        return self.get_observational_channel(band)

--- a/pgmuvi/wavelength_estimation.py
+++ b/pgmuvi/wavelength_estimation.py
@@ -1098,9 +1098,7 @@ def build_wavelength_mean_estimation_context(
 
     return WavelengthMeanEstimationDiagnostics(
         available=any(record.get("available") for record in recommendations.values()),
-        n_usable_bands=int(
-            channel_metadata["n_usable_observational_channels"]
-        ),
+        n_usable_bands=int(raw.size),
         raw_wavelengths=tuple(float(value) for value in raw),
         model_wavelengths=tuple(float(value) for value in model),
         model_median_fluxes=tuple(float(value) for value in flux),

--- a/pgmuvi/wavelength_estimation.py
+++ b/pgmuvi/wavelength_estimation.py
@@ -1,8 +1,9 @@
 """Wavelength-domain summaries for parameter estimation.
 
 The routines in this module summarize the wavelength sampling and robust
-per-band flux distributions of a multiband light curve.  They do not mutate a
-GP model and they do not claim that a particular wavelength model is selected.
+per-observational-channel flux distributions of a multiband light curve. They
+do not mutate a GP model and they do not claim that a particular wavelength
+model is selected.
 The resulting diagnostics are intended to provide a shared, auditable input to
 later wavelength-kernel and wavelength-mean initialization work.
 """
@@ -275,35 +276,73 @@ def build_wavelength_estimation_context(
     uncertainties: Any | None = None,
     band_labels: Any | None = None,
     *,
-    min_points_per_band: int = 3,
+    min_points_per_band: int | None = None,
+    observational_channel_labels: Any | None = None,
+    min_points_per_observational_channel: int | None = None,
 ) -> tuple[WavelengthEstimationDiagnostics, dict[str, BandDiagnostics]]:
-    """Build wavelength sampling and robust per-band diagnostics.
+    """Build wavelength sampling and observational-channel diagnostics.
 
     Parameters
     ----------
     wavelengths
-        Numeric wavelength coordinate for each observation.
+        Numeric physical-wavelength coordinate for each observation.
     fluxes
-        Flux or magnitude value for each observation.  The values are summarized
-        in their supplied linear coordinate; no log-flux transformation is used.
+        Flux value for each observation. The values are summarized in their
+        supplied linear coordinate; no log-flux transformation is used.
     uncertainties
-        Optional measurement uncertainties.  Only finite positive values enter
+        Optional measurement uncertainties. Only finite positive values enter
         the uncertainty and noise-corrected summaries.
+    observational_channel_labels
+        Preferred row-wise identifiers for instrument, detector, filter, or
+        data-stream combinations. Multiple observational channels may share
+        one physical wavelength.
     band_labels
-        Optional row-wise labels.  When absent, exact numeric wavelengths define
-        the groups.
+        Legacy alias for ``observational_channel_labels``.
+    min_points_per_observational_channel
+        Preferred minimum number of finite wavelength/flux pairs required for
+        one observational channel to enter wavelength evidence.
     min_points_per_band
-        Minimum number of finite wavelength/flux pairs required for a band to
-        enter cross-wavelength trend and length-scale summaries.
+        Legacy alias for ``min_points_per_observational_channel``.
 
     Returns
     -------
     tuple
-        Two-element tuple containing an immutable wavelength-level summary and
-        per-band diagnostics keyed by label.
+        An immutable wavelength-level summary and diagnostics keyed by
+        observational-channel identifier.
     """
-    if min_points_per_band < 1:
-        raise ValueError("min_points_per_band must be at least 1.")
+    if (
+        observational_channel_labels is not None
+        and band_labels is not None
+    ):
+        raise ValueError(
+            "observational_channel_labels and band_labels cannot both be "
+            "provided."
+        )
+    if (
+        min_points_per_observational_channel is not None
+        and min_points_per_band is not None
+    ):
+        raise ValueError(
+            "min_points_per_observational_channel and min_points_per_band "
+            "cannot both be provided."
+        )
+
+    channel_labels = (
+        observational_channel_labels
+        if observational_channel_labels is not None
+        else band_labels
+    )
+    minimum_points = (
+        min_points_per_observational_channel
+        if min_points_per_observational_channel is not None
+        else min_points_per_band
+    )
+    if minimum_points is None:
+        minimum_points = 3
+    if minimum_points < 1:
+        raise ValueError(
+            "min_points_per_observational_channel must be at least 1."
+        )
 
     wavelength_values = _finite_array(wavelengths)
     flux_values = _finite_array(fluxes)
@@ -319,7 +358,7 @@ def build_wavelength_estimation_context(
     else:
         uncertainty_values = None
 
-    if band_labels is None:
+    if channel_labels is None:
         labels = np.asarray(
             [
                 _band_label_for_wavelength(value)
@@ -330,16 +369,17 @@ def build_wavelength_estimation_context(
             dtype=str,
         )
     else:
-        labels = np.asarray(band_labels, dtype=str).reshape(-1)
+        labels = np.asarray(channel_labels, dtype=str).reshape(-1)
         if labels.size != flux_values.size:
             raise ValueError(
-                "band_labels must have the same length as wavelengths and fluxes."
+                "observational_channel_labels must have the same length as "
+                "wavelengths and fluxes."
             )
 
-    band_diagnostics: dict[str, BandDiagnostics] = {}
+    observational_channel_diagnostics: dict[str, BandDiagnostics] = {}
     for label in dict.fromkeys(labels.tolist()):
         mask = labels == label
-        band_diagnostics[label] = _build_band_diagnostics(
+        observational_channel_diagnostics[label] = _build_band_diagnostics(
             band=label,
             wavelengths=wavelength_values[mask],
             fluxes=flux_values[mask],
@@ -348,12 +388,12 @@ def build_wavelength_estimation_context(
                 if uncertainty_values is not None
                 else None
             ),
-            min_points_per_band=min_points_per_band,
+            min_points_per_band=minimum_points,
         )
 
     usable = [
         item
-        for item in band_diagnostics.values()
+        for item in observational_channel_diagnostics.values()
         if item.metadata.get("usable_for_wavelength_estimation")
     ]
     usable.sort(key=lambda item: float(item.wavelength))
@@ -397,27 +437,49 @@ def build_wavelength_estimation_context(
         else None
     )
 
+    channels_by_wavelength: dict[float, list[str]] = {}
+    for item in usable:
+        wavelength = float(item.wavelength)
+        channels_by_wavelength.setdefault(wavelength, []).append(item.band)
+    shared_wavelength_channels = {
+        wavelength: tuple(channels)
+        for wavelength, channels in channels_by_wavelength.items()
+        if len(channels) > 1
+    }
+    shared_wavelengths = set(shared_wavelength_channels)
+
+    # TBD[instrument-channel-calibration]: An explicit calibration model is
+    # required before flux summaries from multiple observational channels at
+    # one physical wavelength can be combined. Until then, omit those physical
+    # wavelengths from cross-wavelength trend summaries rather than silently
+    # calibrating or double-counting them.
+    usable_for_trends = [
+        item
+        for item in usable
+        if float(item.wavelength) not in shared_wavelengths
+    ]
+
     median_fluxes = [
         float(item.median_flux)
-        for item in usable
+        for item in usable_for_trends
         if item.median_flux is not None and math.isfinite(item.median_flux)
     ]
     amplitudes = [
         float(item.raw_half_amplitude_q05_q95)
-        for item in usable
+        for item in usable_for_trends
         if item.raw_half_amplitude_q05_q95 is not None
         and math.isfinite(item.raw_half_amplitude_q05_q95)
     ]
     scatters = [
         float(item.robust_scatter)
-        for item in usable
+        for item in usable_for_trends
         if item.robust_scatter is not None and math.isfinite(item.robust_scatter)
     ]
 
     initial, bounds, method = _lengthscale_recommendation(distinct_wavelengths)
     excluded = tuple(
         label
-        for label, item in band_diagnostics.items()
+        for label, item in observational_channel_diagnostics.items()
         if not item.metadata.get("usable_for_wavelength_estimation")
     )
 
@@ -428,7 +490,7 @@ def build_wavelength_estimation_context(
         ),
         n_distinct_wavelengths=int(distinct_wavelengths.size),
         n_usable_bands=len(usable),
-        min_points_per_band=min_points_per_band,
+        min_points_per_band=minimum_points,
         wavelengths=tuple(float(value) for value in distinct_wavelengths),
         wavelength_min=(
             float(distinct_wavelengths[0]) if distinct_wavelengths.size else None
@@ -469,21 +531,52 @@ def build_wavelength_estimation_context(
             "model_lengthscale_units": "raw_wavelength_coordinate",
             "lengthscale_applied_to_models": False,
             "trend_order": "ascending_wavelength",
+            "n_usable_observational_channels": len(usable),
+            "n_distinct_physical_wavelengths": int(
+                distinct_wavelengths.size
+            ),
+            "multiple_observational_channels_per_wavelength": bool(
+                shared_wavelength_channels
+            ),
+            "observational_channels_by_shared_wavelength": {
+                f"{wavelength:.17g}": list(channels)
+                for wavelength, channels in shared_wavelength_channels.items()
+            },
+            "instrument_calibration_status": (
+                "not_implemented"
+                if shared_wavelength_channels
+                else "not_required"
+            ),
+            "instrument_calibration_tbd": bool(shared_wavelength_channels),
+            "shared_wavelength_trend_policy": (
+                "exclude_uncalibrated_shared_wavelengths"
+                if shared_wavelength_channels
+                else "not_applicable"
+            ),
+            "n_physical_wavelengths_used_for_trend_diagnostics": len(
+                usable_for_trends
+            ),
         },
     )
 
-    return diagnostics, band_diagnostics
+    return diagnostics, observational_channel_diagnostics
 
 
-def _wavelength_mean_band_points(
+def _wavelength_mean_observational_channel_points(
     raw_wavelengths: Any,
     model_wavelengths: Any,
     model_fluxes: Any,
-    band_labels: Any | None,
+    observational_channel_labels: Any | None,
     *,
-    min_points_per_band: int,
-) -> tuple[np.ndarray, np.ndarray, np.ndarray, tuple[str, ...]]:
-    """Return robust per-band points for wavelength-mean estimation."""
+    min_points_per_observational_channel: int,
+) -> tuple[
+    np.ndarray,
+    np.ndarray,
+    np.ndarray,
+    tuple[str, ...],
+    dict[str, Any],
+]:
+    """Return robust channel points safe for wavelength-mean estimation."""
     raw = _finite_array(raw_wavelengths)
     model = _finite_array(model_wavelengths)
     flux = _finite_array(model_fluxes)
@@ -493,7 +586,7 @@ def _wavelength_mean_band_points(
             "have the same length."
         )
 
-    if band_labels is None:
+    if observational_channel_labels is None:
         labels = np.asarray(
             [
                 _band_label_for_wavelength(value)
@@ -504,10 +597,14 @@ def _wavelength_mean_band_points(
             dtype=str,
         )
     else:
-        labels = np.asarray(band_labels, dtype=str).reshape(-1)
+        labels = np.asarray(
+            observational_channel_labels,
+            dtype=str,
+        ).reshape(-1)
         if labels.size != raw.size:
             raise ValueError(
-                "band_labels must have the same length as wavelength inputs."
+                "observational_channel_labels must have the same length as "
+                "wavelength inputs."
             )
 
     rows: list[tuple[float, float, float, str]] = []
@@ -518,7 +615,7 @@ def _wavelength_mean_band_points(
         raw_values = raw[finite]
         model_values = model[finite]
         flux_values = flux[finite]
-        if flux_values.size < min_points_per_band:
+        if flux_values.size < min_points_per_observational_channel:
             excluded.append(label)
             continue
         raw_median = float(np.median(raw_values))
@@ -544,11 +641,61 @@ def _wavelength_mean_band_points(
         )
 
     rows.sort(key=lambda item: item[0])
+    channels_by_wavelength: dict[float, list[str]] = {}
+    for raw_value, _, _, label in rows:
+        channels_by_wavelength.setdefault(raw_value, []).append(label)
+    shared_wavelength_channels = {
+        wavelength: tuple(channels)
+        for wavelength, channels in channels_by_wavelength.items()
+        if len(channels) > 1
+    }
+    shared_wavelengths = set(shared_wavelength_channels)
+
+    # TBD[instrument-channel-calibration]: Separate observational channels at
+    # one physical wavelength cannot contribute independent mean-fit points
+    # until an explicit calibration model exists. Excluding the wavelength is
+    # safer than silently combining channel medians or double-counting it.
+    retained_rows = [
+        item for item in rows if item[0] not in shared_wavelengths
+    ]
+    excluded_from_mean = [
+        item[3] for item in rows if item[0] in shared_wavelengths
+    ]
+
+    metadata = {
+        "n_usable_observational_channels": len(rows),
+        "n_distinct_physical_wavelengths": len(channels_by_wavelength),
+        "n_physical_wavelengths_used_for_mean_estimation": len(
+            {item[0] for item in retained_rows}
+        ),
+        "multiple_observational_channels_per_wavelength": bool(
+            shared_wavelength_channels
+        ),
+        "observational_channels_by_shared_wavelength": {
+            f"{wavelength:.17g}": list(channels)
+            for wavelength, channels in shared_wavelength_channels.items()
+        },
+        "instrument_calibration_status": (
+            "not_implemented"
+            if shared_wavelength_channels
+            else "not_required"
+        ),
+        "instrument_calibration_tbd": bool(shared_wavelength_channels),
+        "shared_wavelength_mean_policy": (
+            "exclude_uncalibrated_shared_wavelengths"
+            if shared_wavelength_channels
+            else "not_applicable"
+        ),
+        "observational_channels_excluded_from_mean_estimation": (
+            excluded_from_mean
+        ),
+    }
     return (
-        np.asarray([item[0] for item in rows], dtype=float),
-        np.asarray([item[1] for item in rows], dtype=float),
-        np.asarray([item[2] for item in rows], dtype=float),
+        np.asarray([item[0] for item in retained_rows], dtype=float),
+        np.asarray([item[1] for item in retained_rows], dtype=float),
+        np.asarray([item[2] for item in retained_rows], dtype=float),
         tuple(excluded),
+        metadata,
     )
 
 
@@ -873,47 +1020,102 @@ def build_wavelength_mean_estimation_context(
     model_fluxes: Any,
     band_labels: Any | None = None,
     *,
-    min_points_per_band: int = 3,
+    min_points_per_band: int | None = None,
+    observational_channel_labels: Any | None = None,
+    min_points_per_observational_channel: int | None = None,
 ) -> WavelengthMeanEstimationDiagnostics:
-    """Build model-ready wavelength-mean estimates from robust band medians.
+    """Build model-ready wavelength-mean estimates from channel medians.
 
     Dust and power-law recommendations use raw positive wavelength values but
-    fluxes in the transformed training-target coordinate.  The quadratic model
+    fluxes in the transformed training-target coordinate. The quadratic model
     uses the transformed wavelength coordinate because its coefficients are not
     assigned a physical wavelength interpretation.
+
+    ``observational_channel_labels`` and
+    ``min_points_per_observational_channel`` are the preferred argument names.
+    ``band_labels`` and ``min_points_per_band`` remain supported as legacy
+    aliases.
     """
-    raw, model, flux, excluded = _wavelength_mean_band_points(
-        raw_wavelengths,
-        model_wavelengths,
-        model_fluxes,
-        band_labels,
-        min_points_per_band=min_points_per_band,
+    if (
+        observational_channel_labels is not None
+        and band_labels is not None
+    ):
+        raise ValueError(
+            "observational_channel_labels and band_labels cannot both be "
+            "provided."
+        )
+    if (
+        min_points_per_observational_channel is not None
+        and min_points_per_band is not None
+    ):
+        raise ValueError(
+            "min_points_per_observational_channel and min_points_per_band "
+            "cannot both be provided."
+        )
+
+    channel_labels = (
+        observational_channel_labels
+        if observational_channel_labels is not None
+        else band_labels
+    )
+    minimum_points = (
+        min_points_per_observational_channel
+        if min_points_per_observational_channel is not None
+        else min_points_per_band
+    )
+    if minimum_points is None:
+        minimum_points = 3
+    if minimum_points < 1:
+        raise ValueError(
+            "min_points_per_observational_channel must be at least 1."
+        )
+
+    raw, model, flux, excluded, channel_metadata = (
+        _wavelength_mean_observational_channel_points(
+            raw_wavelengths,
+            model_wavelengths,
+            model_fluxes,
+            channel_labels,
+            min_points_per_observational_channel=minimum_points,
+        )
     )
     recommendations = {
         "2DWavelengthDependent": _quadratic_mean_recommendation(model, flux),
         "2DPowerLawMean": _power_law_mean_recommendation(raw, flux),
         "2DDustMean": _dust_mean_recommendation(raw, flux),
     }
-    warnings = tuple(
+    warnings = [
         f"{model_name}: {record.get('reason')}"
         for model_name, record in recommendations.items()
         if not record.get("available")
-    )
+    ]
+    if channel_metadata["multiple_observational_channels_per_wavelength"]:
+        warnings.append(
+            "Instrument-channel calibration is not implemented; physical "
+            "wavelengths shared by multiple observational channels were "
+            "excluded from wavelength-mean estimation."
+        )
+
     return WavelengthMeanEstimationDiagnostics(
         available=any(record.get("available") for record in recommendations.values()),
-        n_usable_bands=int(raw.size),
+        n_usable_bands=int(
+            channel_metadata["n_usable_observational_channels"]
+        ),
         raw_wavelengths=tuple(float(value) for value in raw),
         model_wavelengths=tuple(float(value) for value in model),
         model_median_fluxes=tuple(float(value) for value in flux),
         recommendations=recommendations,
-        warnings=warnings,
+        warnings=tuple(warnings),
         metadata={
             "uses_log_flux": False,
             "physical_mean_wavelength_coordinate": "raw_positive_wavelength",
             "quadratic_mean_wavelength_coordinate": "model_input_wavelength",
             "flux_coordinate": "model_training_target",
             "excluded_bands": list(excluded),
+            "excluded_observational_channels": list(excluded),
+            "min_points_per_observational_channel": minimum_points,
             "recommendations_applied_to_models": False,
+            **channel_metadata,
         },
     )
 

--- a/pgmuvi/wavelength_validation_real_lpv.py
+++ b/pgmuvi/wavelength_validation_real_lpv.py
@@ -1,0 +1,1731 @@
+"""Representative observed-LPV wavelength-validation orchestration.
+
+This module adapts the maintained period-independent wavelength advisory
+workflow to D3 representative observed sources.  It records source structure,
+fit evidence, warnings, constraints, and failures without constructing
+truth-recovery metrics or selecting a model automatically.
+"""
+
+from __future__ import annotations
+
+import math
+import platform
+import random
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from enum import Enum
+from importlib.metadata import PackageNotFoundError, version
+from typing import Any
+
+import numpy as np
+
+from .wavelength_validation import (
+    WavelengthValidationPhase,
+    WavelengthValidationScenario,
+    WavelengthValidationSourceKind,
+)
+
+REPRESENTATIVE_LPV_VALIDATION_SCHEMA_VERSION = "1.0"
+
+DEFAULT_REPRESENTATIVE_LPV_MODELS = (
+    "2DWavelengthDependent",
+    "2DDustMean",
+    "2DPowerLawMean",
+    "2DSeparable",
+    "2D",
+)
+
+
+def _json_safe(value: Any) -> Any:
+    """Return a recursively JSON-safe value."""
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if isinstance(value, Enum):
+        return value.value
+    if hasattr(value, "to_dict") and callable(value.to_dict):
+        return _json_safe(value.to_dict())
+    if isinstance(value, Mapping):
+        return {
+            str(key): _json_safe(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, Sequence) and not isinstance(
+        value,
+        (str, bytes, bytearray),
+    ):
+        return [_json_safe(item) for item in value]
+
+    detach = getattr(value, "detach", None)
+    if callable(detach):
+        try:
+            value = detach()
+            cpu = getattr(value, "cpu", None)
+            if callable(cpu):
+                value = cpu()
+        except (TypeError, ValueError, RuntimeError):
+            pass
+
+    tolist = getattr(value, "tolist", None)
+    if callable(tolist):
+        try:
+            return _json_safe(tolist())
+        except (TypeError, ValueError, RuntimeError):
+            pass
+
+    item = getattr(value, "item", None)
+    if callable(item):
+        try:
+            return _json_safe(item())
+        except (TypeError, ValueError, RuntimeError):
+            pass
+
+    return str(value)
+
+
+def _representative_lpv_package_version(
+    package_name: str,
+) -> str:
+    """Return an installed package version or an explicit fallback."""
+    try:
+        return version(package_name)
+    except PackageNotFoundError:
+        return "unknown"
+
+
+def build_representative_lpv_runtime_environment() -> dict[str, Any]:
+    """Return compact JSON-safe runtime provenance for D3 execution."""
+    try:
+        import gpytorch
+    except ImportError:
+        gpytorch_version = "unavailable"
+    else:
+        gpytorch_version = str(
+            getattr(gpytorch, "__version__", "unknown")
+        )
+
+    try:
+        import torch
+    except ImportError:
+        torch_version = "unavailable"
+        cuda_available = False
+    else:
+        torch_version = str(
+            getattr(torch, "__version__", "unknown")
+        )
+        cuda_available = bool(torch.cuda.is_available())
+
+    return {
+        "python_version": platform.python_version(),
+        "python_implementation": platform.python_implementation(),
+        "python_executable": sys.executable,
+        "platform": platform.platform(),
+        "pgmuvi_version": _representative_lpv_package_version(
+            "pgmuvi"
+        ),
+        "numpy_version": str(np.__version__),
+        "torch_version": torch_version,
+        "gpytorch_version": gpytorch_version,
+        "cuda_available": cuda_available,
+    }
+
+
+@contextmanager
+def _temporary_representative_lpv_seed(seed: int):
+    """Apply one source seed and restore all supported RNG states."""
+    import torch
+
+    python_state = random.getstate()
+    numpy_state = np.random.get_state()
+    torch_state = torch.random.get_rng_state()
+    cuda_states = (
+        torch.cuda.get_rng_state_all()
+        if torch.cuda.is_available()
+        else None
+    )
+
+    random.seed(seed)
+    np.random.seed(seed % (2**32))
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+    try:
+        yield
+    finally:
+        random.setstate(python_state)
+        np.random.set_state(numpy_state)
+        torch.random.set_rng_state(torch_state)
+        if cuda_states is not None:
+            torch.cuda.set_rng_state_all(cuda_states)
+
+
+def _numpy_array(value: Any) -> np.ndarray:
+    """Convert a tensor/array-like value to a NumPy array."""
+    detach = getattr(value, "detach", None)
+    if callable(detach):
+        value = detach()
+        cpu = getattr(value, "cpu", None)
+        if callable(cpu):
+            value = cpu()
+    return np.asarray(value)
+
+
+def _observational_channel_labels(lightcurve: Any) -> np.ndarray:
+    """Return row-aligned observational-channel labels."""
+    labels = getattr(
+        lightcurve,
+        "observational_channel_labels",
+        None,
+    )
+    if labels is None:
+        labels = getattr(lightcurve, "band", None)
+    if labels is None:
+        raise ValueError(
+            "Representative LPV validation requires row-aligned "
+            "observational-channel labels."
+        )
+
+    labels = np.asarray(labels, dtype=str)
+    if labels.ndim != 1:
+        raise ValueError(
+            "Observational-channel labels must be one-dimensional."
+        )
+    return labels
+
+
+def build_representative_lpv_source_summary(
+    lightcurve: Any,
+) -> dict[str, Any]:
+    """Summarize observed source rows, channels, and wavelengths.
+
+    Multiple observational channels at one physical wavelength remain
+    distinct.  No instrumental calibration, averaging, merging, flux
+    correction, or artificial wavelength reassignment is performed.
+    """
+    xdata = getattr(lightcurve, "_xdata_raw", None)
+    ydata = getattr(lightcurve, "_ydata_raw", None)
+    if xdata is None or ydata is None:
+        raise ValueError(
+            "Representative LPV validation requires a Lightcurve-like "
+            "object with raw xdata and ydata."
+        )
+
+    xarray = _numpy_array(xdata)
+    yarray = _numpy_array(ydata).reshape(-1)
+    if xarray.ndim != 2 or xarray.shape[1] < 2:
+        raise ValueError(
+            "Representative LPV validation requires two-dimensional "
+            "time/wavelength coordinates."
+        )
+    if xarray.shape[0] != yarray.shape[0]:
+        raise ValueError("Raw xdata and ydata row counts must match.")
+
+    channels = _observational_channel_labels(lightcurve)
+    if channels.shape[0] != xarray.shape[0]:
+        raise ValueError(
+            "Observational-channel labels must align with data rows."
+        )
+
+    wavelengths = np.asarray(xarray[:, 1], dtype=float)
+    finite = np.isfinite(wavelengths)
+    if not np.all(finite):
+        raise ValueError(
+            "Physical wavelength coordinates must be finite."
+        )
+
+    unique_channels = sorted(
+        str(item) for item in np.unique(channels)
+    )
+    unique_wavelengths = np.unique(wavelengths)
+
+    channels_by_wavelength: dict[str, list[str]] = {}
+    shared: dict[str, list[str]] = {}
+    for wavelength in unique_wavelengths:
+        mask = wavelengths == wavelength
+        attached_channels = sorted(
+            str(item) for item in np.unique(channels[mask])
+        )
+        key = format(float(wavelength), ".17g")
+        channels_by_wavelength[key] = attached_channels
+        if len(attached_channels) > 1:
+            shared[key] = attached_channels
+
+    return _json_safe(
+        {
+            "kind": "representative_lpv_source_summary",
+            "n_rows": int(xarray.shape[0]),
+            "n_observational_channels": len(unique_channels),
+            "observational_channels": unique_channels,
+            "n_distinct_physical_wavelengths": int(
+                unique_wavelengths.size
+            ),
+            "physical_wavelengths": [
+                float(item) for item in unique_wavelengths
+            ],
+            "observational_channels_by_physical_wavelength": (
+                channels_by_wavelength
+            ),
+            "multiple_observational_channels_per_wavelength": bool(
+                shared
+            ),
+            "observational_channels_by_shared_wavelength": shared,
+            "instrument_calibration_status": "not_implemented",
+            "instrument_calibration_tbd": True,
+            "instrument_calibration_marker": (
+                "TBD[instrument-channel-calibration]"
+            ),
+            "shared_wavelength_policy": (
+                "preserve_channels_without_calibration"
+            ),
+            "linear_flux": True,
+        }
+    )
+
+
+def _workflow_attempt_rows(
+    workflow_report: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    run_report = workflow_report.get("run_report")
+    run_report = (
+        run_report if isinstance(run_report, Mapping) else {}
+    )
+    rows = (
+        run_report.get("model_kernel_config_results")
+        or run_report.get("outcomes")
+        or ()
+    )
+    return [
+        dict(item)
+        for item in rows
+        if isinstance(item, Mapping)
+    ]
+
+
+def _period_evidence(
+    rows: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    by_model: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        period = row.get("consensus_period")
+        frequency = row.get("consensus_frequency")
+        if period is None and frequency is None:
+            continue
+        model = str(row.get("model") or "").strip()
+        if not model:
+            continue
+        by_model[model] = _json_safe(
+            {
+                "model_kernel_config_id": row.get(
+                    "model_kernel_config_id"
+                ),
+                "consensus_success": row.get("consensus_success"),
+                "consensus_period": period,
+                "consensus_frequency": frequency,
+                "consensus_time_kernel_constraint_mode": row.get(
+                    "consensus_time_kernel_constraint_mode"
+                ),
+                "n_accepted_observational_channels": row.get(
+                    "n_accepted_bands"
+                ),
+                "n_rejected_observational_channels": row.get(
+                    "n_rejected_bands"
+                ),
+            }
+        )
+
+    return {
+        "n_models_with_period_evidence": len(by_model),
+        "by_model": by_model,
+        "truth_recovery_evidence": False,
+    }
+
+
+def _fit_quality_evidence(
+    workflow_report: Mapping[str, Any],
+) -> dict[str, Any]:
+    quality = workflow_report.get("quality_report")
+    quality = quality if isinstance(quality, Mapping) else {}
+
+    ranking_status = (
+        quality.get("fit_quality_ranking_status")
+        or workflow_report.get("fit_quality_ranking_status")
+    )
+    ranking_available = (
+        quality.get("fit_quality_ranking_available")
+        if "fit_quality_ranking_available" in quality
+        else workflow_report.get(
+            "fit_quality_ranking_available",
+            False,
+        )
+    )
+
+    return _json_safe(
+        {
+            "score_kind": (
+                quality.get("score_kind")
+                or workflow_report.get("score_kind")
+            ),
+            "ranking_status": ranking_status,
+            "ranking_available": bool(ranking_available),
+            "n_with_fit_quality": quality.get(
+                "n_with_fit_quality"
+            ),
+            "top_ranked_model": (
+                quality.get("top_ranked_model")
+                or workflow_report.get("top_ranked_model")
+            ),
+            "top_ranked_fit_quality_score": (
+                quality.get("top_ranked_fit_quality_score")
+                or workflow_report.get(
+                    "top_ranked_fit_quality_score"
+                )
+            ),
+            "ranked_results": quality.get("ranked_results") or [],
+            "automatic_model_selection_applied": False,
+            "selected_model": None,
+            "truth_recovery_evidence": False,
+            "interpretation": (
+                "Descriptive training-space comparison evidence only."
+            ),
+        }
+    )
+
+
+def _residual_wavelength_evidence(
+    workflow_report: Mapping[str, Any],
+    source_summary: Mapping[str, Any],
+) -> dict[str, Any]:
+    config_report = workflow_report.get(
+        "model_kernel_config_report"
+    )
+    config_report = (
+        config_report
+        if isinstance(config_report, Mapping)
+        else {}
+    )
+    diagnostics = config_report.get(
+        "period_independent_diagnostics"
+    )
+    diagnostics = (
+        diagnostics if isinstance(diagnostics, Mapping) else {}
+    )
+
+    result = dict(_json_safe(diagnostics))
+    result.setdefault(
+        "n_observational_channels",
+        source_summary.get("n_observational_channels"),
+    )
+    result.setdefault(
+        "n_distinct_physical_wavelengths",
+        source_summary.get(
+            "n_distinct_physical_wavelengths"
+        ),
+    )
+    result["truth_recovery_evidence"] = False
+    return result
+
+
+def _constraint_evidence(
+    rows: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    by_model: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        model = str(row.get("model") or "").strip()
+        if not model:
+            continue
+        by_model[model] = _json_safe(
+            {
+                "model_kernel_config_id": row.get(
+                    "model_kernel_config_id"
+                ),
+                "parameter_workflow": row.get(
+                    "parameter_workflow"
+                )
+                or {},
+                "n_sm_ard_boundary_hits": row.get(
+                    "n_sm_ard_boundary_hits"
+                ),
+                "sm_ard_boundary_hits": row.get(
+                    "sm_ard_boundary_hits"
+                )
+                or [],
+                "n_constrained_sm_ard_components": row.get(
+                    "n_constrained_sm_ard_components"
+                ),
+                "constrained_sm_ard_components": row.get(
+                    "constrained_sm_ard_components"
+                )
+                or [],
+                "fit_kwargs": row.get("fit_kwargs") or {},
+            }
+        )
+    return {
+        "by_model": by_model,
+        "truth_recovery_evidence": False,
+    }
+
+
+def _warning_evidence(
+    rows: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    records = []
+    by_category: dict[str, int] = {}
+
+    for row in rows:
+        model = row.get("model")
+        config_id = row.get("model_kernel_config_id")
+        for warning in row.get("warnings") or ():
+            if not isinstance(warning, Mapping):
+                continue
+            record = {
+                **dict(warning),
+                "model": model,
+                "model_kernel_config_id": config_id,
+            }
+            records.append(_json_safe(record))
+            category = str(
+                warning.get("category") or "unclassified"
+            )
+            by_category[category] = (
+                by_category.get(category, 0) + 1
+            )
+
+    return {
+        "n_warning_records": len(records),
+        "by_category": by_category,
+        "records": records,
+    }
+
+
+def _failure_evidence(
+    rows: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    failures = []
+    by_code: dict[str, int] = {}
+    by_stage: dict[str, int] = {}
+
+    for row in rows:
+        failed = (
+            row.get("fit_failed") is True
+            or row.get("status") == "failed"
+            or row.get("technical_outcome") == "failed"
+        )
+        if not failed:
+            continue
+
+        code = str(
+            row.get("failure_code") or "unclassified_failure"
+        )
+        stage = str(
+            row.get("failure_stage") or "unclassified"
+        )
+        by_code[code] = by_code.get(code, 0) + 1
+        by_stage[stage] = by_stage.get(stage, 0) + 1
+
+        failures.append(
+            _json_safe(
+                {
+                    "model_kernel_config_id": row.get(
+                        "model_kernel_config_id"
+                    ),
+                    "model": row.get("model"),
+                    "failure_code": code,
+                    "failure_stage": stage,
+                    "failure_substage": row.get(
+                        "failure_substage"
+                    ),
+                    "failure_stage_reason": row.get(
+                        "failure_stage_reason"
+                    ),
+                    "exception_type": row.get("exception_type"),
+                    "exception_message": row.get(
+                        "exception_message"
+                    ),
+                    "is_consensus_failure": row.get(
+                        "is_consensus_failure"
+                    ),
+                    "is_numerical_failure": row.get(
+                        "is_numerical_failure"
+                    ),
+                    "is_input_validation_failure": row.get(
+                        "is_input_validation_failure"
+                    ),
+                }
+            )
+        )
+
+    return {
+        "n_failed_attempts": len(failures),
+        "by_code": by_code,
+        "by_stage": by_stage,
+        "records": failures,
+    }
+
+
+def _build_source_evidence(
+    workflow_report: Mapping[str, Any],
+    source_summary: Mapping[str, Any],
+) -> dict[str, Any]:
+    rows = _workflow_attempt_rows(workflow_report)
+    return {
+        "period_evidence": _period_evidence(rows),
+        "fit_quality": _fit_quality_evidence(workflow_report),
+        "residual_wavelength_structure": (
+            _residual_wavelength_evidence(
+                workflow_report,
+                source_summary,
+            )
+        ),
+        "constraint_diagnostics": _constraint_evidence(rows),
+        "warnings": _warning_evidence(rows),
+        "failures": _failure_evidence(rows),
+    }
+
+
+def _validate_nonselecting_workflow(
+    workflow_report: Mapping[str, Any],
+) -> None:
+    if workflow_report.get(
+        "automatic_model_selection_applied"
+    ) is not False:
+        raise ValueError(
+            "Representative LPV validation forbids automatic model "
+            "selection."
+        )
+    if workflow_report.get("selected_model") is not None:
+        raise ValueError(
+            "Representative LPV validation forbids automatic model "
+            "selection and requires selected_model=None."
+        )
+
+
+@dataclass(frozen=True)
+class RepresentativeLPVValidationReport:
+    """Typed D3 report for one representative observed LPV."""
+
+    report_id: str
+    scenario: WavelengthValidationScenario
+    source_summary: Mapping[str, Any]
+    workflow_report: Mapping[str, Any]
+    source_evidence: Mapping[str, Any]
+    schema_version: str = (
+        REPRESENTATIVE_LPV_VALIDATION_SCHEMA_VERSION
+    )
+    advisory_only: bool = True
+    automatic_model_selection_applied: bool = False
+    selected_model: str | None = None
+    notes: tuple[str, ...] = ()
+    extra_fields: Mapping[str, Any] = field(
+        default_factory=dict
+    )
+
+    def __post_init__(self) -> None:
+        report_id = str(self.report_id or "").strip()
+        if not report_id:
+            raise ValueError("report_id must be non-empty.")
+        object.__setattr__(self, "report_id", report_id)
+
+        scenario = self.scenario
+        if not isinstance(scenario, WavelengthValidationScenario):
+            scenario = WavelengthValidationScenario.from_mapping(
+                scenario
+            )
+            object.__setattr__(self, "scenario", scenario)
+
+        if (
+            scenario.phase
+            is not WavelengthValidationPhase.D3_REPRESENTATIVE_LPV
+        ):
+            raise ValueError(
+                "Representative LPV reports require a D3 scenario."
+            )
+        if (
+            scenario.source_kind
+            is not WavelengthValidationSourceKind.OBSERVED
+        ):
+            raise ValueError(
+                "Representative LPV reports require an observed source."
+            )
+        if scenario.truth is not None:
+            raise ValueError(
+                "Observed representative LPV reports cannot claim a "
+                "truth record."
+            )
+
+        if self.advisory_only is not True:
+            raise ValueError(
+                "Representative LPV reports must remain advisory-only."
+            )
+        if self.automatic_model_selection_applied is not False:
+            raise ValueError(
+                "Representative LPV reports cannot select a model."
+            )
+        if self.selected_model is not None:
+            raise ValueError(
+                "Representative LPV reports require "
+                "selected_model=None."
+            )
+
+        workflow = dict(_json_safe(self.workflow_report))
+        _validate_nonselecting_workflow(workflow)
+
+        object.__setattr__(
+            self,
+            "schema_version",
+            str(self.schema_version),
+        )
+        object.__setattr__(
+            self,
+            "source_summary",
+            dict(_json_safe(self.source_summary)),
+        )
+        object.__setattr__(self, "workflow_report", workflow)
+        object.__setattr__(
+            self,
+            "source_evidence",
+            dict(_json_safe(self.source_evidence)),
+        )
+        object.__setattr__(
+            self,
+            "notes",
+            tuple(str(item) for item in self.notes),
+        )
+        object.__setattr__(
+            self,
+            "extra_fields",
+            dict(_json_safe(self.extra_fields)),
+        )
+
+    @classmethod
+    def from_mapping(
+        cls,
+        payload: Mapping[str, Any],
+    ) -> RepresentativeLPVValidationReport:
+        """Reconstruct a report from a JSON-safe mapping."""
+        if not isinstance(payload, Mapping):
+            raise TypeError("payload must be a mapping.")
+
+        known = {
+            "schema_version",
+            "report_id",
+            "scenario",
+            "source_summary",
+            "workflow_report",
+            "source_evidence",
+            "advisory_only",
+            "automatic_model_selection_applied",
+            "selected_model",
+            "notes",
+            "extra_fields",
+        }
+        extras = dict(payload.get("extra_fields") or {})
+        for key, value in payload.items():
+            if key not in known:
+                extras[str(key)] = _json_safe(value)
+
+        return cls(
+            schema_version=str(
+                payload.get("schema_version")
+                or REPRESENTATIVE_LPV_VALIDATION_SCHEMA_VERSION
+            ),
+            report_id=str(payload.get("report_id") or ""),
+            scenario=WavelengthValidationScenario.from_mapping(
+                payload.get("scenario") or {}
+            ),
+            source_summary=payload.get("source_summary") or {},
+            workflow_report=payload.get("workflow_report") or {},
+            source_evidence=payload.get("source_evidence") or {},
+            advisory_only=payload.get("advisory_only", True),
+            automatic_model_selection_applied=payload.get(
+                "automatic_model_selection_applied",
+                False,
+            ),
+            selected_model=payload.get("selected_model"),
+            notes=tuple(payload.get("notes") or ()),
+            extra_fields=extras,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the stable JSON-safe D3 report envelope."""
+        return {
+            "schema_version": self.schema_version,
+            "report_id": self.report_id,
+            "scenario": self.scenario.to_dict(),
+            "source_summary": _json_safe(self.source_summary),
+            "workflow_report": _json_safe(self.workflow_report),
+            "source_evidence": _json_safe(self.source_evidence),
+            "advisory_only": True,
+            "automatic_model_selection_applied": False,
+            "selected_model": None,
+            "notes": list(self.notes),
+            "extra_fields": _json_safe(self.extra_fields),
+        }
+
+
+def build_representative_lpv_validation_report(
+    *,
+    source_id: str,
+    description: str,
+    source_summary: Mapping[str, Any],
+    workflow_report: Mapping[str, Any],
+    report_id: str | None = None,
+    notes: Sequence[str] = (),
+) -> RepresentativeLPVValidationReport:
+    """Build a D3 report from an already-completed advisory workflow."""
+    source_id = str(source_id or "").strip()
+    description = str(description or "").strip()
+    if not source_id:
+        raise ValueError("source_id must be non-empty.")
+    if not description:
+        raise ValueError("description must be non-empty.")
+    if not isinstance(workflow_report, Mapping):
+        raise TypeError("workflow_report must be a mapping.")
+
+    normalized_workflow = dict(_json_safe(workflow_report))
+    _validate_nonselecting_workflow(normalized_workflow)
+    normalized_summary = dict(_json_safe(source_summary))
+
+    scenario = WavelengthValidationScenario(
+        scenario_id=source_id,
+        phase=WavelengthValidationPhase.D3_REPRESENTATIVE_LPV,
+        source_kind=WavelengthValidationSourceKind.OBSERVED,
+        description=description,
+    )
+
+    return RepresentativeLPVValidationReport(
+        report_id=report_id or f"d3-representative-lpv:{source_id}",
+        scenario=scenario,
+        source_summary=normalized_summary,
+        workflow_report=normalized_workflow,
+        source_evidence=_build_source_evidence(
+            normalized_workflow,
+            normalized_summary,
+        ),
+        notes=(
+            "Observed-source D3 evidence is descriptive and contains "
+            "no truth-recovery gates.",
+            "Candidate rankings remain advisory and do not install a "
+            "model.",
+            *tuple(str(item) for item in notes),
+        ),
+    )
+
+
+def run_representative_lpv_validation(
+    lightcurve: Any,
+    *,
+    source_id: str,
+    description: str = "Representative observed LPV source.",
+    models: Sequence[str] = DEFAULT_REPRESENTATIVE_LPV_MODELS,
+    workflow_runner: Callable[..., Mapping[str, Any]] | None = None,
+    workflow_kwargs: Mapping[str, Any] | None = None,
+    report_id: str | None = None,
+    notes: Sequence[str] = (),
+) -> RepresentativeLPVValidationReport:
+    """Execute the maintained advisory workflow and build one D3 report."""
+    resolved_models = tuple(str(model) for model in models)
+    if not resolved_models:
+        raise ValueError("models must contain at least one model.")
+    if "2DAchromatic" in resolved_models:
+        raise ValueError(
+            "2DAchromatic is outside the representative LPV model "
+            "priority set."
+        )
+
+    if workflow_runner is None:
+        from .wavelength_diagnostics import (
+            run_period_independent_wavelength_advisory_workflow,
+        )
+
+        workflow_runner = (
+            run_period_independent_wavelength_advisory_workflow
+        )
+
+    kwargs = dict(workflow_kwargs or {})
+    kwargs.setdefault("include_models", resolved_models)
+    kwargs.setdefault("include_2d_baseline", True)
+    kwargs.setdefault("make_text_report", True)
+    kwargs.setdefault("make_plots", False)
+
+    workflow_report = workflow_runner(lightcurve, **kwargs)
+    if not isinstance(workflow_report, Mapping):
+        raise TypeError(
+            "workflow_runner must return a workflow mapping."
+        )
+    _validate_nonselecting_workflow(workflow_report)
+
+    source_summary = build_representative_lpv_source_summary(
+        lightcurve
+    )
+    return build_representative_lpv_validation_report(
+        source_id=source_id,
+        description=description,
+        source_summary=source_summary,
+        workflow_report=workflow_report,
+        report_id=report_id,
+        notes=notes,
+    )
+
+
+@dataclass(frozen=True)
+class RepresentativeLPVSourceSpecification:
+    """Manifest entry for one representative observed LPV source."""
+
+    source_id: str
+    source_path: str
+    description: str
+    sample_role: str
+    selection_reason: str
+    seed: int = 0
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "source_id",
+            "source_path",
+            "description",
+            "sample_role",
+            "selection_reason",
+        ):
+            value = str(getattr(self, field_name) or "").strip()
+            if not value:
+                raise ValueError(f"{field_name} must be non-empty.")
+            object.__setattr__(self, field_name, value)
+
+        if isinstance(self.seed, bool):
+            raise ValueError("seed must be a nonnegative integer.")
+        try:
+            seed = int(self.seed)
+        except (TypeError, ValueError) as exception:
+            raise ValueError(
+                "seed must be a nonnegative integer."
+            ) from exception
+        if seed < 0:
+            raise ValueError("seed must be nonnegative.")
+        object.__setattr__(self, "seed", seed)
+
+        if not isinstance(self.metadata, Mapping):
+            raise TypeError("metadata must be a mapping.")
+        object.__setattr__(
+            self,
+            "metadata",
+            dict(_json_safe(self.metadata)),
+        )
+
+    @classmethod
+    def from_mapping(
+        cls,
+        payload: Mapping[str, Any],
+    ) -> RepresentativeLPVSourceSpecification:
+        """Build a source specification from a JSON-style mapping."""
+        if not isinstance(payload, Mapping):
+            raise TypeError("source specification must be a mapping.")
+
+        return cls(
+            source_id=payload.get("source_id", ""),
+            source_path=payload.get("source_path", ""),
+            description=payload.get("description", ""),
+            sample_role=payload.get("sample_role", ""),
+            selection_reason=payload.get("selection_reason", ""),
+            seed=payload.get("seed", 0),
+            metadata=payload.get("metadata") or {},
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a stable JSON-safe manifest entry."""
+        return {
+            "source_id": self.source_id,
+            "source_path": self.source_path,
+            "description": self.description,
+            "sample_role": self.sample_role,
+            "selection_reason": self.selection_reason,
+            "seed": self.seed,
+            "metadata": _json_safe(self.metadata),
+        }
+
+
+def validate_representative_lpv_source_manifest(
+    manifest: Sequence[
+        RepresentativeLPVSourceSpecification | Mapping[str, Any]
+    ],
+) -> tuple[RepresentativeLPVSourceSpecification, ...]:
+    """Validate and normalize an ordered representative-source manifest."""
+    if isinstance(manifest, (str, bytes, bytearray)):
+        raise TypeError("manifest must be a sequence of source entries.")
+
+    try:
+        entries = tuple(manifest)
+    except TypeError as exception:
+        raise TypeError(
+            "manifest must be a sequence of source entries."
+        ) from exception
+
+    if not entries:
+        raise ValueError("manifest must contain at least one source.")
+
+    normalized = []
+    seen_source_ids = set()
+
+    for index, entry in enumerate(entries):
+        if isinstance(entry, RepresentativeLPVSourceSpecification):
+            specification = entry
+        elif isinstance(entry, Mapping):
+            specification = (
+                RepresentativeLPVSourceSpecification.from_mapping(entry)
+            )
+        else:
+            raise TypeError(
+                "manifest entry "
+                f"{index} must be a source specification or mapping."
+            )
+
+        if specification.source_id in seen_source_ids:
+            raise ValueError(
+                "duplicate source_id in representative LPV manifest: "
+                f"{specification.source_id}"
+            )
+        seen_source_ids.add(specification.source_id)
+        normalized.append(specification)
+
+    return tuple(normalized)
+
+
+def _representative_lpv_safe_path_component(
+    value: Any,
+    *,
+    fallback: str = "source",
+) -> str:
+    """Return a deterministic filesystem-safe path component."""
+    text = str(value or "").strip()
+    safe = "".join(
+        character
+        if character.isalnum() or character in {"-", "_", "."}
+        else "_"
+        for character in text
+    ).strip("._")
+    return safe or fallback
+
+
+def _representative_lpv_source_output_paths(
+    output_root: str,
+    source_id: str,
+) -> tuple[str, str]:
+    root = str(output_root or "").strip().rstrip("/")
+    if not root:
+        raise ValueError("output_root must be non-empty.")
+
+    safe_source_id = _representative_lpv_safe_path_component(
+        source_id
+    )
+    source_output_dir = f"{root}/sources/{safe_source_id}"
+    source_report_path = f"{source_output_dir}/report.json"
+    return source_output_dir, source_report_path
+
+
+def _representative_lpv_source_failure(
+    *,
+    stage: str,
+    exception: Exception,
+) -> dict[str, Any]:
+    return {
+        "stage": stage,
+        "failure_code": f"{stage}_failed",
+        "exception_type": type(exception).__name__,
+        "exception_message": str(exception),
+    }
+
+
+@dataclass(frozen=True)
+class RepresentativeLPVBatchReport:
+    """Failure-aware, non-selecting D3 report for an ordered source set."""
+
+    batch_id: str
+    source_manifest: Sequence[
+        RepresentativeLPVSourceSpecification | Mapping[str, Any]
+    ]
+    source_results: Sequence[Mapping[str, Any]]
+    output_root: str = "validation_outputs/d3_real_lpv"
+    models: Sequence[str] = DEFAULT_REPRESENTATIVE_LPV_MODELS
+    workflow_configuration: Mapping[str, Any] = field(
+        default_factory=dict
+    )
+    runtime_environment: Mapping[str, Any] = field(
+        default_factory=dict
+    )
+    schema_version: str = (
+        REPRESENTATIVE_LPV_VALIDATION_SCHEMA_VERSION
+    )
+    advisory_only: bool = True
+    automatic_model_selection_applied: bool = False
+    selected_model: str | None = None
+    writes_outputs: bool = False
+    automatic_constraints_applied: bool = False
+    automatic_initialization_applied: bool = False
+    notes: Sequence[str] = ()
+    extra_fields: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        batch_id = str(self.batch_id or "").strip()
+        if not batch_id:
+            raise ValueError("batch_id must be non-empty.")
+        object.__setattr__(self, "batch_id", batch_id)
+
+        output_root = str(self.output_root or "").strip().rstrip("/")
+        if not output_root:
+            raise ValueError("output_root must be non-empty.")
+        object.__setattr__(self, "output_root", output_root)
+
+        manifest = validate_representative_lpv_source_manifest(
+            self.source_manifest
+        )
+        object.__setattr__(self, "source_manifest", manifest)
+
+        models = tuple(str(model).strip() for model in self.models)
+        if not models or any(not model for model in models):
+            raise ValueError("models must contain non-empty model names.")
+        if len(set(models)) != len(models):
+            raise ValueError("models must not contain duplicates.")
+        if "2DAchromatic" in models:
+            raise ValueError(
+                "2DAchromatic is outside the representative LPV "
+                "candidate set."
+            )
+        object.__setattr__(self, "models", models)
+
+        if not isinstance(self.workflow_configuration, Mapping):
+            raise TypeError(
+                "workflow_configuration must be a mapping."
+            )
+        object.__setattr__(
+            self,
+            "workflow_configuration",
+            dict(_json_safe(self.workflow_configuration)),
+        )
+
+        if not isinstance(self.runtime_environment, Mapping):
+            raise TypeError("runtime_environment must be a mapping.")
+        object.__setattr__(
+            self,
+            "runtime_environment",
+            dict(_json_safe(self.runtime_environment)),
+        )
+
+        if len(self.source_results) != len(manifest):
+            raise ValueError(
+                "source_results must contain one row per manifest source."
+            )
+
+        normalized_results = []
+        expected_ids = tuple(item.source_id for item in manifest)
+        actual_ids = []
+
+        for row in self.source_results:
+            if not isinstance(row, Mapping):
+                raise TypeError(
+                    "each source result must be a mapping."
+                )
+            normalized = dict(_json_safe(row))
+            source_id = str(normalized.get("source_id") or "")
+            status = normalized.get("status")
+            if status not in {"completed", "failed"}:
+                raise ValueError(
+                    "source result status must be 'completed' or "
+                    "'failed'."
+                )
+            if status == "completed":
+                if normalized.get("validation_report") is None:
+                    raise ValueError(
+                        "completed source results require a validation "
+                        "report."
+                    )
+                if normalized.get("failure") is not None:
+                    raise ValueError(
+                        "completed source results cannot contain a "
+                        "failure."
+                    )
+            else:
+                if normalized.get("failure") is None:
+                    raise ValueError(
+                        "failed source results require a failure record."
+                    )
+
+            actual_ids.append(source_id)
+            normalized_results.append(normalized)
+
+        if tuple(actual_ids) != expected_ids:
+            raise ValueError(
+                "source_results must preserve manifest source order."
+            )
+
+        object.__setattr__(
+            self,
+            "source_results",
+            tuple(normalized_results),
+        )
+
+        if self.advisory_only is not True:
+            raise ValueError(
+                "representative LPV batch reports must remain "
+                "advisory-only."
+            )
+        if self.automatic_model_selection_applied is not False:
+            raise ValueError(
+                "representative LPV batch reports cannot apply "
+                "automatic model selection."
+            )
+        if self.selected_model is not None:
+            raise ValueError(
+                "representative LPV batch reports require "
+                "selected_model=None."
+            )
+        if self.writes_outputs is not False:
+            raise ValueError(
+                "the protocol runner must not write output artifacts."
+            )
+        if self.automatic_constraints_applied is not False:
+            raise ValueError(
+                "the D3 protocol runner cannot apply constraints "
+                "automatically."
+            )
+        if self.automatic_initialization_applied is not False:
+            raise ValueError(
+                "the D3 protocol runner cannot apply initialization "
+                "automatically."
+            )
+
+        object.__setattr__(
+            self,
+            "schema_version",
+            str(self.schema_version),
+        )
+        object.__setattr__(
+            self,
+            "notes",
+            tuple(str(item) for item in self.notes),
+        )
+        object.__setattr__(
+            self,
+            "extra_fields",
+            dict(_json_safe(self.extra_fields)),
+        )
+
+    @classmethod
+    def from_mapping(
+        cls,
+        payload: Mapping[str, Any],
+    ) -> RepresentativeLPVBatchReport:
+        """Reconstruct a batch report from its JSON-safe envelope."""
+        if not isinstance(payload, Mapping):
+            raise TypeError("payload must be a mapping.")
+
+        known = {
+            "schema_version",
+            "batch_id",
+            "source_manifest",
+            "source_results",
+            "output_root",
+            "models",
+            "workflow_configuration",
+            "runtime_environment",
+            "n_sources",
+            "n_completed_sources",
+            "n_failed_sources",
+            "source_status_counts",
+            "advisory_only",
+            "automatic_model_selection_applied",
+            "selected_model",
+            "writes_outputs",
+            "automatic_constraints_applied",
+            "automatic_initialization_applied",
+            "notes",
+            "extra_fields",
+        }
+        extras = dict(payload.get("extra_fields") or {})
+        for key, value in payload.items():
+            if key not in known:
+                extras[str(key)] = _json_safe(value)
+
+        return cls(
+            schema_version=payload.get(
+                "schema_version",
+                REPRESENTATIVE_LPV_VALIDATION_SCHEMA_VERSION,
+            ),
+            batch_id=payload.get("batch_id", ""),
+            source_manifest=payload.get("source_manifest") or (),
+            source_results=payload.get("source_results") or (),
+            output_root=payload.get(
+                "output_root",
+                "validation_outputs/d3_real_lpv",
+            ),
+            models=payload.get(
+                "models",
+                DEFAULT_REPRESENTATIVE_LPV_MODELS,
+            ),
+            workflow_configuration=payload.get(
+                "workflow_configuration"
+            )
+            or {},
+            runtime_environment=payload.get("runtime_environment")
+            or {},
+            advisory_only=payload.get("advisory_only", True),
+            automatic_model_selection_applied=payload.get(
+                "automatic_model_selection_applied",
+                False,
+            ),
+            selected_model=payload.get("selected_model"),
+            writes_outputs=payload.get("writes_outputs", False),
+            automatic_constraints_applied=payload.get(
+                "automatic_constraints_applied",
+                False,
+            ),
+            automatic_initialization_applied=payload.get(
+                "automatic_initialization_applied",
+                False,
+            ),
+            notes=payload.get("notes") or (),
+            extra_fields=extras,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the stable JSON-safe batch report envelope."""
+        completed = sum(
+            row["status"] == "completed"
+            for row in self.source_results
+        )
+        failed = sum(
+            row["status"] == "failed"
+            for row in self.source_results
+        )
+
+        return {
+            "schema_version": self.schema_version,
+            "batch_id": self.batch_id,
+            "source_manifest": [
+                item.to_dict() for item in self.source_manifest
+            ],
+            "source_results": _json_safe(self.source_results),
+            "output_root": self.output_root,
+            "models": list(self.models),
+            "workflow_configuration": _json_safe(
+                self.workflow_configuration
+            ),
+            "runtime_environment": _json_safe(
+                self.runtime_environment
+            ),
+            "n_sources": len(self.source_results),
+            "n_completed_sources": completed,
+            "n_failed_sources": failed,
+            "source_status_counts": {
+                "completed": completed,
+                "failed": failed,
+            },
+            "advisory_only": True,
+            "automatic_model_selection_applied": False,
+            "selected_model": None,
+            "writes_outputs": False,
+            "automatic_constraints_applied": False,
+            "automatic_initialization_applied": False,
+            "notes": list(self.notes),
+            "extra_fields": _json_safe(self.extra_fields),
+        }
+
+
+def _default_representative_lpv_source_loader(
+    specification: RepresentativeLPVSourceSpecification,
+) -> Any:
+    from .lightcurve import Lightcurve
+
+    return Lightcurve.from_csv(
+        specification.source_path,
+        check_sampling=False,
+        max_samples=None,
+        max_samples_per_band=None,
+    )
+
+
+def run_representative_lpv_validation_batch(
+    manifest: Sequence[
+        RepresentativeLPVSourceSpecification | Mapping[str, Any]
+    ],
+    *,
+    source_loader: Callable[
+        [RepresentativeLPVSourceSpecification],
+        Any,
+    ] | None = None,
+    workflow_runner: Callable[..., Mapping[str, Any]] | None = None,
+    models: Sequence[str] = DEFAULT_REPRESENTATIVE_LPV_MODELS,
+    workflow_kwargs: Mapping[str, Any] | None = None,
+    output_root: str = "validation_outputs/d3_real_lpv",
+    batch_id: str = "d3-representative-observed-lpv",
+    notes: Sequence[str] = (),
+) -> RepresentativeLPVBatchReport:
+    """Run a failure-aware D3 protocol over an ordered source manifest.
+
+    This protocol layer computes reports and deterministic intended output
+    paths.  It does not write files, install a model, apply constraints, or
+    apply initialization automatically.
+    """
+    specifications = validate_representative_lpv_source_manifest(
+        manifest
+    )
+
+    resolved_models = tuple(str(model).strip() for model in models)
+    if not resolved_models or any(
+        not model for model in resolved_models
+    ):
+        raise ValueError("models must contain non-empty model names.")
+    if len(set(resolved_models)) != len(resolved_models):
+        raise ValueError("models must not contain duplicates.")
+    if "2DAchromatic" in resolved_models:
+        raise ValueError(
+            "2DAchromatic is outside the representative LPV "
+            "candidate set."
+        )
+
+    loader = (
+        source_loader
+        if source_loader is not None
+        else _default_representative_lpv_source_loader
+    )
+    if not callable(loader):
+        raise TypeError("source_loader must be callable.")
+    if workflow_runner is not None and not callable(workflow_runner):
+        raise TypeError("workflow_runner must be callable.")
+
+    base_workflow_kwargs = dict(workflow_kwargs or {})
+    runtime_environment = (
+        build_representative_lpv_runtime_environment()
+    )
+    results = []
+
+    for specification in specifications:
+        source_output_dir, source_report_path = (
+            _representative_lpv_source_output_paths(
+                output_root,
+                specification.source_id,
+            )
+        )
+
+        base_result = {
+            "source_id": specification.source_id,
+            "source_specification": specification.to_dict(),
+            "source_output_dir": source_output_dir,
+            "source_report_path": source_report_path,
+        }
+
+        with _temporary_representative_lpv_seed(
+            specification.seed
+        ):
+            try:
+                lightcurve = loader(specification)
+            except Exception as exception:
+                results.append(
+                    {
+                        **base_result,
+                        "status": "failed",
+                        "execution_seed": specification.seed,
+                        "seed_applied": True,
+                        "seed_scope": (
+                            "source_loading_and_advisory_workflow"
+                        ),
+                        "validation_report": None,
+                        "failure": (
+                            _representative_lpv_source_failure(
+                                stage="source_loading",
+                                exception=exception,
+                            )
+                        ),
+                    }
+                )
+                continue
+
+            try:
+                validation_report = (
+                    run_representative_lpv_validation(
+                        lightcurve,
+                        source_id=specification.source_id,
+                        description=specification.description,
+                        models=resolved_models,
+                        workflow_runner=workflow_runner,
+                        workflow_kwargs=base_workflow_kwargs,
+                        notes=(
+                            (
+                                "sample_role="
+                                f"{specification.sample_role}"
+                            ),
+                            (
+                                "selection_reason="
+                                f"{specification.selection_reason}"
+                            ),
+                            f"seed={specification.seed}",
+                        ),
+                    )
+                )
+            except Exception as exception:
+                results.append(
+                    {
+                        **base_result,
+                        "status": "failed",
+                        "execution_seed": specification.seed,
+                        "seed_applied": True,
+                        "seed_scope": (
+                            "source_loading_and_advisory_workflow"
+                        ),
+                        "validation_report": None,
+                        "failure": (
+                            _representative_lpv_source_failure(
+                                stage="advisory_workflow",
+                                exception=exception,
+                            )
+                        ),
+                    }
+                )
+                continue
+
+            results.append(
+                {
+                    **base_result,
+                    "status": "completed",
+                    "execution_seed": specification.seed,
+                    "seed_applied": True,
+                    "seed_scope": (
+                        "source_loading_and_advisory_workflow"
+                    ),
+                    "validation_report": validation_report.to_dict(),
+                    "failure": None,
+                }
+            )
+
+    return RepresentativeLPVBatchReport(
+        batch_id=batch_id,
+        source_manifest=specifications,
+        source_results=results,
+        output_root=output_root,
+        models=resolved_models,
+        workflow_configuration=base_workflow_kwargs,
+        runtime_environment=runtime_environment,
+        notes=(
+            "Source order is preserved from the validated manifest.",
+            "A source loading or advisory workflow failure does not "
+            "abort later sources.",
+            "Output paths are deterministic protocol metadata; this "
+            "runner does not write files.",
+            "Each source seed controls source loading and advisory "
+            "execution while caller RNG states are restored.",
+            "Workflow configuration and compact runtime environment "
+            "provenance are retained in the batch report.",
+            *tuple(str(item) for item in notes),
+        ),
+    )
+
+
+def _representative_lpv_write_json(
+    path: Any,
+    payload: Any,
+) -> str:
+    """Write strict JSON and return the written path."""
+    import json
+    from pathlib import Path
+
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(
+            _json_safe(payload),
+            indent=2,
+            sort_keys=True,
+            allow_nan=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return str(output_path)
+
+
+def _representative_lpv_write_summary_csv(
+    path: Any,
+    source_results: Sequence[Mapping[str, Any]],
+) -> str:
+    """Write the compact source-level D3 status table."""
+    import csv
+    from pathlib import Path
+
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    fieldnames = (
+        "source_index",
+        "source_id",
+        "status",
+        "sample_role",
+        "seed",
+        "failure_stage",
+        "failure_code",
+        "exception_type",
+        "exception_message",
+        "source_artifact_path",
+    )
+
+    with output_path.open(
+        "w",
+        encoding="utf-8",
+        newline="",
+    ) as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+
+        for source_index, row in enumerate(source_results):
+            specification = row.get("source_specification") or {}
+            failure = row.get("failure") or {}
+            writer.writerow(
+                {
+                    "source_index": source_index,
+                    "source_id": row.get("source_id"),
+                    "status": row.get("status"),
+                    "sample_role": specification.get("sample_role"),
+                    "seed": specification.get("seed"),
+                    "failure_stage": failure.get("stage"),
+                    "failure_code": failure.get("failure_code"),
+                    "exception_type": failure.get("exception_type"),
+                    "exception_message": failure.get(
+                        "exception_message"
+                    ),
+                    "source_artifact_path": row.get(
+                        "exported_source_artifact_path"
+                    ),
+                }
+            )
+
+    return str(output_path)
+
+
+def export_representative_lpv_batch_report(
+    report: RepresentativeLPVBatchReport | Mapping[str, Any],
+    output_dir: Any | None = None,
+) -> dict[str, Any]:
+    """Serialize an already-computed D3 batch report.
+
+    This is an output layer only.  It does not load light curves, run fits,
+    score or rank candidates, select or install a model, or automatically
+    apply constraints or initialization.
+    """
+    from pathlib import Path
+
+    if isinstance(report, Mapping):
+        resolved_report = RepresentativeLPVBatchReport.from_mapping(
+            report
+        )
+    elif isinstance(report, RepresentativeLPVBatchReport):
+        resolved_report = report
+    else:
+        raise TypeError(
+            "report must be a RepresentativeLPVBatchReport or mapping."
+        )
+
+    destination = (
+        resolved_report.output_root
+        if output_dir is None
+        else output_dir
+    )
+    root = Path(destination)
+    root.mkdir(parents=True, exist_ok=True)
+
+    payload = resolved_report.to_dict()
+
+    batch_report_path = _representative_lpv_write_json(
+        root / "batch_report.json",
+        payload,
+    )
+    source_manifest_path = _representative_lpv_write_json(
+        root / "source_manifest.json",
+        payload["source_manifest"],
+    )
+
+    exported_source_rows = []
+    source_artifacts = []
+
+    for source_index, row in enumerate(payload["source_results"]):
+        source_id = str(row["source_id"])
+        safe_source_id = _representative_lpv_safe_path_component(
+            source_id,
+            fallback=f"source_{source_index:04d}",
+        )
+        source_dir = root / "sources" / safe_source_id
+        source_dir.mkdir(parents=True, exist_ok=True)
+
+        source_result_path = _representative_lpv_write_json(
+            source_dir / "source_result.json",
+            row,
+        )
+
+        if row["status"] == "completed":
+            source_artifact_kind = "validation_report"
+            source_artifact_path = _representative_lpv_write_json(
+                source_dir / "report.json",
+                row["validation_report"],
+            )
+        else:
+            source_artifact_kind = "failure"
+            source_artifact_path = _representative_lpv_write_json(
+                source_dir / "failure.json",
+                row["failure"],
+            )
+
+        exported_row = {
+            **row,
+            "exported_source_result_path": source_result_path,
+            "exported_source_artifact_kind": source_artifact_kind,
+            "exported_source_artifact_path": source_artifact_path,
+        }
+        exported_source_rows.append(exported_row)
+        source_artifacts.append(
+            {
+                "source_index": source_index,
+                "source_id": source_id,
+                "status": row["status"],
+                "source_dir": str(source_dir),
+                "source_result_path": source_result_path,
+                "artifact_kind": source_artifact_kind,
+                "artifact_path": source_artifact_path,
+            }
+        )
+
+    source_summary_path = _representative_lpv_write_summary_csv(
+        root / "source_summary.csv",
+        exported_source_rows,
+    )
+
+    export_manifest = {
+        "kind": "representative_lpv_batch_report_export",
+        "schema_version": resolved_report.schema_version,
+        "batch_id": resolved_report.batch_id,
+        "output_dir": str(root),
+        "batch_report_path": batch_report_path,
+        "source_manifest_path": source_manifest_path,
+        "source_summary_path": source_summary_path,
+        "source_artifacts": source_artifacts,
+        "n_sources": payload["n_sources"],
+        "n_completed_sources": payload["n_completed_sources"],
+        "n_failed_sources": payload["n_failed_sources"],
+        "advisory_only": True,
+        "automatic_model_selection_applied": False,
+        "selected_model": None,
+        "automatic_constraints_applied": False,
+        "automatic_initialization_applied": False,
+        "source_report_writes_only": True,
+        "runs_fits": False,
+    }
+    export_manifest_path = root / "export_manifest.json"
+    export_manifest["export_manifest_path"] = str(
+        export_manifest_path
+    )
+    _representative_lpv_write_json(
+        export_manifest_path,
+        export_manifest,
+    )
+    return dict(_json_safe(export_manifest))
+

--- a/scripts/run_representative_lpv_validation.py
+++ b/scripts/run_representative_lpv_validation.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Run the failure-aware D3 representative observed-LPV protocol."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from pgmuvi.wavelength_validation_real_lpv import (
+    DEFAULT_REPRESENTATIVE_LPV_MODELS,
+    RepresentativeLPVSourceSpecification,
+    export_representative_lpv_batch_report,
+    run_representative_lpv_validation_batch,
+    validate_representative_lpv_source_manifest,
+)
+
+
+def _read_json(json_path: Path) -> Any:
+    try:
+        return json.loads(json_path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exception:
+        raise ValueError(
+            f"JSON file does not exist: {json_path}"
+        ) from exception
+    except json.JSONDecodeError as exception:
+        raise ValueError(
+            f"Invalid JSON in {json_path}: {exception}"
+        ) from exception
+
+
+def load_representative_lpv_manifest(
+    manifest_path: str | Path,
+) -> tuple[RepresentativeLPVSourceSpecification, ...]:
+    """Load, validate, and resolve one ordered source manifest."""
+    resolved_manifest_path = Path(manifest_path).expanduser().resolve()
+    payload = _read_json(resolved_manifest_path)
+
+    if isinstance(payload, Mapping):
+        entries = payload.get("sources")
+        if entries is None:
+            raise ValueError(
+                "Manifest objects must contain a 'sources' list."
+            )
+    else:
+        entries = payload
+
+    specifications = validate_representative_lpv_source_manifest(
+        entries
+    )
+    resolved_specifications = []
+
+    for specification in specifications:
+        source_path = Path(specification.source_path).expanduser()
+        if not source_path.is_absolute():
+            source_path = (
+                resolved_manifest_path.parent / source_path
+            ).resolve()
+
+        resolved_specifications.append(
+            RepresentativeLPVSourceSpecification(
+                source_id=specification.source_id,
+                source_path=str(source_path),
+                description=specification.description,
+                sample_role=specification.sample_role,
+                selection_reason=specification.selection_reason,
+                seed=specification.seed,
+                metadata={
+                    **dict(specification.metadata),
+                    "manifest_path": str(resolved_manifest_path),
+                    "manifest_source_path": (
+                        specification.source_path
+                    ),
+                },
+            )
+        )
+
+    return tuple(resolved_specifications)
+
+
+def load_representative_lpv_workflow_configuration(
+    configuration_path: str | Path | None,
+) -> dict[str, Any]:
+    """Load optional workflow keyword arguments from strict JSON."""
+    if configuration_path is None:
+        return {}
+
+    resolved_path = Path(configuration_path).expanduser().resolve()
+    payload = _read_json(resolved_path)
+    if not isinstance(payload, Mapping):
+        raise ValueError(
+            "Workflow configuration JSON must contain an object."
+        )
+    return dict(payload)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run the failure-aware, advisory-only D3 representative "
+            "observed-LPV validation protocol."
+        )
+    )
+    parser.add_argument(
+        "--manifest",
+        required=True,
+        help=(
+            "JSON source manifest. Relative source paths are resolved "
+            "relative to this file."
+        ),
+    )
+    parser.add_argument(
+        "--workflow-config",
+        help=(
+            "Optional JSON mapping passed as workflow_kwargs to the "
+            "D3 batch runner."
+        ),
+    )
+    parser.add_argument(
+        "--output-root",
+        default="validation_outputs/d3_real_lpv",
+        help=(
+            "Output directory used by the report exporter. Default: "
+            "validation_outputs/d3_real_lpv"
+        ),
+    )
+    parser.add_argument(
+        "--batch-id",
+        default="d3-representative-observed-lpv",
+        help="Stable identifier stored in the batch report.",
+    )
+    parser.add_argument(
+        "--validate-manifest-only",
+        action="store_true",
+        help=(
+            "Validate and resolve the manifest without loading sources, "
+            "running fits, or writing outputs."
+        ),
+    )
+    parser.add_argument(
+        "--no-export",
+        action="store_true",
+        help=(
+            "Run the protocol but do not serialize its report artifacts."
+        ),
+    )
+    parser.add_argument(
+        "--fail-on-source-failure",
+        action="store_true",
+        help=(
+            "Return exit status 2 after reporting when one or more "
+            "sources failed. Later sources are still attempted."
+        ),
+    )
+    return parser
+
+
+def _print_json(payload: Mapping[str, Any]) -> None:
+    print(
+        json.dumps(
+            payload,
+            indent=2,
+            sort_keys=True,
+            allow_nan=False,
+        )
+    )
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    batch_runner: Callable[..., Any] = (
+        run_representative_lpv_validation_batch
+    ),
+    exporter: Callable[..., Mapping[str, Any]] = (
+        export_representative_lpv_batch_report
+    ),
+) -> int:
+    parser = build_parser()
+    arguments = parser.parse_args(argv)
+
+    try:
+        specifications = load_representative_lpv_manifest(
+            arguments.manifest
+        )
+        workflow_configuration = (
+            load_representative_lpv_workflow_configuration(
+                arguments.workflow_config
+            )
+        )
+    except (TypeError, ValueError) as exception:
+        parser.error(str(exception))
+
+    if arguments.validate_manifest_only:
+        _print_json(
+            {
+                "kind": (
+                    "representative_lpv_manifest_validation"
+                ),
+                "valid": True,
+                "manifest_path": str(
+                    Path(arguments.manifest)
+                    .expanduser()
+                    .resolve()
+                ),
+                "n_sources": len(specifications),
+                "source_ids": [
+                    item.source_id for item in specifications
+                ],
+                "models": list(
+                    DEFAULT_REPRESENTATIVE_LPV_MODELS
+                ),
+                "runs_fits": False,
+                "writes_outputs": False,
+                "automatic_model_selection_applied": False,
+                "selected_model": None,
+            }
+        )
+        return 0
+
+    batch_report = batch_runner(
+        specifications,
+        workflow_kwargs=workflow_configuration,
+        output_root=arguments.output_root,
+        batch_id=arguments.batch_id,
+    )
+    batch_payload = batch_report.to_dict()
+
+    export_manifest = None
+    if not arguments.no_export:
+        export_manifest = exporter(
+            batch_report,
+            arguments.output_root,
+        )
+
+    result = {
+        "kind": "representative_lpv_cli_result",
+        "batch_id": batch_payload["batch_id"],
+        "n_sources": batch_payload["n_sources"],
+        "n_completed_sources": (
+            batch_payload["n_completed_sources"]
+        ),
+        "n_failed_sources": batch_payload["n_failed_sources"],
+        "source_status_counts": (
+            batch_payload["source_status_counts"]
+        ),
+        "models": batch_payload["models"],
+        "output_root": arguments.output_root,
+        "exported": export_manifest is not None,
+        "export_manifest": export_manifest,
+        "advisory_only": True,
+        "automatic_model_selection_applied": False,
+        "selected_model": None,
+    }
+    _print_json(result)
+
+    if (
+        arguments.fail_on_source_failure
+        and batch_payload["n_failed_sources"] > 0
+    ):
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_docs_lightcurve_validation.py
+++ b/tests/test_docs_lightcurve_validation.py
@@ -23,7 +23,7 @@ class TestLightcurveValidationDocs(unittest.TestCase):
             "CSV input contract",
             "Auto-detected CSV columns",
             "Numeric wavelength",
-            "String band label",
+            "Observational-channel label",
             "shape ``(N, 2)``",
             "arbitrary numeric indices",
             "actual numeric wavelengths",

--- a/tests/test_docs_observational_channel_terminology.py
+++ b/tests/test_docs_observational_channel_terminology.py
@@ -1,0 +1,60 @@
+"""Documentation contracts for observational-channel terminology."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LOADING = ROOT / "docs/source/howto/loading_data.rst"
+MULTIBAND = ROOT / "docs/source/howto/multiband.rst"
+ESTIMATION = ROOT / "docs/source/pgmuvi.wavelength_estimation.rst"
+FUTURE = ROOT / "docs/source/future_work.rst"
+
+
+class TestObservationalChannelDocumentation(unittest.TestCase):
+    def test_loading_guide_defines_channel_and_wavelength_roles(self):
+        text = " ".join(LOADING.read_text(encoding="utf-8").split())
+
+        self.assertIn("observational-channel label", text)
+        self.assertIn("physical wavelength coordinate", text)
+        self.assertIn(
+            "multiple observational channels may share one physical wavelength",
+            text,
+        )
+        self.assertIn(
+            "Lightcurve.band is retained as the legacy attribute",
+            text,
+        )
+
+    def test_multiband_guide_uses_distinct_terms(self):
+        text = " ".join(MULTIBAND.read_text(encoding="utf-8").split())
+
+        self.assertIn("observational channel", text)
+        self.assertIn("physical wavelength", text)
+        self.assertIn(
+            "observational-channel labels do not replace the numeric physical "
+            "wavelength coordinate",
+            text,
+        )
+        self.assertIn("TBD[instrument-channel-calibration]", text)
+
+    def test_wavelength_estimation_documents_channel_level_evidence(self):
+        text = " ".join(ESTIMATION.read_text(encoding="utf-8").split())
+
+        self.assertIn("per-observational-channel", text)
+        self.assertIn("distinct physical wavelengths", text)
+        self.assertIn("TBD[instrument-channel-calibration]", text)
+        self.assertIn("No instrument-channel calibration is performed", text)
+
+    def test_future_work_registers_calibration_tbd(self):
+        text = FUTURE.read_text(encoding="utf-8")
+
+        self.assertIn("TBD[instrument-channel-calibration]", text)
+        self.assertIn("observational channels", text)
+        self.assertIn("physical wavelength", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_docs_wavelength_validation_real_lpv.py
+++ b/tests/test_docs_wavelength_validation_real_lpv.py
@@ -1,0 +1,230 @@
+"""Public API and documentation contracts for D3 real-LPV validation."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+import pgmuvi
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = ROOT / "docs" / "source"
+
+
+def _normalized(path: Path) -> str:
+    return " ".join(path.read_text(encoding="utf-8").split())
+
+
+class TestRepresentativeLPVPublicAPI(unittest.TestCase):
+    def test_module_is_listed_in_package_public_api(self):
+        self.assertIn(
+            "wavelength_validation_real_lpv",
+            pgmuvi.__all__,
+        )
+
+
+class TestRepresentativeLPVAPIReference(unittest.TestCase):
+    def test_api_toctree_includes_real_lpv_module(self):
+        text = (DOCS / "api.rst").read_text(encoding="utf-8")
+        self.assertIn(
+            "pgmuvi.wavelength_validation_real_lpv",
+            text,
+        )
+
+    def test_real_lpv_api_page_exists_and_uses_automodule(self):
+        path = DOCS / "pgmuvi.wavelength_validation_real_lpv.rst"
+        self.assertTrue(path.is_file())
+
+        normalized = _normalized(path)
+        self.assertIn(
+            ".. automodule:: pgmuvi.wavelength_validation_real_lpv",
+            normalized,
+        )
+        self.assertIn(":members:", normalized)
+        self.assertIn(":undoc-members:", normalized)
+        self.assertIn(":show-inheritance:", normalized)
+
+
+class TestRepresentativeLPVHowToGuide(unittest.TestCase):
+    def test_howto_index_includes_real_lpv_validation_guide(self):
+        text = (DOCS / "howto" / "index.rst").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn(
+            "representative_lpv_validation",
+            text,
+        )
+
+    def test_real_lpv_validation_guide_documents_contract(self):
+        path = DOCS / "howto" / "representative_lpv_validation.rst"
+        self.assertTrue(path.is_file())
+
+        normalized = _normalized(path)
+
+        required = (
+            "D3",
+            "representative observed LPV",
+            "examples/data/10131+3049.csv",
+            "linear flux",
+            "observational channel",
+            "physical wavelength",
+            "TBD[instrument-channel-calibration]",
+            "2DWavelengthDependent",
+            "2DDustMean",
+            "2DPowerLawMean",
+            "2DSeparable",
+            "2D",
+            'fit_strategy="consensus"',
+            'time_kernel_type="quasi_periodic"',
+            "learn_additional_noise=True",
+            "run_representative_lpv_validation",
+            "automatic model selection",
+            "selected_model",
+            "truth-recovery",
+        )
+        for token in required:
+            with self.subTest(token=token):
+                self.assertIn(token, normalized)
+
+        self.assertNotIn("2DAchromatic", normalized)
+
+    def test_guide_distinguishes_ranked_evidence_from_selection(self):
+        normalized = _normalized(
+            DOCS / "howto" / "representative_lpv_validation.rst"
+        )
+        self.assertIn(
+            "A top-ranked model is descriptive evidence",
+            normalized,
+        )
+        self.assertIn(
+            "does not install or select that model",
+            normalized,
+        )
+
+    def test_guide_documents_shared_wavelength_policy(self):
+        normalized = _normalized(
+            DOCS / "howto" / "representative_lpv_validation.rst"
+        )
+        self.assertIn(
+            "multiple observational channels may share one physical wavelength",
+            normalized,
+        )
+        self.assertIn(
+            "does not average, merge, calibrate, correct, or reassign",
+            normalized,
+        )
+
+
+
+    def test_guide_documents_failure_aware_batch_protocol(self):
+        normalized = _normalized(
+            DOCS / "howto" / "representative_lpv_validation.rst"
+        )
+
+        required = (
+            "RepresentativeLPVSourceSpecification",
+            "run_representative_lpv_validation_batch",
+            "Manifest order is preserved",
+            "Duplicate source identifiers are rejected",
+            "does not abort later manifest entries",
+            "validation_outputs/d3_real_lpv/sources/<source_id>",
+            "writes_outputs=False",
+            "does not automatically apply wavelength-derived constraints",
+            "initialization",
+        )
+        for token in required:
+            with self.subTest(token=token):
+                self.assertIn(token, normalized)
+
+    def test_guide_documents_reproducible_execution_provenance(self):
+        normalized = _normalized(
+            DOCS / "howto" / "representative_lpv_validation.rst"
+        )
+
+        required = (
+            "seed is applied across source loading and advisory execution",
+            "Python, NumPy, and PyTorch",
+            "RNG streams advanced",
+            "exact workflow configuration",
+            "compact runtime provenance",
+            "GPyTorch",
+            "package-version information",
+        )
+        for token in required:
+            with self.subTest(token=token):
+                self.assertIn(token, normalized)
+
+    def test_guide_documents_command_line_runner(self):
+        normalized = _normalized(
+            DOCS / "howto" / "representative_lpv_validation.rst"
+        )
+
+        required = (
+            "scripts/run_representative_lpv_validation.py",
+            "d3_representative_lpv_manifest.json",
+            "d3_representative_lpv_workflow.json",
+            "--validate-manifest-only",
+            "resolves relative source paths",
+            "writes no outputs",
+            "--fail-on-source-failure",
+            "status 2",
+        )
+        for token in required:
+            with self.subTest(token=token):
+                self.assertIn(token, normalized)
+
+    def test_guide_documents_report_export_layer(self):
+        normalized = _normalized(
+            DOCS / "howto" / "representative_lpv_validation.rst"
+        )
+
+        required = (
+            "export_representative_lpv_batch_report",
+            "strict JSON",
+            "source-summary CSV",
+            "source_result.json",
+            "report.json",
+            "failure.json",
+            "Filesystem path components are sanitized",
+            "does not rerun fits",
+        )
+        for token in required:
+            with self.subTest(token=token):
+                self.assertIn(token, normalized)
+
+    def test_guide_does_not_claim_batch_runner_writes_outputs(self):
+        normalized = _normalized(
+            DOCS / "howto" / "representative_lpv_validation.rst"
+        )
+
+        self.assertIn(
+            "The protocol runner does not create those directories or write report files",
+            normalized,
+        )
+        self.assertNotIn(
+            "The protocol runner writes report files",
+            normalized,
+        )
+
+
+class TestRepresentativeLPVFutureWorkStatus(unittest.TestCase):
+    def test_future_work_no_longer_calls_d3_the_next_unimplemented_step(self):
+        normalized = _normalized(DOCS / "future_work.rst")
+
+        self.assertNotIn(
+            "The next validation step is D3 application",
+            normalized,
+        )
+        self.assertIn(
+            "D3 representative observed-LPV validation infrastructure",
+            normalized,
+        )
+        self.assertIn(
+            "TBD[instrument-channel-calibration]",
+            normalized,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_docs_wavelength_validation_robustness.py
+++ b/tests/test_docs_wavelength_validation_robustness.py
@@ -38,7 +38,7 @@ class TestSyntheticWavelengthRobustnessDocumentation(unittest.TestCase):
 
         self.assertIn("canonical 20-seed D2 robustness calibration", normalized)
         self.assertIn("maintained wavelength-constraint notebook are complete", normalized)
-        self.assertIn("D3 application to representative real LPV sources", normalized)
+        self.assertIn("D3 representative observed-LPV validation infrastructure", normalized)
         self.assertNotIn("Execute and document the full D2 population", future)
 
     def test_notebook_status_tracks_constraint_walkthrough(self):

--- a/tests/test_docs_wavelength_validation_robustness_calibration.py
+++ b/tests/test_docs_wavelength_validation_robustness_calibration.py
@@ -57,7 +57,7 @@ class TestSyntheticWavelengthRobustnessCalibrationDocumentation(
         normalized = " ".join(future.split())
         self.assertIn("canonical 20-seed D2 robustness calibration", normalized)
         self.assertIn("maintained wavelength-constraint notebook are complete", normalized)
-        self.assertIn("D3 application to representative real LPV sources", normalized)
+        self.assertIn("D3 representative observed-LPV validation infrastructure", normalized)
         self.assertNotIn("Execute and document the full D2 population", future)
 
 

--- a/tests/test_observational_channel_count_semantics.py
+++ b/tests/test_observational_channel_count_semantics.py
@@ -1,0 +1,39 @@
+"""Regression tests for wavelength evidence and channel counts."""
+
+import unittest
+
+from pgmuvi.parameter_context import (
+    WavelengthMeanEstimationDiagnostics,
+)
+
+
+class TestObservationalChannelCountSemantics(unittest.TestCase):
+    """Keep channel counts distinct from mean-fit evidence counts."""
+
+    def test_preferred_property_uses_channel_metadata(self):
+        diagnostics = WavelengthMeanEstimationDiagnostics(
+            n_usable_bands=3,
+            metadata={
+                "n_usable_observational_channels": 5,
+            },
+        )
+
+        self.assertEqual(
+            diagnostics.n_usable_observational_channels,
+            5,
+        )
+        self.assertEqual(diagnostics.n_usable_bands, 3)
+
+    def test_legacy_payload_falls_back_to_evidence_count(self):
+        diagnostics = WavelengthMeanEstimationDiagnostics(
+            n_usable_bands=3,
+        )
+
+        self.assertEqual(
+            diagnostics.n_usable_observational_channels,
+            3,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_observational_channel_mean_estimation.py
+++ b/tests/test_observational_channel_mean_estimation.py
@@ -126,6 +126,23 @@ class TestObservationalChannelMeanEstimation(unittest.TestCase):
 
         metadata = diagnostics.metadata
         self.assertEqual(metadata["n_usable_observational_channels"], 5)
+        self.assertEqual(diagnostics.n_usable_bands, 3)
+        self.assertEqual(
+            diagnostics.n_usable_observational_channels,
+            5,
+        )
+        self.assertEqual(
+            diagnostics.n_usable_bands,
+            len(diagnostics.raw_wavelengths),
+        )
+        self.assertEqual(
+            diagnostics.n_usable_bands,
+            len(diagnostics.model_wavelengths),
+        )
+        self.assertEqual(
+            diagnostics.n_usable_bands,
+            len(diagnostics.model_median_fluxes),
+        )
         self.assertEqual(metadata["n_distinct_physical_wavelengths"], 4)
         self.assertEqual(
             metadata["n_physical_wavelengths_used_for_mean_estimation"],

--- a/tests/test_observational_channel_mean_estimation.py
+++ b/tests/test_observational_channel_mean_estimation.py
@@ -1,0 +1,165 @@
+"""Observational-channel contracts for wavelength-mean estimation."""
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+
+from pgmuvi.wavelength_estimation import (
+    build_wavelength_mean_estimation_context,
+)
+
+
+class TestObservationalChannelMeanEstimation(unittest.TestCase):
+    @staticmethod
+    def _rows():
+        raw_wavelengths = []
+        model_wavelengths = []
+        model_fluxes = []
+        observational_channels = []
+
+        channel_rows = [
+            # Two independent observational channels at one wavelength.
+            ("instrument-r-0", 0.5, 0.0, 1.0),
+            ("instrument-r-1", 0.5, 0.0, 1.4),
+            # Three unambiguous physical wavelengths.
+            ("channel-j", 1.0, 0.2, 2.0),
+            ("channel-h", 2.0, 0.4, 3.0),
+            ("channel-k", 4.0, 0.8, 5.0),
+        ]
+
+        for channel, raw, model, flux in channel_rows:
+            for offset in (-0.01, 0.0, 0.01):
+                raw_wavelengths.append(raw)
+                model_wavelengths.append(model)
+                model_fluxes.append(flux + offset)
+                observational_channels.append(channel)
+
+        return (
+            np.asarray(raw_wavelengths, dtype=float),
+            np.asarray(model_wavelengths, dtype=float),
+            np.asarray(model_fluxes, dtype=float),
+            np.asarray(observational_channels, dtype=str),
+        )
+
+    def test_preferred_observational_channel_arguments_are_supported(self):
+        raw, model, flux, channels = self._rows()
+
+        diagnostics = build_wavelength_mean_estimation_context(
+            raw,
+            model,
+            flux,
+            observational_channel_labels=channels,
+            min_points_per_observational_channel=3,
+        )
+
+        self.assertTrue(diagnostics.available)
+
+    def test_legacy_band_arguments_remain_supported(self):
+        raw, model, flux, channels = self._rows()
+
+        diagnostics = build_wavelength_mean_estimation_context(
+            raw,
+            model,
+            flux,
+            band_labels=channels,
+            min_points_per_band=3,
+        )
+
+        self.assertTrue(diagnostics.available)
+
+    def test_preferred_and_legacy_labels_cannot_both_be_supplied(self):
+        raw, model, flux, channels = self._rows()
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "observational_channel_labels.*band_labels",
+        ):
+            build_wavelength_mean_estimation_context(
+                raw,
+                model,
+                flux,
+                band_labels=channels,
+                observational_channel_labels=channels,
+            )
+
+    def test_preferred_and_legacy_minimums_cannot_both_be_supplied(self):
+        raw, model, flux, channels = self._rows()
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "min_points_per_observational_channel.*min_points_per_band",
+        ):
+            build_wavelength_mean_estimation_context(
+                raw,
+                model,
+                flux,
+                observational_channel_labels=channels,
+                min_points_per_band=3,
+                min_points_per_observational_channel=3,
+            )
+
+    def test_uncalibrated_shared_wavelength_is_excluded_from_mean_fit(self):
+        raw, model, flux, channels = self._rows()
+
+        diagnostics = build_wavelength_mean_estimation_context(
+            raw,
+            model,
+            flux,
+            observational_channel_labels=channels,
+            min_points_per_observational_channel=3,
+        )
+
+        self.assertEqual(
+            diagnostics.raw_wavelengths,
+            (1.0, 2.0, 4.0),
+        )
+        self.assertEqual(
+            diagnostics.model_wavelengths,
+            (0.2, 0.4, 0.8),
+        )
+        self.assertEqual(
+            diagnostics.model_median_fluxes,
+            (2.0, 3.0, 5.0),
+        )
+
+        metadata = diagnostics.metadata
+        self.assertEqual(metadata["n_usable_observational_channels"], 5)
+        self.assertEqual(metadata["n_distinct_physical_wavelengths"], 4)
+        self.assertEqual(
+            metadata["n_physical_wavelengths_used_for_mean_estimation"],
+            3,
+        )
+        self.assertTrue(
+            metadata["multiple_observational_channels_per_wavelength"]
+        )
+        self.assertEqual(
+            metadata["instrument_calibration_status"],
+            "not_implemented",
+        )
+        self.assertTrue(metadata["instrument_calibration_tbd"])
+        self.assertEqual(
+            metadata["shared_wavelength_mean_policy"],
+            "exclude_uncalibrated_shared_wavelengths",
+        )
+        self.assertEqual(
+            metadata["observational_channels_by_shared_wavelength"],
+            {
+                "0.5": [
+                    "instrument-r-0",
+                    "instrument-r-1",
+                ]
+            },
+        )
+
+        for recommendation in diagnostics.recommendations.values():
+            self.assertNotIn(0.5, diagnostics.raw_wavelengths)
+            self.assertNotEqual(
+                recommendation.get("reason"),
+                "instrument_channels_silently_combined",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_observational_channel_public_api.py
+++ b/tests/test_observational_channel_public_api.py
@@ -1,0 +1,55 @@
+"""Public API contracts for observational-channel terminology."""
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+
+from pgmuvi.lightcurve import Lightcurve
+from pgmuvi.parameter_context import (
+    BandDiagnostics,
+    ObservationalChannelDiagnostics,
+)
+
+
+class TestObservationalChannelPublicAPI(unittest.TestCase):
+    def test_preferred_diagnostics_name_is_public_alias(self):
+        self.assertIs(ObservationalChannelDiagnostics, BandDiagnostics)
+
+    def test_lightcurve_exposes_observational_channel_labels(self):
+        xdata = np.asarray(
+            [
+                [0.0, 1.0],
+                [1.0, 1.0],
+                [0.0, 2.0],
+                [1.0, 2.0],
+            ]
+        )
+        flux = np.asarray([1.0, 1.1, 2.0, 2.1])
+        error = np.full(4, 0.1)
+        labels = np.asarray(
+            ["channel-a", "channel-a", "channel-b", "channel-b"]
+        )
+
+        lightcurve = Lightcurve(
+            xdata,
+            flux,
+            error,
+            band=labels,
+            center_time=False,
+            max_samples=None,
+        )
+
+        self.assertIs(
+            lightcurve.observational_channel_labels,
+            lightcurve.band,
+        )
+        self.assertEqual(
+            lightcurve.observational_channel_labels.tolist(),
+            labels.tolist(),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_observational_channel_terminology.py
+++ b/tests/test_observational_channel_terminology.py
@@ -1,0 +1,159 @@
+"""Contracts for observational-channel and physical-wavelength terminology."""
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+
+from pgmuvi.parameter_context import (
+    BandDiagnostics,
+    ParameterEstimationContext,
+    WavelengthEstimationDiagnostics,
+)
+from pgmuvi.wavelength_estimation import (
+    build_wavelength_estimation_context,
+)
+
+
+class TestObservationalChannelCompatibility(unittest.TestCase):
+    """Protect new terminology without breaking the legacy public API."""
+
+    def test_band_diagnostics_exposes_observational_channel_alias(self):
+        diagnostics = BandDiagnostics(
+            band="KELT/OSN_Johnson.Cousins_R3_0",
+            wavelength=0.6561154962791801,
+            n_points=10,
+        )
+
+        self.assertEqual(
+            diagnostics.observational_channel,
+            diagnostics.band,
+        )
+
+    def test_parameter_context_exposes_observational_channel_accessors(self):
+        diagnostics = BandDiagnostics(
+            band="channel-a",
+            wavelength=1.0,
+            n_points=5,
+        )
+        context = ParameterEstimationContext(
+            is_multiband=True,
+            band_diagnostics={"channel-a": diagnostics},
+        )
+
+        self.assertEqual(
+            context.observational_channels(),
+            ["channel-a"],
+        )
+        self.assertIs(
+            context.get_observational_channel("channel-a"),
+            diagnostics,
+        )
+        self.assertIs(
+            context.observational_channel_diagnostics,
+            context.band_diagnostics,
+        )
+
+    def test_wavelength_summary_exposes_channel_count_aliases(self):
+        diagnostics = WavelengthEstimationDiagnostics(
+            n_distinct_wavelengths=1,
+            n_usable_bands=2,
+            excluded_bands=("channel-c",),
+        )
+
+        self.assertEqual(
+            diagnostics.n_usable_observational_channels,
+            2,
+        )
+        self.assertEqual(
+            diagnostics.excluded_observational_channels,
+            ("channel-c",),
+        )
+
+    def test_builder_accepts_observational_channel_labels(self):
+        wavelengths = np.asarray([1.0, 1.0, 2.0, 2.0])
+        fluxes = np.asarray([1.0, 1.1, 2.0, 2.1])
+        labels = np.asarray(
+            ["channel-a", "channel-a", "channel-b", "channel-b"]
+        )
+
+        summary, channel_diagnostics = build_wavelength_estimation_context(
+            wavelengths=wavelengths,
+            fluxes=fluxes,
+            observational_channel_labels=labels,
+            min_points_per_observational_channel=2,
+        )
+
+        self.assertEqual(summary.n_usable_observational_channels, 2)
+        self.assertEqual(summary.n_distinct_wavelengths, 2)
+        self.assertEqual(
+            set(channel_diagnostics),
+            {"channel-a", "channel-b"},
+        )
+
+    def test_legacy_band_arguments_remain_supported(self):
+        wavelengths = np.asarray([1.0, 1.0, 2.0, 2.0])
+        fluxes = np.asarray([1.0, 1.1, 2.0, 2.1])
+        labels = np.asarray(["a", "a", "b", "b"])
+
+        summary, diagnostics = build_wavelength_estimation_context(
+            wavelengths=wavelengths,
+            fluxes=fluxes,
+            band_labels=labels,
+            min_points_per_band=2,
+        )
+
+        self.assertEqual(summary.n_usable_observational_channels, 2)
+        self.assertEqual(set(diagnostics), {"a", "b"})
+
+    def test_new_and_legacy_label_arguments_cannot_both_be_given(self):
+        values = np.asarray([1.0, 1.0])
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "observational_channel_labels.*band_labels",
+        ):
+            build_wavelength_estimation_context(
+                wavelengths=values,
+                fluxes=values,
+                observational_channel_labels=np.asarray(["a", "a"]),
+                band_labels=np.asarray(["a", "a"]),
+            )
+
+    def test_shared_wavelength_channels_are_reported_separately(self):
+        wavelengths = np.asarray([1.0, 1.0, 1.0, 1.0])
+        fluxes = np.asarray([1.0, 1.1, 1.2, 1.3])
+        labels = np.asarray(
+            ["telescope-a", "telescope-a", "telescope-b", "telescope-b"]
+        )
+
+        summary, diagnostics = build_wavelength_estimation_context(
+            wavelengths=wavelengths,
+            fluxes=fluxes,
+            observational_channel_labels=labels,
+            min_points_per_observational_channel=2,
+        )
+
+        self.assertEqual(summary.n_usable_observational_channels, 2)
+        self.assertEqual(summary.n_distinct_wavelengths, 1)
+        self.assertEqual(
+            set(diagnostics),
+            {"telescope-a", "telescope-b"},
+        )
+        self.assertTrue(
+            summary.metadata[
+                "multiple_observational_channels_per_wavelength"
+            ]
+        )
+        self.assertEqual(
+            summary.metadata["instrument_calibration_status"],
+            "not_implemented",
+        )
+        self.assertTrue(
+            summary.metadata["instrument_calibration_tbd"]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_run_representative_lpv_validation_script.py
+++ b/tests/test_run_representative_lpv_validation_script.py
@@ -1,0 +1,339 @@
+"""Contracts for the D3 representative-LPV command-line runner."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+from pgmuvi.wavelength_validation_real_lpv import (
+    RepresentativeLPVBatchReport,
+    RepresentativeLPVSourceSpecification,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = (
+    ROOT / "scripts" / "run_representative_lpv_validation.py"
+)
+
+
+def _load_script():
+    specification = importlib.util.spec_from_file_location(
+        "run_representative_lpv_validation",
+        SCRIPT_PATH,
+    )
+    if specification is None or specification.loader is None:
+        raise RuntimeError("Could not load D3 runner script.")
+
+    module = importlib.util.module_from_spec(specification)
+    specification.loader.exec_module(module)
+    return module
+
+
+SCRIPT = _load_script()
+
+
+class TestRepresentativeLPVManifestLoader(unittest.TestCase):
+    def test_example_manifest_resolves_public_source_path(self):
+        manifest_path = (
+            ROOT
+            / "examples"
+            / "validation"
+            / "d3_representative_lpv_manifest.json"
+        )
+        specifications = (
+            SCRIPT.load_representative_lpv_manifest(
+                manifest_path
+            )
+        )
+
+        self.assertEqual(len(specifications), 1)
+        self.assertEqual(
+            specifications[0].source_id,
+            "10131+3049",
+        )
+        self.assertEqual(
+            Path(specifications[0].source_path),
+            (
+                ROOT
+                / "examples"
+                / "data"
+                / "10131+3049.csv"
+            ).resolve(),
+        )
+        self.assertEqual(
+            specifications[0].metadata["manifest_source_path"],
+            "../data/10131+3049.csv",
+        )
+
+    def test_object_manifest_requires_sources_key(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            manifest_path = (
+                Path(temporary_directory) / "manifest.json"
+            )
+            manifest_path.write_text(
+                json.dumps({"not_sources": []}),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ValueError, "sources"):
+                SCRIPT.load_representative_lpv_manifest(
+                    manifest_path
+                )
+
+    def test_workflow_configuration_must_be_mapping(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            configuration_path = (
+                Path(temporary_directory) / "workflow.json"
+            )
+            configuration_path.write_text(
+                json.dumps(["not", "a", "mapping"]),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ValueError, "object"):
+                SCRIPT.load_representative_lpv_workflow_configuration(
+                    configuration_path
+                )
+
+
+class TestRepresentativeLPVCLI(unittest.TestCase):
+    def setUp(self):
+        self.manifest_path = (
+            ROOT
+            / "examples"
+            / "validation"
+            / "d3_representative_lpv_manifest.json"
+        )
+        self.workflow_path = (
+            ROOT
+            / "examples"
+            / "validation"
+            / "d3_representative_lpv_workflow.json"
+        )
+
+    def test_validate_only_runs_no_fits_and_writes_no_outputs(self):
+        batch_calls = []
+        export_calls = []
+        stdout = io.StringIO()
+
+        with redirect_stdout(stdout):
+            status = SCRIPT.main(
+                [
+                    "--manifest",
+                    str(self.manifest_path),
+                    "--validate-manifest-only",
+                ],
+                batch_runner=lambda *args, **kwargs: (
+                    batch_calls.append((args, kwargs))
+                ),
+                exporter=lambda *args, **kwargs: (
+                    export_calls.append((args, kwargs))
+                ),
+            )
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(status, 0)
+        self.assertEqual(batch_calls, [])
+        self.assertEqual(export_calls, [])
+        self.assertTrue(payload["valid"])
+        self.assertFalse(payload["runs_fits"])
+        self.assertFalse(payload["writes_outputs"])
+        self.assertEqual(
+            payload["source_ids"],
+            ["10131+3049"],
+        )
+
+    def test_run_passes_manifest_configuration_and_exports(self):
+        captured = {}
+        stdout = io.StringIO()
+
+        def fake_batch_runner(
+            manifest,
+            *,
+            workflow_kwargs,
+            output_root,
+            batch_id,
+        ):
+            captured["manifest"] = manifest
+            captured["workflow_kwargs"] = workflow_kwargs
+            captured["output_root"] = output_root
+            captured["batch_id"] = batch_id
+
+            source = manifest[0]
+            return RepresentativeLPVBatchReport(
+                batch_id=batch_id,
+                source_manifest=manifest,
+                source_results=(
+                    {
+                        "source_id": source.source_id,
+                        "source_specification": source.to_dict(),
+                        "source_output_dir": (
+                            f"{output_root}/sources/10131_3049"
+                        ),
+                        "source_report_path": (
+                            f"{output_root}/sources/"
+                            "10131_3049/report.json"
+                        ),
+                        "status": "completed",
+                        "execution_seed": source.seed,
+                        "seed_applied": True,
+                        "seed_scope": (
+                            "source_loading_and_advisory_workflow"
+                        ),
+                        "validation_report": {
+                            "report_id": "d3:10131+3049",
+                            "advisory_only": True,
+                            "automatic_model_selection_applied": (
+                                False
+                            ),
+                            "selected_model": None,
+                        },
+                        "failure": None,
+                    },
+                ),
+                output_root=output_root,
+                workflow_configuration=workflow_kwargs,
+                runtime_environment={
+                    "python_version": "test",
+                },
+            )
+
+        def fake_exporter(report, output_root):
+            captured["export_report"] = report
+            captured["export_output_root"] = output_root
+            return {
+                "kind": (
+                    "representative_lpv_batch_report_export"
+                ),
+                "output_dir": output_root,
+            }
+
+        with redirect_stdout(stdout):
+            status = SCRIPT.main(
+                [
+                    "--manifest",
+                    str(self.manifest_path),
+                    "--workflow-config",
+                    str(self.workflow_path),
+                    "--output-root",
+                    "validation_outputs/test_d3",
+                    "--batch-id",
+                    "test-d3-batch",
+                ],
+                batch_runner=fake_batch_runner,
+                exporter=fake_exporter,
+            )
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(status, 0)
+        self.assertEqual(
+            captured["manifest"][0].source_id,
+            "10131+3049",
+        )
+        self.assertEqual(
+            captured["workflow_kwargs"][
+                "base_fit_kwargs"
+            ]["fit_strategy"],
+            "consensus",
+        )
+        self.assertEqual(
+            captured["workflow_kwargs"][
+                "base_fit_kwargs"
+            ]["time_kernel_type"],
+            "quasi_periodic",
+        )
+        self.assertTrue(
+            captured["workflow_kwargs"][
+                "base_fit_kwargs"
+            ]["learn_additional_noise"]
+        )
+        self.assertEqual(
+            captured["output_root"],
+            "validation_outputs/test_d3",
+        )
+        self.assertEqual(
+            captured["batch_id"],
+            "test-d3-batch",
+        )
+        self.assertTrue(payload["exported"])
+        self.assertEqual(payload["n_failed_sources"], 0)
+        self.assertFalse(
+            payload["automatic_model_selection_applied"]
+        )
+        self.assertIsNone(payload["selected_model"])
+
+    def test_fail_on_source_failure_returns_two_after_reporting(self):
+        source = RepresentativeLPVSourceSpecification(
+            source_id="failed",
+            source_path="inputs/failed.csv",
+            description="Synthetic failed source.",
+            sample_role="failure_boundary",
+            selection_reason="Exercise CLI exit status.",
+            seed=3,
+        )
+
+        def fake_batch_runner(*args, **kwargs):
+            del args
+            output_root = kwargs["output_root"]
+            return RepresentativeLPVBatchReport(
+                batch_id=kwargs["batch_id"],
+                source_manifest=(source,),
+                source_results=(
+                    {
+                        "source_id": source.source_id,
+                        "source_specification": source.to_dict(),
+                        "source_output_dir": (
+                            f"{output_root}/sources/failed"
+                        ),
+                        "source_report_path": (
+                            f"{output_root}/sources/"
+                            "failed/report.json"
+                        ),
+                        "status": "failed",
+                        "execution_seed": 3,
+                        "seed_applied": True,
+                        "seed_scope": (
+                            "source_loading_and_advisory_workflow"
+                        ),
+                        "validation_report": None,
+                        "failure": {
+                            "stage": "source_loading",
+                            "failure_code": (
+                                "source_loading_failed"
+                            ),
+                            "exception_type": (
+                                "FileNotFoundError"
+                            ),
+                            "exception_message": "Missing.",
+                        },
+                    },
+                ),
+                output_root=output_root,
+            )
+
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            status = SCRIPT.main(
+                [
+                    "--manifest",
+                    str(self.manifest_path),
+                    "--no-export",
+                    "--fail-on-source-failure",
+                ],
+                batch_runner=fake_batch_runner,
+            )
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(status, 2)
+        self.assertFalse(payload["exported"])
+        self.assertEqual(payload["n_failed_sources"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wavelength_validation_real_lpv.py
+++ b/tests/test_wavelength_validation_real_lpv.py
@@ -1,0 +1,453 @@
+"""Contracts for representative real-LPV wavelength validation."""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+from pgmuvi.lightcurve import Lightcurve
+from pgmuvi.wavelength_validation import (
+    WavelengthValidationPhase,
+    WavelengthValidationSourceKind,
+)
+from pgmuvi.wavelength_validation_real_lpv import (
+    DEFAULT_REPRESENTATIVE_LPV_MODELS,
+    RepresentativeLPVValidationReport,
+    build_representative_lpv_source_summary,
+    build_representative_lpv_validation_report,
+    run_representative_lpv_validation,
+)
+
+
+class RepresentativeLPVFixtures:
+    @staticmethod
+    def public_lightcurve():
+        return Lightcurve.from_csv(
+            Path("examples/data/10131+3049.csv"),
+            check_sampling=False,
+            max_samples=None,
+            max_samples_per_band=None,
+        )
+
+    @staticmethod
+    def workflow_report():
+        return {
+            "kind": "period_independent_wavelength_advisory_workflow",
+            "advisory_only": True,
+            "automatic_model_selection_applied": False,
+            "selected_model": None,
+            "fit_quality_ranking_status": "available",
+            "fit_quality_ranking_available": True,
+            "top_ranked_model": "2DDustMean",
+            "top_ranked_fit_quality_score": 0.83,
+            "model_kernel_config_report": {
+                "period_independent_diagnostics": {
+                    "kind": (
+                        "period_independent_wavelength_structure_diagnostics"
+                    ),
+                    "n_usable_observational_channels": 17,
+                    "n_distinct_physical_wavelengths": 16,
+                    "median_flux_trend": "non_monotonic",
+                    "amplitude_trend": "non_monotonic",
+                },
+            },
+            "run_report": {
+                "model_kernel_config_results": [
+                    {
+                        "model_kernel_config_id": "dust-qp-consensus",
+                        "model": "2DDustMean",
+                        "status": "passed",
+                        "fit_success": True,
+                        "fit_failed": False,
+                        "technical_outcome": "completed_with_warnings",
+                        "diagnostic_validity": "valid",
+                        "scientific_usability": "usable",
+                        "comparison_eligibility": "eligible",
+                        "warning_count": 1,
+                        "warnings": [
+                            {
+                                "category": "RuntimeWarning",
+                                "message": "Test warning.",
+                            }
+                        ],
+                        "consensus_success": True,
+                        "consensus_period": 500.0,
+                        "consensus_frequency": 0.002,
+                        "n_accepted_bands": 15,
+                        "n_rejected_bands": 2,
+                        "fit_kwargs": {
+                            "model": "2DDustMean",
+                            "fit_strategy": "consensus",
+                            "time_kernel_type": "quasi_periodic",
+                            "learn_additional_noise": True,
+                        },
+                        "training_nrmse_by_target_scale": 0.12,
+                        "training_median_abs_standardized_residual": 0.81,
+                        "training_outlier_fraction_3sigma": 0.01,
+                        "training_reduced_chi2": 1.08,
+                        "parameter_workflow": {
+                            "available": True,
+                            "n_applied": 4,
+                        },
+                        "n_sm_ard_boundary_hits": 0,
+                        "sm_ard_boundary_hits": [],
+                        "n_constrained_sm_ard_components": 0,
+                    },
+                    {
+                        "model_kernel_config_id": "joint-sm-consensus",
+                        "model": "2D",
+                        "status": "failed",
+                        "fit_success": False,
+                        "fit_failed": True,
+                        "technical_outcome": "failed",
+                        "diagnostic_validity": "invalid",
+                        "scientific_usability": "unusable",
+                        "comparison_eligibility": "ineligible",
+                        "warning_count": 0,
+                        "warnings": [],
+                        "failure_code": "numerical_stability_failed",
+                        "failure_stage": "numerical_stability",
+                        "failure_substage": "cholesky",
+                        "failure_stage_reason": (
+                            "Covariance matrix was not positive definite."
+                        ),
+                        "exception_type": "NotPSDError",
+                        "exception_message": "Matrix not positive definite.",
+                        "fit_kwargs": {
+                            "model": "2D",
+                            "fit_strategy": "consensus",
+                            "learn_additional_noise": True,
+                        },
+                        "n_sm_ard_boundary_hits": 2,
+                        "sm_ard_boundary_hits": [
+                            {
+                                "parameter": "mixture_scales",
+                                "dimension": "wavelength_frequency",
+                                "component_index": 0,
+                                "side": "upper",
+                            },
+                            {
+                                "parameter": "mixture_means",
+                                "dimension": "wavelength_frequency",
+                                "component_index": 0,
+                                "side": "lower",
+                            },
+                        ],
+                        "n_constrained_sm_ard_components": 1,
+                    },
+                ],
+            },
+            "quality_report": {
+                "score_kind": "training_residual_fit_quality",
+                "fit_quality_ranking_status": "available",
+                "fit_quality_ranking_available": True,
+                "n_with_fit_quality": 1,
+                "top_ranked_model": "2DDustMean",
+                "top_ranked_fit_quality_score": 0.83,
+                "ranked_results": [
+                    {
+                        "quality_rank": 1,
+                        "model_kernel_config_id": "dust-qp-consensus",
+                        "model": "2DDustMean",
+                        "fit_quality_available": True,
+                        "fit_quality_score": 0.83,
+                        "is_top_ranked": True,
+                    }
+                ],
+            },
+            "advisory_conclusions": [
+                {
+                    "scope": "complete_configuration",
+                    "subject": "2DDustMean",
+                    "disposition": "remains_plausible",
+                    "summary": (
+                        "The fitted configuration remains plausible for this "
+                        "source, subject to the recorded limitations."
+                    ),
+                    "models": ["2DDustMean"],
+                    "model_kernel_config_ids": ["dust-qp-consensus"],
+                }
+            ],
+            "unresolved_ambiguities": [
+                {
+                    "code": "training_space_ranking_only",
+                    "summary": (
+                        "Ranking uses training-space residual diagnostics."
+                    ),
+                }
+            ],
+        }
+
+
+class TestRepresentativeLPVDefaults(unittest.TestCase):
+    def test_default_model_order_prioritizes_lpv_relevant_families(self):
+        self.assertEqual(
+            DEFAULT_REPRESENTATIVE_LPV_MODELS,
+            (
+                "2DWavelengthDependent",
+                "2DDustMean",
+                "2DPowerLawMean",
+                "2DSeparable",
+                "2D",
+            ),
+        )
+        self.assertNotIn(
+            "2DAchromatic",
+            DEFAULT_REPRESENTATIVE_LPV_MODELS,
+        )
+
+
+class TestRepresentativeLPVSourceSummary(
+    RepresentativeLPVFixtures,
+    unittest.TestCase,
+):
+    @classmethod
+    def setUpClass(cls):
+        cls.lightcurve = cls.public_lightcurve()
+        cls.summary = build_representative_lpv_source_summary(
+            cls.lightcurve
+        )
+
+    def test_public_source_counts_rows_channels_and_wavelengths(self):
+        self.assertEqual(self.summary["n_rows"], 10815)
+        self.assertEqual(
+            self.summary["n_observational_channels"],
+            17,
+        )
+        self.assertEqual(
+            self.summary["n_distinct_physical_wavelengths"],
+            16,
+        )
+
+    def test_public_source_records_shared_wavelength_channels(self):
+        self.assertTrue(
+            self.summary[
+                "multiple_observational_channels_per_wavelength"
+            ]
+        )
+        self.assertEqual(
+            self.summary["instrument_calibration_status"],
+            "not_implemented",
+        )
+        self.assertTrue(
+            self.summary["instrument_calibration_tbd"]
+        )
+        self.assertEqual(
+            self.summary["shared_wavelength_policy"],
+            "preserve_channels_without_calibration",
+        )
+
+        shared = self.summary[
+            "observational_channels_by_shared_wavelength"
+        ]
+        self.assertEqual(len(shared), 1)
+        self.assertEqual(
+            next(iter(shared.values())),
+            [
+                "KELT/OSN_Johnson.Cousins_R3_0",
+                "KELT/OSN_Johnson.Cousins_R3_1",
+            ],
+        )
+
+    def test_source_summary_is_json_safe(self):
+        json.dumps(self.summary, allow_nan=False)
+
+
+class TestRepresentativeLPVReport(
+    RepresentativeLPVFixtures,
+    unittest.TestCase,
+):
+    @classmethod
+    def setUpClass(cls):
+        cls.source_summary = build_representative_lpv_source_summary(
+            cls.public_lightcurve()
+        )
+        cls.report = build_representative_lpv_validation_report(
+            source_id="10131+3049",
+            description=(
+                "Representative public LPV validation source."
+            ),
+            source_summary=cls.source_summary,
+            workflow_report=cls.workflow_report(),
+        )
+        cls.payload = cls.report.to_dict()
+
+    def test_report_uses_observed_d3_scenario_without_truth(self):
+        scenario = self.report.scenario
+        self.assertIs(
+            scenario.phase,
+            WavelengthValidationPhase.D3_REPRESENTATIVE_LPV,
+        )
+        self.assertIs(
+            scenario.source_kind,
+            WavelengthValidationSourceKind.OBSERVED,
+        )
+        self.assertIsNone(scenario.truth)
+
+    def test_report_is_advisory_and_never_selects_model(self):
+        self.assertTrue(self.payload["advisory_only"])
+        self.assertFalse(
+            self.payload["automatic_model_selection_applied"]
+        )
+        self.assertIsNone(self.payload["selected_model"])
+
+        self.assertEqual(
+            self.payload["workflow_report"]["top_ranked_model"],
+            "2DDustMean",
+        )
+        self.assertIsNone(self.payload["selected_model"])
+
+    def test_report_collects_required_d3_evidence_sections(self):
+        evidence = self.payload["source_evidence"]
+
+        self.assertEqual(
+            set(evidence),
+            {
+                "period_evidence",
+                "fit_quality",
+                "residual_wavelength_structure",
+                "constraint_diagnostics",
+                "warnings",
+                "failures",
+            },
+        )
+
+        self.assertEqual(
+            evidence["period_evidence"]["n_models_with_period_evidence"],
+            1,
+        )
+        self.assertEqual(
+            evidence["period_evidence"]["by_model"][
+                "2DDustMean"
+            ]["consensus_period"],
+            500.0,
+        )
+
+        self.assertEqual(
+            evidence["fit_quality"]["ranking_status"],
+            "available",
+        )
+        self.assertEqual(
+            evidence["fit_quality"]["top_ranked_model"],
+            "2DDustMean",
+        )
+        self.assertFalse(
+            evidence["fit_quality"][
+                "automatic_model_selection_applied"
+            ]
+        )
+
+        self.assertEqual(
+            evidence["residual_wavelength_structure"][
+                "n_distinct_physical_wavelengths"
+            ],
+            16,
+        )
+
+        self.assertIn(
+            "2DDustMean",
+            evidence["constraint_diagnostics"]["by_model"],
+        )
+        self.assertIn(
+            "2D",
+            evidence["constraint_diagnostics"]["by_model"],
+        )
+
+        self.assertEqual(
+            evidence["warnings"]["n_warning_records"],
+            1,
+        )
+        self.assertEqual(
+            evidence["failures"]["n_failed_attempts"],
+            1,
+        )
+        self.assertEqual(
+            evidence["failures"]["by_code"],
+            {"numerical_stability_failed": 1},
+        )
+
+    def test_report_does_not_create_truth_recovery_gates(self):
+        self.assertNotIn("truth", self.payload["source_evidence"])
+        self.assertNotIn("recovery_metrics", self.payload)
+        self.assertNotIn("recovery_gates", self.payload)
+        self.assertFalse(
+            self.payload["source_evidence"]["fit_quality"].get(
+                "truth_recovery_evidence",
+                False,
+            )
+        )
+
+    def test_report_round_trip_and_json_serialization(self):
+        rebuilt = RepresentativeLPVValidationReport.from_mapping(
+            self.payload
+        )
+        self.assertEqual(rebuilt.to_dict(), self.payload)
+        json.dumps(self.payload, allow_nan=False)
+
+
+class TestRepresentativeLPVRunner(
+    RepresentativeLPVFixtures,
+    unittest.TestCase,
+):
+    def test_runner_reuses_advisory_workflow_with_explicit_models(self):
+        lightcurve = self.public_lightcurve()
+        captured = {}
+
+        def fake_workflow_runner(candidate_lightcurve, **kwargs):
+            captured["lightcurve"] = candidate_lightcurve
+            captured["kwargs"] = dict(kwargs)
+            return self.workflow_report()
+
+        report = run_representative_lpv_validation(
+            lightcurve,
+            source_id="10131+3049",
+            description="Representative public LPV source.",
+            workflow_runner=fake_workflow_runner,
+        )
+
+        self.assertIs(captured["lightcurve"], lightcurve)
+        self.assertEqual(
+            tuple(captured["kwargs"]["include_models"]),
+            DEFAULT_REPRESENTATIVE_LPV_MODELS,
+        )
+        self.assertTrue(
+            captured["kwargs"]["include_2d_baseline"]
+        )
+        self.assertTrue(
+            captured["kwargs"]["make_text_report"]
+        )
+        self.assertFalse(
+            captured["kwargs"]["make_plots"]
+        )
+
+        payload = report.to_dict()
+        self.assertTrue(payload["advisory_only"])
+        self.assertFalse(
+            payload["automatic_model_selection_applied"]
+        )
+        self.assertIsNone(payload["selected_model"])
+
+    def test_runner_rejects_workflow_selection_claims(self):
+        lightcurve = self.public_lightcurve()
+        workflow = self.workflow_report()
+        workflow["automatic_model_selection_applied"] = True
+        workflow["selected_model"] = "2DDustMean"
+
+        def invalid_workflow_runner(candidate_lightcurve, **kwargs):
+            del candidate_lightcurve, kwargs
+            return workflow
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "automatic model selection",
+        ):
+            run_representative_lpv_validation(
+                lightcurve,
+                source_id="invalid-selection-claim",
+                workflow_runner=invalid_workflow_runner,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wavelength_validation_real_lpv_batch.py
+++ b/tests/test_wavelength_validation_real_lpv_batch.py
@@ -1,0 +1,428 @@
+"""Failure-aware batch contracts for representative observed-LPV validation."""
+
+from __future__ import annotations
+
+import json
+import unittest
+
+import numpy as np
+import torch
+
+from pgmuvi.lightcurve import Lightcurve
+from pgmuvi.wavelength_validation_real_lpv import (
+    DEFAULT_REPRESENTATIVE_LPV_MODELS,
+    RepresentativeLPVBatchReport,
+    RepresentativeLPVSourceSpecification,
+    run_representative_lpv_validation_batch,
+    validate_representative_lpv_source_manifest,
+)
+
+
+class BatchFixtures:
+    @staticmethod
+    def lightcurve(name):
+        x = torch.tensor(
+            [
+                [0.0, 0.55],
+                [1.0, 0.55],
+                [0.0, 1.25],
+                [1.0, 1.25],
+            ],
+            dtype=torch.float64,
+        )
+        y = torch.tensor(
+            [10.0, 11.0, 8.0, 9.0],
+            dtype=torch.float64,
+        )
+        yerr = torch.tensor(
+            [0.2, 0.2, 0.3, 0.3],
+            dtype=torch.float64,
+        )
+        return Lightcurve(
+            x,
+            y,
+            yerr=yerr,
+            band=np.asarray(
+                ["instrument-v", "instrument-v", "instrument-j", "instrument-j"],
+                dtype=str,
+            ),
+            xtransform=None,
+            center_time=False,
+            check_sampling=False,
+            max_samples=None,
+            max_samples_per_band=None,
+            name=name,
+        )
+
+    @staticmethod
+    def successful_workflow(model="2DDustMean"):
+        return {
+            "kind": "period_independent_wavelength_advisory_workflow",
+            "advisory_only": True,
+            "automatic_model_selection_applied": False,
+            "selected_model": None,
+            "fit_quality_ranking_status": "single_valid_candidate",
+            "fit_quality_ranking_available": False,
+            "only_valid_model": model,
+            "top_ranked_model": None,
+            "model_kernel_config_report": {
+                "period_independent_diagnostics": {
+                    "kind": (
+                        "period_independent_wavelength_structure_diagnostics"
+                    ),
+                    "n_usable_observational_channels": 2,
+                    "n_distinct_physical_wavelengths": 2,
+                },
+            },
+            "run_report": {
+                "model_kernel_config_results": [
+                    {
+                        "model_kernel_config_id": f"{model}-config",
+                        "model": model,
+                        "status": "passed",
+                        "fit_success": True,
+                        "fit_failed": False,
+                        "technical_outcome": "completed",
+                        "diagnostic_validity": "valid",
+                        "scientific_usability": "usable",
+                        "comparison_eligibility": "eligible",
+                        "warning_count": 0,
+                        "warnings": [],
+                        "consensus_success": True,
+                        "consensus_period": 410.0,
+                        "consensus_frequency": 1.0 / 410.0,
+                        "n_accepted_bands": 2,
+                        "n_rejected_bands": 0,
+                        "fit_kwargs": {
+                            "model": model,
+                            "fit_strategy": "consensus",
+                            "time_kernel_type": "quasi_periodic",
+                            "learn_additional_noise": True,
+                        },
+                        "training_nrmse_by_target_scale": 0.15,
+                        "n_sm_ard_boundary_hits": 0,
+                        "sm_ard_boundary_hits": [],
+                    }
+                ],
+            },
+            "quality_report": {
+                "score_kind": "training_residual_fit_quality",
+                "fit_quality_ranking_status": "single_valid_candidate",
+                "fit_quality_ranking_available": False,
+                "n_with_fit_quality": 1,
+                "only_valid_model": model,
+                "top_ranked_model": None,
+                "ranked_results": [],
+            },
+            "advisory_conclusions": [],
+            "unresolved_ambiguities": [
+                {
+                    "code": "single_valid_candidate",
+                    "summary": (
+                        "Only one candidate supplied usable fit-quality "
+                        "diagnostics."
+                    ),
+                }
+            ],
+        }
+
+
+class TestRepresentativeLPVSourceSpecification(unittest.TestCase):
+    def test_source_specification_round_trip_is_json_safe(self):
+        specification = RepresentativeLPVSourceSpecification(
+            source_id="lpv-a",
+            source_path="inputs/lpv-a.csv",
+            description="Representative oxygen-rich LPV.",
+            sample_role="oxygen_rich",
+            selection_reason="Public source with broad wavelength coverage.",
+            seed=17,
+            metadata={"catalog": "public-example"},
+        )
+
+        payload = specification.to_dict()
+        rebuilt = RepresentativeLPVSourceSpecification.from_mapping(payload)
+
+        self.assertEqual(rebuilt.to_dict(), payload)
+        self.assertEqual(payload["seed"], 17)
+        json.dumps(payload, allow_nan=False)
+
+    def test_required_manifest_fields_cannot_be_empty(self):
+        required_fields = {
+            "source_id": "lpv-a",
+            "source_path": "inputs/lpv-a.csv",
+            "description": "Representative LPV.",
+            "sample_role": "validation",
+            "selection_reason": "Representative wavelength coverage.",
+        }
+
+        for field_name in required_fields:
+            with self.subTest(field_name=field_name):
+                values = dict(required_fields)
+                values[field_name] = ""
+                with self.assertRaisesRegex(ValueError, field_name):
+                    RepresentativeLPVSourceSpecification(**values)
+
+    def test_seed_must_be_nonnegative(self):
+        with self.assertRaisesRegex(ValueError, "seed"):
+            RepresentativeLPVSourceSpecification(
+                source_id="lpv-a",
+                source_path="inputs/lpv-a.csv",
+                description="Representative LPV.",
+                sample_role="validation",
+                selection_reason="Representative wavelength coverage.",
+                seed=-1,
+            )
+
+
+class TestRepresentativeLPVManifestValidation(unittest.TestCase):
+    def test_manifest_rejects_duplicate_source_ids(self):
+        manifest = [
+            {
+                "source_id": "duplicate",
+                "source_path": "inputs/a.csv",
+                "description": "Source A.",
+                "sample_role": "validation",
+                "selection_reason": "Reason A.",
+            },
+            {
+                "source_id": "duplicate",
+                "source_path": "inputs/b.csv",
+                "description": "Source B.",
+                "sample_role": "validation",
+                "selection_reason": "Reason B.",
+            },
+        ]
+
+        with self.assertRaisesRegex(ValueError, "duplicate"):
+            validate_representative_lpv_source_manifest(manifest)
+
+    def test_manifest_preserves_input_order(self):
+        normalized = validate_representative_lpv_source_manifest(
+            [
+                {
+                    "source_id": "lpv-b",
+                    "source_path": "inputs/b.csv",
+                    "description": "Source B.",
+                    "sample_role": "carbon_rich",
+                    "selection_reason": "Carbon-rich representative.",
+                },
+                {
+                    "source_id": "lpv-a",
+                    "source_path": "inputs/a.csv",
+                    "description": "Source A.",
+                    "sample_role": "oxygen_rich",
+                    "selection_reason": "Oxygen-rich representative.",
+                },
+            ]
+        )
+
+        self.assertEqual(
+            tuple(item.source_id for item in normalized),
+            ("lpv-b", "lpv-a"),
+        )
+
+
+class TestRepresentativeLPVBatchRunner(BatchFixtures, unittest.TestCase):
+    def setUp(self):
+        self.manifest = [
+            RepresentativeLPVSourceSpecification(
+                source_id="good-source",
+                source_path="inputs/good.csv",
+                description="Source expected to complete.",
+                sample_role="validation",
+                selection_reason="Exercises successful D3 reporting.",
+                seed=11,
+            ),
+            RepresentativeLPVSourceSpecification(
+                source_id="load-failure",
+                source_path="inputs/missing.csv",
+                description="Source expected to fail while loading.",
+                sample_role="failure_boundary",
+                selection_reason="Exercises setup-failure continuation.",
+                seed=12,
+            ),
+            RepresentativeLPVSourceSpecification(
+                source_id="workflow-failure",
+                source_path="inputs/workflow.csv",
+                description="Source expected to fail during workflow.",
+                sample_role="failure_boundary",
+                selection_reason="Exercises workflow-failure continuation.",
+                seed=13,
+            ),
+        ]
+
+    def test_batch_continues_after_source_failures(self):
+        loader_calls = []
+        workflow_calls = []
+
+        def source_loader(specification):
+            loader_calls.append(specification.source_id)
+            if specification.source_id == "load-failure":
+                raise FileNotFoundError("Synthetic missing-source failure.")
+            return self.lightcurve(specification.source_id)
+
+        def workflow_runner(lightcurve, **kwargs):
+            workflow_calls.append(
+                {
+                    "name": lightcurve.name,
+                    "kwargs": dict(kwargs),
+                }
+            )
+            if lightcurve.name == "workflow-failure":
+                raise RuntimeError("Synthetic workflow failure.")
+            return self.successful_workflow()
+
+        report = run_representative_lpv_validation_batch(
+            self.manifest,
+            source_loader=source_loader,
+            workflow_runner=workflow_runner,
+            output_root="validation_outputs/d3_real_lpv",
+        )
+
+        self.assertEqual(
+            loader_calls,
+            ["good-source", "load-failure", "workflow-failure"],
+        )
+        self.assertEqual(
+            [item["name"] for item in workflow_calls],
+            ["good-source", "workflow-failure"],
+        )
+
+        payload = report.to_dict()
+        self.assertEqual(payload["n_sources"], 3)
+        self.assertEqual(payload["n_completed_sources"], 1)
+        self.assertEqual(payload["n_failed_sources"], 2)
+        self.assertEqual(
+            payload["source_status_counts"],
+            {
+                "completed": 1,
+                "failed": 2,
+            },
+        )
+
+        rows = {
+            row["source_id"]: row
+            for row in payload["source_results"]
+        }
+
+        self.assertEqual(rows["good-source"]["status"], "completed")
+        self.assertIsNotNone(
+            rows["good-source"]["validation_report"]
+        )
+
+        self.assertEqual(rows["load-failure"]["status"], "failed")
+        self.assertEqual(
+            rows["load-failure"]["failure"]["stage"],
+            "source_loading",
+        )
+        self.assertEqual(
+            rows["load-failure"]["failure"]["exception_type"],
+            "FileNotFoundError",
+        )
+
+        self.assertEqual(
+            rows["workflow-failure"]["failure"]["stage"],
+            "advisory_workflow",
+        )
+        self.assertEqual(
+            rows["workflow-failure"]["failure"]["exception_type"],
+            "RuntimeError",
+        )
+
+    def test_batch_uses_explicit_model_order_and_output_paths(self):
+        captured = []
+
+        def source_loader(specification):
+            return self.lightcurve(specification.source_id)
+
+        def workflow_runner(lightcurve, **kwargs):
+            captured.append(
+                {
+                    "name": lightcurve.name,
+                    "kwargs": dict(kwargs),
+                }
+            )
+            return self.successful_workflow()
+
+        report = run_representative_lpv_validation_batch(
+            self.manifest[:1],
+            source_loader=source_loader,
+            workflow_runner=workflow_runner,
+            output_root="validation_outputs/d3_real_lpv",
+        )
+
+        self.assertEqual(
+            tuple(captured[0]["kwargs"]["include_models"]),
+            DEFAULT_REPRESENTATIVE_LPV_MODELS,
+        )
+        self.assertTrue(
+            captured[0]["kwargs"]["include_2d_baseline"]
+        )
+
+        row = report.to_dict()["source_results"][0]
+        self.assertEqual(
+            row["source_output_dir"],
+            "validation_outputs/d3_real_lpv/sources/good-source",
+        )
+        self.assertEqual(
+            row["source_report_path"],
+            (
+                "validation_outputs/d3_real_lpv/sources/"
+                "good-source/report.json"
+            ),
+        )
+
+    def test_batch_report_is_advisory_nonselecting_and_json_safe(self):
+        def source_loader(specification):
+            return self.lightcurve(specification.source_id)
+
+        def workflow_runner(lightcurve, **kwargs):
+            del lightcurve, kwargs
+            return self.successful_workflow()
+
+        report = run_representative_lpv_validation_batch(
+            self.manifest[:1],
+            source_loader=source_loader,
+            workflow_runner=workflow_runner,
+            output_root="validation_outputs/d3_real_lpv",
+        )
+
+        self.assertIsInstance(report, RepresentativeLPVBatchReport)
+
+        payload = report.to_dict()
+        self.assertTrue(payload["advisory_only"])
+        self.assertFalse(
+            payload["automatic_model_selection_applied"]
+        )
+        self.assertIsNone(payload["selected_model"])
+        self.assertFalse(payload["writes_outputs"])
+        self.assertFalse(payload["automatic_constraints_applied"])
+        self.assertFalse(payload["automatic_initialization_applied"])
+
+        rebuilt = RepresentativeLPVBatchReport.from_mapping(payload)
+        self.assertEqual(rebuilt.to_dict(), payload)
+        json.dumps(payload, allow_nan=False)
+
+    def test_batch_does_not_mutate_manifest_objects(self):
+        before = [item.to_dict() for item in self.manifest]
+
+        def source_loader(specification):
+            return self.lightcurve(specification.source_id)
+
+        def workflow_runner(lightcurve, **kwargs):
+            del lightcurve, kwargs
+            return self.successful_workflow()
+
+        run_representative_lpv_validation_batch(
+            self.manifest,
+            source_loader=source_loader,
+            workflow_runner=workflow_runner,
+            output_root="validation_outputs/d3_real_lpv",
+        )
+
+        after = [item.to_dict() for item in self.manifest]
+        self.assertEqual(after, before)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wavelength_validation_real_lpv_export.py
+++ b/tests/test_wavelength_validation_real_lpv_export.py
@@ -1,0 +1,203 @@
+"""Export contracts for representative observed-LPV D3 reports."""
+
+from __future__ import annotations
+
+import csv
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from pgmuvi.wavelength_validation_real_lpv import (
+    RepresentativeLPVBatchReport,
+    RepresentativeLPVSourceSpecification,
+    export_representative_lpv_batch_report,
+)
+
+
+class TestRepresentativeLPVBatchExport(unittest.TestCase):
+    def setUp(self):
+        self.manifest = (
+            RepresentativeLPVSourceSpecification(
+                source_id="good/source",
+                source_path="inputs/good.csv",
+                description="Completed representative LPV.",
+                sample_role="validation",
+                selection_reason="Exercises completed export.",
+                seed=21,
+            ),
+            RepresentativeLPVSourceSpecification(
+                source_id="failed-source",
+                source_path="inputs/failed.csv",
+                description="Failed representative LPV.",
+                sample_role="failure_boundary",
+                selection_reason="Exercises failure export.",
+                seed=22,
+            ),
+        )
+        self.report = RepresentativeLPVBatchReport(
+            batch_id="d3-export-test",
+            source_manifest=self.manifest,
+            source_results=(
+                {
+                    "source_id": "good/source",
+                    "source_specification": self.manifest[0].to_dict(),
+                    "source_output_dir": (
+                        "validation_outputs/d3_real_lpv/"
+                        "sources/good_source"
+                    ),
+                    "source_report_path": (
+                        "validation_outputs/d3_real_lpv/"
+                        "sources/good_source/report.json"
+                    ),
+                    "status": "completed",
+                    "validation_report": {
+                        "report_id": "d3:good/source",
+                        "advisory_only": True,
+                        "automatic_model_selection_applied": False,
+                        "selected_model": None,
+                    },
+                    "failure": None,
+                },
+                {
+                    "source_id": "failed-source",
+                    "source_specification": self.manifest[1].to_dict(),
+                    "source_output_dir": (
+                        "validation_outputs/d3_real_lpv/"
+                        "sources/failed-source"
+                    ),
+                    "source_report_path": (
+                        "validation_outputs/d3_real_lpv/"
+                        "sources/failed-source/report.json"
+                    ),
+                    "status": "failed",
+                    "validation_report": None,
+                    "failure": {
+                        "stage": "advisory_workflow",
+                        "failure_code": "advisory_workflow_failed",
+                        "exception_type": "RuntimeError",
+                        "exception_message": "Synthetic failure.",
+                    },
+                },
+            ),
+        )
+
+    def test_export_writes_deterministic_artifact_tree(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            manifest = export_representative_lpv_batch_report(
+                self.report,
+                temporary_directory,
+            )
+            root = Path(temporary_directory)
+
+            expected = (
+                root / "batch_report.json",
+                root / "source_manifest.json",
+                root / "source_summary.csv",
+                root / "export_manifest.json",
+                root / "sources" / "good_source" / "source_result.json",
+                root / "sources" / "good_source" / "report.json",
+                (
+                    root
+                    / "sources"
+                    / "failed-source"
+                    / "source_result.json"
+                ),
+                root / "sources" / "failed-source" / "failure.json",
+            )
+            for path in expected:
+                with self.subTest(path=path):
+                    self.assertTrue(path.is_file())
+
+            self.assertEqual(manifest["n_sources"], 2)
+            self.assertEqual(manifest["n_completed_sources"], 1)
+            self.assertEqual(manifest["n_failed_sources"], 1)
+
+    def test_exported_json_is_strict_and_round_trips(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            manifest = export_representative_lpv_batch_report(
+                self.report.to_dict(),
+                temporary_directory,
+            )
+
+            for path in (
+                manifest["batch_report_path"],
+                manifest["source_manifest_path"],
+                manifest["export_manifest_path"],
+                *(
+                    item["source_result_path"]
+                    for item in manifest["source_artifacts"]
+                ),
+                *(
+                    item["artifact_path"]
+                    for item in manifest["source_artifacts"]
+                ),
+            ):
+                with self.subTest(path=path):
+                    payload = json.loads(
+                        Path(path).read_text(encoding="utf-8")
+                    )
+                    json.dumps(payload, allow_nan=False)
+
+    def test_summary_csv_records_completed_and_failed_sources(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            manifest = export_representative_lpv_batch_report(
+                self.report,
+                temporary_directory,
+            )
+
+            with Path(manifest["source_summary_path"]).open(
+                encoding="utf-8",
+                newline="",
+            ) as handle:
+                rows = list(csv.DictReader(handle))
+
+            self.assertEqual(
+                [row["source_id"] for row in rows],
+                ["good/source", "failed-source"],
+            )
+            self.assertEqual(
+                [row["status"] for row in rows],
+                ["completed", "failed"],
+            )
+            self.assertEqual(
+                rows[1]["failure_stage"],
+                "advisory_workflow",
+            )
+            self.assertEqual(
+                rows[1]["exception_type"],
+                "RuntimeError",
+            )
+
+    def test_export_layer_remains_nonselecting_and_does_not_run_fits(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            manifest = export_representative_lpv_batch_report(
+                self.report,
+                temporary_directory,
+            )
+
+            self.assertTrue(manifest["advisory_only"])
+            self.assertFalse(
+                manifest["automatic_model_selection_applied"]
+            )
+            self.assertIsNone(manifest["selected_model"])
+            self.assertFalse(
+                manifest["automatic_constraints_applied"]
+            )
+            self.assertFalse(
+                manifest["automatic_initialization_applied"]
+            )
+            self.assertTrue(manifest["source_report_writes_only"])
+            self.assertFalse(manifest["runs_fits"])
+
+    def test_invalid_report_type_is_rejected(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            with self.assertRaisesRegex(TypeError, "report"):
+                export_representative_lpv_batch_report(
+                    object(),
+                    temporary_directory,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wavelength_validation_real_lpv_reproducibility.py
+++ b/tests/test_wavelength_validation_real_lpv_reproducibility.py
@@ -1,0 +1,259 @@
+"""Reproducibility contracts for representative LPV D3 execution."""
+
+from __future__ import annotations
+
+import json
+import random
+import unittest
+
+import numpy as np
+import torch
+
+from pgmuvi.lightcurve import Lightcurve
+from pgmuvi.wavelength_validation_real_lpv import (
+    RepresentativeLPVBatchReport,
+    RepresentativeLPVSourceSpecification,
+    build_representative_lpv_runtime_environment,
+    run_representative_lpv_validation_batch,
+)
+
+
+def _lightcurve(name):
+    return Lightcurve(
+        torch.tensor(
+            [
+                [0.0, 0.55],
+                [1.0, 0.55],
+                [0.0, 1.25],
+                [1.0, 1.25],
+            ],
+            dtype=torch.float64,
+        ),
+        torch.tensor(
+            [10.0, 11.0, 8.0, 9.0],
+            dtype=torch.float64,
+        ),
+        yerr=torch.tensor(
+            [0.2, 0.2, 0.3, 0.3],
+            dtype=torch.float64,
+        ),
+        band=np.asarray(
+            [
+                "instrument-v",
+                "instrument-v",
+                "instrument-j",
+                "instrument-j",
+            ],
+            dtype=str,
+        ),
+        xtransform=None,
+        center_time=False,
+        check_sampling=False,
+        max_samples=None,
+        max_samples_per_band=None,
+        name=name,
+    )
+
+
+def _workflow_report():
+    return {
+        "kind": "period_independent_wavelength_advisory_workflow",
+        "advisory_only": True,
+        "automatic_model_selection_applied": False,
+        "selected_model": None,
+        "fit_quality_ranking_status": "unavailable",
+        "fit_quality_ranking_available": False,
+        "top_ranked_model": None,
+        "model_kernel_config_report": {
+            "period_independent_diagnostics": {
+                "kind": (
+                    "period_independent_wavelength_structure_diagnostics"
+                ),
+                "n_usable_observational_channels": 2,
+                "n_distinct_physical_wavelengths": 2,
+            },
+        },
+        "run_report": {
+            "model_kernel_config_results": [],
+        },
+        "quality_report": {
+            "fit_quality_ranking_status": "unavailable",
+            "fit_quality_ranking_available": False,
+            "n_with_fit_quality": 0,
+            "top_ranked_model": None,
+            "ranked_results": [],
+        },
+    }
+
+
+class TestRepresentativeLPVRuntimeEnvironment(unittest.TestCase):
+    def test_runtime_environment_is_compact_and_json_safe(self):
+        payload = build_representative_lpv_runtime_environment()
+
+        required = (
+            "python_version",
+            "python_implementation",
+            "python_executable",
+            "platform",
+            "pgmuvi_version",
+            "numpy_version",
+            "torch_version",
+            "gpytorch_version",
+            "cuda_available",
+        )
+        for key in required:
+            with self.subTest(key=key):
+                self.assertIn(key, payload)
+
+        json.dumps(payload, allow_nan=False)
+
+
+class TestRepresentativeLPVSourceSeed(unittest.TestCase):
+    def setUp(self):
+        self.manifest = (
+            RepresentativeLPVSourceSpecification(
+                source_id="seeded-source",
+                source_path="inputs/source.csv",
+                description="Seeded representative LPV.",
+                sample_role="reproducibility",
+                selection_reason="Exercises deterministic source execution.",
+                seed=135,
+            ),
+        )
+
+    def _run_and_capture(self):
+        draws = {}
+
+        def loader(specification):
+            draws["loader"] = (
+                random.random(),
+                float(np.random.random()),
+                float(torch.rand(())),
+            )
+            return _lightcurve(specification.source_id)
+
+        def workflow_runner(lightcurve, **kwargs):
+            del lightcurve, kwargs
+            draws["workflow"] = (
+                random.random(),
+                float(np.random.random()),
+                float(torch.rand(())),
+            )
+            return _workflow_report()
+
+        report = run_representative_lpv_validation_batch(
+            self.manifest,
+            source_loader=loader,
+            workflow_runner=workflow_runner,
+            workflow_kwargs={
+                "base_fit_kwargs": {
+                    "fit_strategy": "consensus",
+                    "time_kernel_type": "quasi_periodic",
+                    "learn_additional_noise": True,
+                },
+            },
+        )
+        return draws, report
+
+    def test_same_source_seed_repeats_loader_and_workflow_draws(self):
+        first_draws, first_report = self._run_and_capture()
+        second_draws, second_report = self._run_and_capture()
+
+        self.assertEqual(first_draws, second_draws)
+
+        first_row = first_report.to_dict()["source_results"][0]
+        second_row = second_report.to_dict()["source_results"][0]
+
+        self.assertEqual(first_row["execution_seed"], 135)
+        self.assertTrue(first_row["seed_applied"])
+        self.assertEqual(
+            first_row["seed_scope"],
+            "source_loading_and_advisory_workflow",
+        )
+        self.assertEqual(first_row, second_row)
+
+    def test_batch_restores_caller_rng_states(self):
+        random.seed(90210)
+        np.random.seed(90210)
+        torch.manual_seed(90210)
+
+        python_state = random.getstate()
+        numpy_state = np.random.get_state()
+        torch_state = torch.random.get_rng_state().clone()
+
+        self._run_and_capture()
+
+        self.assertEqual(random.getstate(), python_state)
+
+        restored_numpy_state = np.random.get_state()
+        self.assertEqual(
+            restored_numpy_state[0],
+            numpy_state[0],
+        )
+        np.testing.assert_array_equal(
+            restored_numpy_state[1],
+            numpy_state[1],
+        )
+        self.assertEqual(
+            restored_numpy_state[2:],
+            numpy_state[2:],
+        )
+        self.assertTrue(
+            torch.equal(
+                torch.random.get_rng_state(),
+                torch_state,
+            )
+        )
+
+
+class TestRepresentativeLPVExecutionProvenance(unittest.TestCase):
+    def test_batch_report_retains_workflow_and_runtime_provenance(self):
+        specification = RepresentativeLPVSourceSpecification(
+            source_id="provenance-source",
+            source_path="inputs/source.csv",
+            description="Representative LPV provenance source.",
+            sample_role="reproducibility",
+            selection_reason="Exercises execution provenance.",
+            seed=7,
+        )
+        workflow_configuration = {
+            "base_fit_kwargs": {
+                "fit_strategy": "consensus",
+                "time_kernel_type": "quasi_periodic",
+                "learn_additional_noise": True,
+                "training_iter": 500,
+                "miniter": 100,
+            },
+            "make_plots": False,
+        }
+
+        report = run_representative_lpv_validation_batch(
+            (specification,),
+            source_loader=lambda item: _lightcurve(item.source_id),
+            workflow_runner=lambda lightcurve, **kwargs: (
+                _workflow_report()
+            ),
+            workflow_kwargs=workflow_configuration,
+        )
+
+        payload = report.to_dict()
+        self.assertEqual(
+            payload["workflow_configuration"],
+            workflow_configuration,
+        )
+        self.assertIn(
+            "python_version",
+            payload["runtime_environment"],
+        )
+        self.assertIn(
+            "torch_version",
+            payload["runtime_environment"],
+        )
+
+        rebuilt = RepresentativeLPVBatchReport.from_mapping(payload)
+        self.assertEqual(rebuilt.to_dict(), payload)
+        json.dumps(payload, allow_nan=False)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This pull request defines the D3 protocol and execution infrastructure for
representative observed-LPV wavelength validation.

It adds:

- an advisory-only single-source representative-LPV validation report;
- an ordered, failure-aware batch runner that continues after individual
  source failures;
- deterministic JSON and CSV artifact export;
- reproducible per-source random seeds with caller RNG-state restoration;
- runtime and workflow-configuration provenance;
- a maintained command-line runner;
- a public validation manifest and workflow configuration for
  