### PR TITLE
Execute representative LPV wavelength validation

### DIFF
--- a/examples/validation/d3_representative_lpv_calibration_summary.json
+++ b/examples/validation/d3_representative_lpv_calibration_summary.json
@@ -1,0 +1,406 @@
+{
+  "batch_id": "pr136-corrected-sampled-1000-100-per-channel",
+  "execution": {
+    "consensus_frequency_per_day": 0.0016740147349865707,
+    "consensus_period_days": 597.3663069387632,
+    "models": [
+      "2DWavelengthDependent",
+      "2DDustMean",
+      "2DPowerLawMean",
+      "2DSeparable",
+      "2D"
+    ],
+    "n_accepted_observational_channels": 9,
+    "n_attempted": 5,
+    "n_failed": 0,
+    "n_passed": 5,
+    "n_rejected_observational_channels": 8,
+    "technical_outcome_counts": {
+      "completed_with_warnings": 5
+    }
+  },
+  "execution_scope": "deterministically_sampled_representative_observed_lpv",
+  "failure_evidence": {
+    "by_code": {},
+    "by_stage": {},
+    "n_failed_attempts": 0
+  },
+  "fit_quality": {
+    "interpretation": "Descriptive transformed-training-space residual comparison only; not held-out predictive model selection.",
+    "n_with_fit_quality": 5,
+    "ranked_models": [
+      "2DDustMean",
+      "2DWavelengthDependent",
+      "2DSeparable",
+      "2DPowerLawMean",
+      "2D"
+    ],
+    "ranking_available": true,
+    "ranking_status": "available",
+    "score_kind": "training_residual_fit_quality",
+    "top_ranked_fit_quality_score": -1454.9713807659482,
+    "top_ranked_model": "2DDustMean"
+  },
+  "kind": "representative_lpv_calibration_summary",
+  "model_results": [
+    {
+      "constraint_diagnostics": {
+        "n_constrained_sm_ard_components": 0,
+        "n_sm_ard_boundary_hits": 0
+      },
+      "fit_configuration": {
+        "fit_strategy": "consensus",
+        "learn_additional_noise": true,
+        "miniter": 100,
+        "time_kernel_type": "quasi_periodic",
+        "training_iter": 500
+      },
+      "fit_quality": {
+        "fit_quality_score": -1631.3012073348584,
+        "quality_rank": 2,
+        "training_median_abs_standardized_residual": 0.07169611866104225,
+        "training_nrmse_by_target_scale": 69.22902480717192,
+        "training_outlier_fraction_3sigma": 0.005069708491761723,
+        "training_reduced_chi2": 0.43541700073461415
+      },
+      "model": "2DWavelengthDependent",
+      "model_hypothesis": {
+        "baseline": false,
+        "comparison_cautions": [
+          "This label describes a complete mean-plus-covariance GP configuration, not an isolated physical mechanism.",
+          "A score difference from 2DSeparable changes both the mean structure and potentially the instantiated covariance configuration."
+        ],
+        "covariance_separable": true,
+        "covariance_structure": "separable_smooth_wavelength",
+        "covariance_wavelength_dependent": true,
+        "lpv_advisory_priority": 1,
+        "mean_structure": "quadratic",
+        "mean_wavelength_dependent": true,
+        "metadata": {},
+        "model": "2DWavelengthDependent",
+        "role": "mean_and_covariance",
+        "schema_version": "pgmuvi-wavelength-hypotheses-v1",
+        "summary": "Quadratic wavelength-dependent mean plus separable configurable time covariance and smooth wavelength covariance.",
+        "temporal_kernel_configurable": true
+      },
+      "model_kernel_config_id": "rank1_2DWavelengthDependent",
+      "period_evidence": {
+        "consensus_frequency_per_day": 0.0016740147349865707,
+        "consensus_period_days": 597.3663069387632,
+        "consensus_success": true,
+        "n_accepted_observational_channels": 9,
+        "n_rejected_observational_channels": 8
+      },
+      "residual_wavelength_structure": {
+        "available": true,
+        "largest_absolute_bias": 11.578223673679465,
+        "largest_absolute_bias_physical_wavelength": 3.4935196814573,
+        "n_physical_wavelengths": 16,
+        "worst_rmse": 34.15528443353768,
+        "worst_rmse_physical_wavelength": 3.4935196814573
+      },
+      "status": "passed",
+      "technical_outcome": "completed_with_warnings",
+      "warning_count": 1
+    },
+    {
+      "constraint_diagnostics": {
+        "n_constrained_sm_ard_components": 0,
+        "n_sm_ard_boundary_hits": 0
+      },
+      "fit_configuration": {
+        "fit_strategy": "consensus",
+        "learn_additional_noise": true,
+        "miniter": 100,
+        "time_kernel_type": "quasi_periodic",
+        "training_iter": 500
+      },
+      "fit_quality": {
+        "fit_quality_score": -1454.9713807659482,
+        "quality_rank": 1,
+        "training_median_abs_standardized_residual": 0.05681669151988894,
+        "training_nrmse_by_target_scale": 62.179631224529466,
+        "training_outlier_fraction_3sigma": 0.005069708491761723,
+        "training_reduced_chi2": 0.3219341526115374
+      },
+      "model": "2DDustMean",
+      "model_hypothesis": {
+        "baseline": false,
+        "comparison_cautions": [
+          "This label describes a complete mean-plus-covariance GP configuration, not an isolated physical mechanism.",
+          "This is not a mean-only hypothesis; it also contains wavelength covariance.",
+          "A better complete-fit score alone does not isolate evidence for the dust mean law."
+        ],
+        "covariance_separable": true,
+        "covariance_structure": "separable_smooth_wavelength",
+        "covariance_wavelength_dependent": true,
+        "lpv_advisory_priority": 2,
+        "mean_structure": "dust_attenuation",
+        "mean_wavelength_dependent": true,
+        "metadata": {},
+        "model": "2DDustMean",
+        "role": "mean_and_covariance",
+        "schema_version": "pgmuvi-wavelength-hypotheses-v1",
+        "summary": "Dust-attenuation wavelength mean plus the same broad family of separable configurable time and smooth wavelength covariance.",
+        "temporal_kernel_configurable": true
+      },
+      "model_kernel_config_id": "rank2_2DDustMean",
+      "period_evidence": {
+        "consensus_frequency_per_day": 0.0016740147349865707,
+        "consensus_period_days": 597.3663069387632,
+        "consensus_success": true,
+        "n_accepted_observational_channels": 9,
+        "n_rejected_observational_channels": 8
+      },
+      "residual_wavelength_structure": {
+        "available": true,
+        "largest_absolute_bias": 18.35278393068747,
+        "largest_absolute_bias_physical_wavelength": 3.4935196814573,
+        "n_physical_wavelengths": 16,
+        "worst_rmse": 30.764432563053976,
+        "worst_rmse_physical_wavelength": 3.4935196814573
+      },
+      "status": "passed",
+      "technical_outcome": "completed_with_warnings",
+      "warning_count": 1
+    },
+    {
+      "constraint_diagnostics": {
+        "n_constrained_sm_ard_components": 0,
+        "n_sm_ard_boundary_hits": 0
+      },
+      "fit_configuration": {
+        "fit_strategy": "consensus",
+        "learn_additional_noise": true,
+        "miniter": 100,
+        "time_kernel_type": "quasi_periodic",
+        "training_iter": 500
+      },
+      "fit_quality": {
+        "fit_quality_score": -5262.670183498213,
+        "quality_rank": 4,
+        "training_median_abs_standardized_residual": 0.100800064205042,
+        "training_nrmse_by_target_scale": 214.47675239707033,
+        "training_outlier_fraction_3sigma": 0.005069708491761723,
+        "training_reduced_chi2": 0.620155532807821
+      },
+      "model": "2DPowerLawMean",
+      "model_hypothesis": {
+        "baseline": false,
+        "comparison_cautions": [
+          "This label describes a complete mean-plus-covariance GP configuration, not an isolated physical mechanism.",
+          "This is not a mean-only hypothesis; it also contains wavelength covariance.",
+          "A better complete-fit score alone does not isolate evidence for the power-law mean."
+        ],
+        "covariance_separable": true,
+        "covariance_structure": "separable_smooth_wavelength",
+        "covariance_wavelength_dependent": true,
+        "lpv_advisory_priority": 3,
+        "mean_structure": "power_law",
+        "mean_wavelength_dependent": true,
+        "metadata": {},
+        "model": "2DPowerLawMean",
+        "role": "mean_and_covariance",
+        "schema_version": "pgmuvi-wavelength-hypotheses-v1",
+        "summary": "Power-law wavelength mean plus the same broad family of separable configurable time and smooth wavelength covariance.",
+        "temporal_kernel_configurable": true
+      },
+      "model_kernel_config_id": "rank3_2DPowerLawMean",
+      "period_evidence": {
+        "consensus_frequency_per_day": 0.0016740147349865707,
+        "consensus_period_days": 597.3663069387632,
+        "consensus_success": true,
+        "n_accepted_observational_channels": 9,
+        "n_rejected_observational_channels": 8
+      },
+      "residual_wavelength_structure": {
+        "available": true,
+        "largest_absolute_bias": 52.82666764537064,
+        "largest_absolute_bias_physical_wavelength": 3.4935196814573,
+        "n_physical_wavelengths": 16,
+        "worst_rmse": 106.58952214900647,
+        "worst_rmse_physical_wavelength": 3.4935196814573
+      },
+      "status": "passed",
+      "technical_outcome": "completed_with_warnings",
+      "warning_count": 1
+    },
+    {
+      "constraint_diagnostics": {
+        "n_constrained_sm_ard_components": 0,
+        "n_sm_ard_boundary_hits": 0
+      },
+      "fit_configuration": {
+        "fit_strategy": "consensus",
+        "learn_additional_noise": true,
+        "miniter": 100,
+        "time_kernel_type": "quasi_periodic",
+        "training_iter": 500
+      },
+      "fit_quality": {
+        "fit_quality_score": -3584.562813133531,
+        "quality_rank": 3,
+        "training_median_abs_standardized_residual": 0.0945801418349322,
+        "training_nrmse_by_target_scale": 147.35403333247598,
+        "training_outlier_fraction_3sigma": 0.005069708491761723,
+        "training_reduced_chi2": 0.5672862187514763
+      },
+      "model": "2DSeparable",
+      "model_hypothesis": {
+        "baseline": false,
+        "comparison_cautions": [
+          "This label describes a complete mean-plus-covariance GP configuration, not an isolated physical mechanism.",
+          "A constant mean can leave wavelength-dependent baseline structure to the covariance model or residuals."
+        ],
+        "covariance_separable": true,
+        "covariance_structure": "separable_product",
+        "covariance_wavelength_dependent": true,
+        "lpv_advisory_priority": 4,
+        "mean_structure": "constant",
+        "mean_wavelength_dependent": false,
+        "metadata": {},
+        "model": "2DSeparable",
+        "role": "covariance_focused",
+        "schema_version": "pgmuvi-wavelength-hypotheses-v1",
+        "summary": "Constant mean with a separable product of configurable time and wavelength covariance kernels.",
+        "temporal_kernel_configurable": true
+      },
+      "model_kernel_config_id": "rank4_2DSeparable",
+      "period_evidence": {
+        "consensus_frequency_per_day": 0.0016740147349865707,
+        "consensus_period_days": 597.3663069387632,
+        "consensus_success": true,
+        "n_accepted_observational_channels": 9,
+        "n_rejected_observational_channels": 8
+      },
+      "residual_wavelength_structure": {
+        "available": true,
+        "largest_absolute_bias": 39.01477477309959,
+        "largest_absolute_bias_physical_wavelength": 3.4935196814573,
+        "n_physical_wavelengths": 16,
+        "worst_rmse": 73.16911673874033,
+        "worst_rmse_physical_wavelength": 3.4935196814573
+      },
+      "status": "passed",
+      "technical_outcome": "completed_with_warnings",
+      "warning_count": 1
+    },
+    {
+      "constraint_diagnostics": {
+        "n_constrained_sm_ard_components": 1,
+        "n_sm_ard_boundary_hits": 4
+      },
+      "fit_configuration": {
+        "fit_strategy": "consensus",
+        "learn_additional_noise": true,
+        "miniter": 100,
+        "time_kernel_type": "model_default",
+        "training_iter": 500
+      },
+      "fit_quality": {
+        "fit_quality_score": -41654.74765547373,
+        "quality_rank": 5,
+        "training_median_abs_standardized_residual": 0.24255135804441103,
+        "training_nrmse_by_target_scale": 1670.0941997981872,
+        "training_outlier_fraction_3sigma": 0.029150823827629912,
+        "training_reduced_chi2": 5.077129923922273
+      },
+      "model": "2D",
+      "model_hypothesis": {
+        "baseline": true,
+        "comparison_cautions": [
+          "This label describes a complete mean-plus-covariance GP configuration, not an isolated physical mechanism.",
+          "Its joint spectral-mixture covariance is not the same parameterization as the separable LPV configurations."
+        ],
+        "covariance_separable": false,
+        "covariance_structure": "joint_2d_spectral_mixture",
+        "covariance_wavelength_dependent": true,
+        "lpv_advisory_priority": 5,
+        "mean_structure": "constant",
+        "mean_wavelength_dependent": false,
+        "metadata": {},
+        "model": "2D",
+        "role": "joint_baseline",
+        "schema_version": "pgmuvi-wavelength-hypotheses-v1",
+        "summary": "Constant mean with one joint non-separable two-dimensional spectral-mixture covariance over time and wavelength.",
+        "temporal_kernel_configurable": false
+      },
+      "model_kernel_config_id": "rank5_2D_baseline",
+      "period_evidence": {
+        "consensus_frequency_per_day": 0.0016740147349865707,
+        "consensus_period_days": 597.3663069387632,
+        "consensus_success": true,
+        "n_accepted_observational_channels": 9,
+        "n_rejected_observational_channels": 8
+      },
+      "residual_wavelength_structure": {
+        "available": true,
+        "largest_absolute_bias": 585.3591233602872,
+        "largest_absolute_bias_physical_wavelength": 3.4935196814573,
+        "n_physical_wavelengths": 16,
+        "worst_rmse": 816.5365337341327,
+        "worst_rmse_physical_wavelength": 3.4935196814573
+      },
+      "status": "passed",
+      "technical_outcome": "completed_with_warnings",
+      "warning_count": 1
+    }
+  ],
+  "phase": "D3",
+  "residual_wavelength_structure": {
+    "aggregation_scope": "physical_wavelength",
+    "available": true,
+    "n_models_with_evidence": 5,
+    "shared_wavelength_observational_channels_aggregated": true
+  },
+  "schema_version": "1.0",
+  "scientific_boundaries": {
+    "advisory_only": true,
+    "automatic_model_selection_applied": false,
+    "closes_wavelength_constraint_validation_marker": false,
+    "full_data_execution_completed": false,
+    "instrument_channel_calibration_applied": false,
+    "instrument_channel_calibration_marker": "TBD[instrument-channel-calibration]",
+    "limitations": [
+      "The execution used a deterministic sample rather than all 10815 observations.",
+      "The ranking uses transformed training-space residual diagnostics, not held-out prediction.",
+      "The evidence comes from one representative observed LPV.",
+      "Observational channels sharing a physical wavelength remain aggregated.",
+      "All five fits emitted a small-noise NumericalWarning."
+    ],
+    "selected_model": null,
+    "single_source_only": true,
+    "truth_recovery_evidence": false
+  },
+  "source_data": {
+    "linear_flux": true,
+    "max_samples": 1000,
+    "max_samples_per_observational_channel": 100,
+    "maximum_retained_observational_channel_count": 100,
+    "multiple_observational_channels_per_wavelength": true,
+    "n_distinct_physical_wavelengths": 16,
+    "n_observational_channels": 17,
+    "n_rows_original": 10815,
+    "n_rows_sampled": 789,
+    "public_source_path": "examples/data/10131+3049.csv",
+    "shared_wavelength_policy": "preserve_channels_without_calibration"
+  },
+  "source_id": "10131+3049",
+  "warning_evidence": {
+    "by_category": {
+      "NumericalWarning": 5
+    },
+    "interpretation": "Each candidate completed after GPyTorch raised very small noise values to 1e-6.",
+    "n_warning_records": 5
+  },
+  "workflow_configuration": {
+    "base_fit_kwargs": {
+      "fit_strategy": "consensus",
+      "learn_additional_noise": true,
+      "miniter": 100,
+      "training_iter": 500
+    },
+    "make_plots": false,
+    "make_text_report": true
+  }
+}

--- a/examples/validation/d3_representative_lpv_calibration_summary.json
+++ b/examples/validation/d3_representative_lpv_calibration_summary.json
@@ -376,7 +376,7 @@
     "linear_flux": true,
     "max_samples": 1000,
     "max_samples_per_observational_channel": 100,
-    "maximum_retained_observational_channel_count": 100,
+    "maximum_retained_samples_per_observational_channel": 100,
     "multiple_observational_channels_per_wavelength": true,
     "n_distinct_physical_wavelengths": 16,
     "n_observational_channels": 17,

--- a/examples/validation/d3_representative_lpv_workflow.json
+++ b/examples/validation/d3_representative_lpv_workflow.json
@@ -1,11 +1,10 @@
 {
   "base_fit_kwargs": {
-    "training_iter": 500,
-    "miniter": 100,
     "fit_strategy": "consensus",
-    "time_kernel_type": "quasi_periodic",
-    "learn_additional_noise": true
+    "learn_additional_noise": true,
+    "miniter": 100,
+    "training_iter": 500
   },
-  "make_text_report": true,
-  "make_plots": false
+  "make_plots": false,
+  "make_text_report": true
 }

--- a/pgmuvi/wavelength_diagnostics.py
+++ b/pgmuvi/wavelength_diagnostics.py
@@ -3513,7 +3513,25 @@ def build_period_independent_wavelength_model_kernel_configs(
             "period-independent wavelength parameter plan."
         )
 
-    include_set = {str(model) for model in include_models} if include_models else None
+    normalized_include_models: list[str] = []
+    if include_models is not None:
+        for raw_model in include_models:
+            model = str(raw_model).strip()
+            if not model or model in normalized_include_models:
+                continue
+            normalized_include_models.append(model)
+
+        if not normalized_include_models:
+            raise ValueError(
+                "include_models must contain at least one non-empty "
+                "model name when provided."
+            )
+
+    include_set = (
+        set(normalized_include_models)
+        if include_models is not None
+        else None
+    )
     suggestions = plan.get("model_parameter_suggestions", {})
 
     candidates: list[dict[str, Any]] = []
@@ -3556,8 +3574,8 @@ def build_period_independent_wavelength_model_kernel_configs(
         }
         candidates.append(candidate)
 
-    if include_models:
-        requested_models = [str(model) for model in include_models]
+    if include_models is not None:
+        requested_models = normalized_include_models
 
         for requested_model in requested_models:
             if requested_model == "2D" or requested_model in seen:

--- a/pgmuvi/wavelength_diagnostics.py
+++ b/pgmuvi/wavelength_diagnostics.py
@@ -3556,6 +3556,73 @@ def build_period_independent_wavelength_model_kernel_configs(
         }
         candidates.append(candidate)
 
+    if include_models:
+        requested_models = [str(model) for model in include_models]
+
+        for requested_model in requested_models:
+            if requested_model == "2D" or requested_model in seen:
+                continue
+
+            seen.add(requested_model)
+            fit_kwargs = _piwd_candidate_fit_kwargs(
+                requested_model,
+                base_fit_kwargs=base_fit_kwargs,
+                fit_strategy=fit_strategy,
+                lpv_time_kernel_type=lpv_time_kernel_type,
+                learn_additional_noise=learn_additional_noise,
+            )
+            reason = (
+                "Explicitly requested comparison candidate retained even "
+                "though it was absent from the parameter-plan ranking."
+            )
+            candidates.append(
+                {
+                    "model_kernel_config_id": (
+                        f"rank{len(candidates) + 1}_{requested_model}"
+                    ),
+                    "rank": len(candidates) + 1,
+                    "source": "explicit_include_models",
+                    "source_plan_rank": None,
+                    "model": requested_model,
+                    "fit_kwargs": fit_kwargs,
+                    "recommendation_strength": "advisory",
+                    "hard_exclusion": False,
+                    "primary_reason": reason,
+                    "reason": reason,
+                    "applies_parameter_suggestions": False,
+                    "parameter_suggestions_applied": False,
+                    "applies_constraints": False,
+                    "parameter_suggestions": (
+                        suggestions.get(requested_model)
+                        if include_parameter_suggestions
+                        else None
+                    ),
+                    "model_hypothesis": (
+                        describe_wavelength_model_hypothesis(
+                            requested_model,
+                            fit_kwargs=fit_kwargs,
+                        ).to_dict()
+                    ),
+                }
+            )
+
+        requested_order = {
+            model: index
+            for index, model in enumerate(requested_models)
+            if model != "2D"
+        }
+        candidates.sort(
+            key=lambda candidate: requested_order.get(
+                candidate["model"],
+                len(requested_order),
+            )
+        )
+        for index, candidate in enumerate(candidates, start=1):
+            candidate["rank"] = index
+            candidate["model_kernel_config_id"] = (
+                f"rank{index}_{candidate['model']}"
+            )
+
     if include_2d_baseline and (include_set is None or "2D" in include_set) and "2D" not in seen:
         baseline_kwargs = _piwd_candidate_fit_kwargs(
             "2D",

--- a/pgmuvi/wavelength_validation_real_lpv.py
+++ b/pgmuvi/wavelength_validation_real_lpv.py
@@ -414,18 +414,93 @@ def _residual_wavelength_evidence(
         diagnostics if isinstance(diagnostics, Mapping) else {}
     )
 
+    by_model: dict[str, dict[str, Any]] = {}
+
+    for row in _workflow_attempt_rows(workflow_report):
+        model = str(row.get("model") or "").strip()
+        if not model:
+            continue
+
+        fit_quality = row.get("fit_quality")
+        if not isinstance(fit_quality, Mapping):
+            continue
+
+        wavelength_rows = []
+
+        for wavelength_row in fit_quality.get("by_band") or ():
+            if not isinstance(wavelength_row, Mapping):
+                continue
+
+            wavelength = wavelength_row.get("wavelength")
+            if wavelength is None:
+                continue
+
+            wavelength_rows.append(
+                _json_safe(
+                    {
+                        "physical_wavelength": wavelength,
+                        "n_points": wavelength_row.get("n_points"),
+                        "bias": wavelength_row.get("bias"),
+                        "mae": wavelength_row.get("mae"),
+                        "median_abs_residual": wavelength_row.get(
+                            "median_abs_residual"
+                        ),
+                        "rmse": wavelength_row.get("rmse"),
+                    }
+                )
+            )
+
+        wavelength_rows.sort(
+            key=lambda item: item["physical_wavelength"]
+        )
+
+        if not wavelength_rows:
+            continue
+
+        by_model[model] = _json_safe(
+            {
+                "model_kernel_config_id": row.get(
+                    "model_kernel_config_id"
+                ),
+                "residual_space": fit_quality.get("space"),
+                "n_points": fit_quality.get("n_points"),
+                "n_physical_wavelengths": len(wavelength_rows),
+                "by_physical_wavelength": wavelength_rows,
+            }
+        )
+
     result = dict(_json_safe(diagnostics))
-    result.setdefault(
-        "n_observational_channels",
-        source_summary.get("n_observational_channels"),
+    result.update(
+        {
+            "available": bool(by_model),
+            "aggregation_scope": "physical_wavelength",
+            "n_models_with_residual_wavelength_evidence": (
+                len(by_model)
+            ),
+            "n_observational_channels": source_summary.get(
+                "n_observational_channels"
+            ),
+            "n_distinct_physical_wavelengths": source_summary.get(
+                "n_distinct_physical_wavelengths"
+            ),
+            "shared_wavelength_observational_channels_aggregated": (
+                bool(
+                    source_summary.get(
+                        "multiple_observational_channels_per_wavelength"
+                    )
+                )
+            ),
+            "by_model": by_model,
+            "interpretation": (
+                "Descriptive transformed-training-space residual "
+                "summaries grouped by physical wavelength. "
+                "Observational channels sharing a physical wavelength "
+                "remain aggregated pending instrument-channel "
+                "calibration."
+            ),
+            "truth_recovery_evidence": False,
+        }
     )
-    result.setdefault(
-        "n_distinct_physical_wavelengths",
-        source_summary.get(
-            "n_distinct_physical_wavelengths"
-        ),
-    )
-    result["truth_recovery_evidence"] = False
     return result
 
 
@@ -478,7 +553,12 @@ def _warning_evidence(
     for row in rows:
         model = row.get("model")
         config_id = row.get("model_kernel_config_id")
-        for warning in row.get("warnings") or ():
+        warning_records = (
+            row.get("warning_records")
+            or row.get("warnings")
+            or ()
+        )
+        for warning in warning_records:
             if not isinstance(warning, Mapping):
                 continue
             record = {

--- a/pgmuvi/wavelength_validation_real_lpv.py
+++ b/pgmuvi/wavelength_validation_real_lpv.py
@@ -553,11 +553,11 @@ def _warning_evidence(
     for row in rows:
         model = row.get("model")
         config_id = row.get("model_kernel_config_id")
-        warning_records = (
-            row.get("warning_records")
-            or row.get("warnings")
-            or ()
-        )
+        if "warning_records" in row:
+            warning_records = row.get("warning_records") or ()
+        else:
+            warning_records = row.get("warnings") or ()
+
         for warning in warning_records:
             if not isinstance(warning, Mapping):
                 continue

--- a/tests/test_d3_representative_lpv_calibration_summary.py
+++ b/tests/test_d3_representative_lpv_calibration_summary.py
@@ -60,7 +60,7 @@ class TestRepresentativeLPVCalibrationSummary(
         )
         self.assertLessEqual(
             source[
-                "maximum_retained_observational_channel_count"
+                "maximum_retained_samples_per_observational_channel"
             ],
             source[
                 "max_samples_per_observational_channel"

--- a/tests/test_d3_representative_lpv_calibration_summary.py
+++ b/tests/test_d3_representative_lpv_calibration_summary.py
@@ -1,0 +1,215 @@
+"""Contract tests for the PR136 D3 calibration summary."""
+
+import json
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SUMMARY_PATH = (
+    ROOT
+    / "examples/validation/"
+    "d3_representative_lpv_calibration_summary.json"
+)
+
+
+class TestRepresentativeLPVCalibrationSummary(
+    unittest.TestCase
+):
+    @classmethod
+    def setUpClass(cls):
+        cls.payload = json.loads(
+            SUMMARY_PATH.read_text(encoding="utf-8")
+        )
+
+    def test_identity_and_scope(self):
+        self.assertEqual(
+            self.payload["kind"],
+            "representative_lpv_calibration_summary",
+        )
+        self.assertEqual(
+            self.payload["schema_version"],
+            "1.0",
+        )
+        self.assertEqual(
+            self.payload["source_id"],
+            "10131+3049",
+        )
+        self.assertEqual(
+            self.payload["execution_scope"],
+            (
+                "deterministically_sampled_"
+                "representative_observed_lpv"
+            ),
+        )
+
+    def test_sampling_is_bounded(self):
+        source = self.payload["source_data"]
+
+        self.assertEqual(
+            source["n_rows_original"],
+            10815,
+        )
+        self.assertEqual(
+            source["n_rows_sampled"],
+            789,
+        )
+        self.assertLessEqual(
+            source["n_rows_sampled"],
+            source["max_samples"],
+        )
+        self.assertLessEqual(
+            source[
+                "maximum_retained_observational_channel_count"
+            ],
+            source[
+                "max_samples_per_observational_channel"
+            ],
+        )
+        self.assertEqual(
+            source["n_observational_channels"],
+            17,
+        )
+        self.assertEqual(
+            source["n_distinct_physical_wavelengths"],
+            16,
+        )
+        self.assertTrue(
+            source[
+                "multiple_observational_channels_per_wavelength"
+            ]
+        )
+
+    def test_all_priority_models_completed(self):
+        execution = self.payload["execution"]
+
+        self.assertEqual(
+            execution["models"],
+            [
+                "2DWavelengthDependent",
+                "2DDustMean",
+                "2DPowerLawMean",
+                "2DSeparable",
+                "2D",
+            ],
+        )
+        self.assertEqual(execution["n_attempted"], 5)
+        self.assertEqual(execution["n_passed"], 5)
+        self.assertEqual(execution["n_failed"], 0)
+        self.assertAlmostEqual(
+            execution["consensus_period_days"],
+            597.3663069387632,
+            places=8,
+        )
+
+        by_model = {
+            row["model"]: row
+            for row in self.payload["model_results"]
+        }
+
+        for model in execution["models"][:-1]:
+            self.assertEqual(
+                by_model[model][
+                    "fit_configuration"
+                ]["time_kernel_type"],
+                "quasi_periodic",
+            )
+
+        self.assertEqual(
+            by_model["2D"][
+                "fit_configuration"
+            ]["time_kernel_type"],
+            "model_default",
+        )
+
+    def test_warning_failure_and_residual_evidence(self):
+        self.assertEqual(
+            self.payload["warning_evidence"][
+                "n_warning_records"
+            ],
+            5,
+        )
+        self.assertEqual(
+            self.payload["warning_evidence"][
+                "by_category"
+            ],
+            {"NumericalWarning": 5},
+        )
+        self.assertEqual(
+            self.payload["failure_evidence"][
+                "n_failed_attempts"
+            ],
+            0,
+        )
+        residual = self.payload[
+            "residual_wavelength_structure"
+        ]
+        self.assertTrue(residual["available"])
+        self.assertEqual(
+            residual["aggregation_scope"],
+            "physical_wavelength",
+        )
+        self.assertEqual(
+            residual["n_models_with_evidence"],
+            5,
+        )
+
+    def test_ranking_remains_advisory(self):
+        fit_quality = self.payload["fit_quality"]
+        boundaries = self.payload[
+            "scientific_boundaries"
+        ]
+
+        self.assertEqual(
+            fit_quality["ranked_models"],
+            [
+                "2DDustMean",
+                "2DWavelengthDependent",
+                "2DSeparable",
+                "2DPowerLawMean",
+                "2D",
+            ],
+        )
+        self.assertEqual(
+            fit_quality["top_ranked_model"],
+            "2DDustMean",
+        )
+        self.assertTrue(boundaries["advisory_only"])
+        self.assertFalse(
+            boundaries[
+                "automatic_model_selection_applied"
+            ]
+        )
+        self.assertIsNone(boundaries["selected_model"])
+        self.assertFalse(
+            boundaries["full_data_execution_completed"]
+        )
+        self.assertFalse(
+            boundaries[
+                "closes_wavelength_constraint_validation_marker"
+            ]
+        )
+
+    def test_2d_structural_diagnostics_are_recorded(self):
+        by_model = {
+            row["model"]: row
+            for row in self.payload["model_results"]
+        }
+        baseline = by_model["2D"]
+
+        self.assertEqual(
+            baseline["constraint_diagnostics"][
+                "n_sm_ard_boundary_hits"
+            ],
+            4,
+        )
+        self.assertEqual(
+            baseline["constraint_diagnostics"][
+                "n_constrained_sm_ard_components"
+            ],
+            1,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pr136_real_lpv_execution_corrections.py
+++ b/tests/test_pr136_real_lpv_execution_corrections.py
@@ -1,0 +1,274 @@
+"""Regression tests for PR136 representative-LPV execution."""
+
+import json
+import unittest
+from pathlib import Path
+
+from pgmuvi.wavelength_diagnostics import (
+    build_period_independent_wavelength_model_kernel_configs,
+)
+from pgmuvi.wavelength_validation_real_lpv import (
+    DEFAULT_REPRESENTATIVE_LPV_MODELS,
+    _residual_wavelength_evidence,
+    _warning_evidence,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class TestRepresentativeLPVRequestedModelCoverage(unittest.TestCase):
+    def test_all_requested_models_are_built_in_requested_order(self):
+        plan = {
+            "kind": "period_independent_wavelength_parameter_plan",
+            "ranked_candidates": [
+                {
+                    "rank": 1,
+                    "model": "2DDustMean",
+                    "recommendation_strength": "advisory",
+                },
+                {
+                    "rank": 2,
+                    "model": "2DPowerLawMean",
+                    "recommendation_strength": "advisory",
+                },
+                {
+                    "rank": 3,
+                    "model": "2DWavelengthDependent",
+                    "recommendation_strength": "advisory",
+                },
+            ],
+            "model_parameter_suggestions": {},
+        }
+
+        report = (
+            build_period_independent_wavelength_model_kernel_configs(
+                plan,
+                include_models=DEFAULT_REPRESENTATIVE_LPV_MODELS,
+                include_2d_baseline=True,
+                base_fit_kwargs={
+                    "training_iter": 5,
+                    "miniter": 1,
+                    "fit_strategy": "consensus",
+                    "learn_additional_noise": True,
+                },
+            )
+        )
+
+        candidates = report["model_kernel_configs"]
+
+        self.assertEqual(
+            [candidate["model"] for candidate in candidates],
+            list(DEFAULT_REPRESENTATIVE_LPV_MODELS),
+        )
+
+        by_model = {
+            candidate["model"]: candidate
+            for candidate in candidates
+        }
+
+        self.assertEqual(
+            by_model["2DSeparable"]["source"],
+            "explicit_include_models",
+        )
+
+        for model in DEFAULT_REPRESENTATIVE_LPV_MODELS[:-1]:
+            self.assertEqual(
+                by_model[model]["fit_kwargs"]["time_kernel_type"],
+                "quasi_periodic",
+            )
+
+        self.assertNotIn(
+            "time_kernel_type",
+            by_model["2D"]["fit_kwargs"],
+        )
+
+
+class TestRepresentativeLPVPublicWorkflowConfiguration(
+    unittest.TestCase
+):
+    def test_shared_base_kwargs_do_not_override_2d_time_kernel(self):
+        workflow = json.loads(
+            (
+                ROOT
+                / "examples/validation/"
+                "d3_representative_lpv_workflow.json"
+            ).read_text(encoding="utf-8")
+        )
+
+        self.assertNotIn(
+            "time_kernel_type",
+            workflow["base_fit_kwargs"],
+        )
+        self.assertEqual(
+            workflow["base_fit_kwargs"]["fit_strategy"],
+            "consensus",
+        )
+        self.assertTrue(
+            workflow["base_fit_kwargs"]["learn_additional_noise"]
+        )
+
+
+class TestRepresentativeLPVWarningEvidence(unittest.TestCase):
+    def test_attempt_warning_records_are_collected(self):
+        evidence = _warning_evidence(
+            [
+                {
+                    "model": "2DDustMean",
+                    "model_kernel_config_id": (
+                        "rank2_2DDustMean"
+                    ),
+                    "warning_records": [
+                        {
+                            "category": "NumericalWarning",
+                            "message": "small noise rounded",
+                            "severity": "warning",
+                        }
+                    ],
+                }
+            ]
+        )
+
+        self.assertEqual(evidence["n_warning_records"], 1)
+        self.assertEqual(
+            evidence["by_category"],
+            {"NumericalWarning": 1},
+        )
+        self.assertEqual(
+            evidence["records"][0]["model"],
+            "2DDustMean",
+        )
+
+    def test_legacy_warnings_field_remains_supported(self):
+        evidence = _warning_evidence(
+            [
+                {
+                    "model": "2DPowerLawMean",
+                    "warnings": [
+                        {
+                            "category": "UserWarning",
+                            "message": "legacy warning",
+                        }
+                    ],
+                }
+            ]
+        )
+
+        self.assertEqual(evidence["n_warning_records"], 1)
+        self.assertEqual(
+            evidence["by_category"],
+            {"UserWarning": 1},
+        )
+
+
+class TestRepresentativeLPVResidualWavelengthEvidence(
+    unittest.TestCase
+):
+    def test_fit_quality_rows_are_exposed_by_physical_wavelength(
+        self,
+    ):
+        workflow_report = {
+            "run_report": {
+                "model_kernel_config_results": [
+                    {
+                        "model": "2DDustMean",
+                        "model_kernel_config_id": (
+                            "rank2_2DDustMean"
+                        ),
+                        "fit_quality": {
+                            "space": "transformed_training_space",
+                            "n_points": 30,
+                            "by_band": [
+                                {
+                                    "wavelength": 2.2,
+                                    "n_points": 10,
+                                    "bias": 0.2,
+                                    "mae": 0.3,
+                                    "median_abs_residual": 0.25,
+                                    "rmse": 0.4,
+                                },
+                                {
+                                    "wavelength": 0.65,
+                                    "n_points": 20,
+                                    "bias": -0.01,
+                                    "mae": 0.02,
+                                    "median_abs_residual": 0.015,
+                                    "rmse": 0.03,
+                                },
+                            ],
+                        },
+                    }
+                ]
+            }
+        }
+        source_summary = {
+            "n_observational_channels": 3,
+            "n_distinct_physical_wavelengths": 2,
+            "multiple_observational_channels_per_wavelength": True,
+        }
+
+        evidence = _residual_wavelength_evidence(
+            workflow_report,
+            source_summary,
+        )
+
+        self.assertTrue(evidence["available"])
+        self.assertEqual(
+            evidence[
+                "n_models_with_residual_wavelength_evidence"
+            ],
+            1,
+        )
+        self.assertEqual(
+            evidence["aggregation_scope"],
+            "physical_wavelength",
+        )
+        self.assertTrue(
+            evidence[
+                "shared_wavelength_observational_channels_aggregated"
+            ]
+        )
+
+        dust = evidence["by_model"]["2DDustMean"]
+
+        self.assertEqual(dust["n_physical_wavelengths"], 2)
+        self.assertEqual(
+            [
+                row["physical_wavelength"]
+                for row in dust["by_physical_wavelength"]
+            ],
+            [0.65, 2.2],
+        )
+        self.assertEqual(
+            dust["by_physical_wavelength"][1]["rmse"],
+            0.4,
+        )
+
+    def test_unavailable_evidence_is_explicit(self):
+        evidence = _residual_wavelength_evidence(
+            {
+                "run_report": {
+                    "model_kernel_config_results": []
+                }
+            },
+            {
+                "n_observational_channels": 0,
+                "n_distinct_physical_wavelengths": 0,
+                "multiple_observational_channels_per_wavelength": (
+                    False
+                ),
+            },
+        )
+
+        self.assertFalse(evidence["available"])
+        self.assertEqual(
+            evidence[
+                "n_models_with_residual_wavelength_evidence"
+            ],
+            0,
+        )
+        self.assertEqual(evidence["by_model"], {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pr136_real_lpv_execution_corrections.py
+++ b/tests/test_pr136_real_lpv_execution_corrections.py
@@ -18,6 +18,57 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 class TestRepresentativeLPVRequestedModelCoverage(unittest.TestCase):
+    def test_include_models_are_stripped_deduplicated_and_validated(
+        self,
+    ):
+        plan = {
+            "kind": "period_independent_wavelength_parameter_plan",
+            "ranked_candidates": [
+                {
+                    "rank": 1,
+                    "model": "2DDustMean",
+                    "recommendation_strength": "advisory",
+                }
+            ],
+            "model_parameter_suggestions": {},
+        }
+
+        report = (
+            build_period_independent_wavelength_model_kernel_configs(
+                plan,
+                include_models=[
+                    " 2DDustMean ",
+                    "",
+                    "   ",
+                    "2DSeparable",
+                    "2DSeparable",
+                    " 2D ",
+                ],
+                include_2d_baseline=True,
+            )
+        )
+
+        self.assertEqual(
+            [
+                candidate["model"]
+                for candidate in report["model_kernel_configs"]
+            ],
+            [
+                "2DDustMean",
+                "2DSeparable",
+                "2D",
+            ],
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "at least one non-empty model name",
+        ):
+            build_period_independent_wavelength_model_kernel_configs(
+                plan,
+                include_models=["", "   "],
+            )
+
     def test_all_requested_models_are_built_in_requested_order(self):
         plan = {
             "kind": "period_independent_wavelength_parameter_plan",
@@ -138,6 +189,28 @@ class TestRepresentativeLPVWarningEvidence(unittest.TestCase):
             evidence["records"][0]["model"],
             "2DDustMean",
         )
+
+    def test_explicit_empty_warning_records_override_legacy_field(
+        self,
+    ):
+        evidence = _warning_evidence(
+            [
+                {
+                    "model": "2DDustMean",
+                    "warning_records": [],
+                    "warnings": [
+                        {
+                            "category": "UserWarning",
+                            "message": "stale legacy warning",
+                        }
+                    ],
+                }
+            ]
+        )
+
+        self.assertEqual(evidence["n_warning_records"], 0)
+        self.assertEqual(evidence["by_category"], {})
+        self.assertEqual(evidence["records"], [])
 
     def test_legacy_warnings_field_remains_supported(self):
         evidence = _warning_evidence(

--- a/tests/test_run_representative_lpv_validation_script.py
+++ b/tests/test_run_representative_lpv_validation_script.py
@@ -242,11 +242,9 @@ class TestRepresentativeLPVCLI(unittest.TestCase):
             ]["fit_strategy"],
             "consensus",
         )
-        self.assertEqual(
-            captured["workflow_kwargs"][
-                "base_fit_kwargs"
-            ]["time_kernel_type"],
-            "quasi_periodic",
+        self.assertNotIn(
+            "time_kernel_type",
+            captured["workflow_kwargs"]["base_fit_kwargs"],
         )
         self.assertTrue(
             captured["workflow_kwargs"][


### PR DESCRIPTION
## Summary

- execute the representative observed-LPV D3 workflow on a deterministic bounded sample of the public `10131+3049` light curve
- run all five maintained LPV-relevant candidates in the documented order
- preserve the full `2D` baseline spectral-mixture time-kernel default
- propagate captured fit warnings into source-level evidence
- expose transformed-training-space residual summaries by physical wavelength
- commit a compact calibration summary with explicit scientific limitations

## Validation scope

The execution uses linear flux and retains all 17 observational channels and 16 distinct physical wavelengths. It is bounded to at most 1,000 total samples and 100 samples per observational channel.

The maintained candidate set is:

1. `2DWavelengthDependent`
2. `2DDustMean`
3. `2DPowerLawMean`
4. `2DSeparable`
5. `2D`

The four separable LPV models use consensus fitting with a quasi-periodic time kernel. The non-separable `2D` baseline retains its model-default spectral-mixture kernel.

## Result

- five candidate fits attempted
- five candidate fits completed
- consensus period approximately 597.37 days
- five propagated GPyTorch `NumericalWarning` records
- residual-wavelength evidence available for all five candidates
- descriptive training-residual ranking led by `2DDustMean`

The ranking remains advisory. It is not held-out predictive comparison and does not perform automatic model selection.

## Scientific boundaries

- `selected_model` remains `None`
- no automatic constraints or initialization are applied
- the execution covers one sampled representative observed LPV
- shared-wavelength observational channels remain aggregated
- instrument-specific channel calibration remains future work
- `TBD[wavelength-constraint-validation]` remains open for the subsequent consolidation PR
- `TBD[instrument-channel-calibration]` remains open

## Validation

- `ruff check -v --output-format=full --show-fixes ./pgmuvi`
- `make -C docs clean && make -C docs html-strict`
- `PYTHONPATH=. python3 -m unittest discover -s tests -p "test*.py" -v`
