### PR TITLE
Consolidate D3 wavelength validation documentation

### DIFF
--- a/docs/source/future_work.rst
+++ b/docs/source/future_work.rst
@@ -74,20 +74,40 @@ Completed wavelength-derived constraint tranche (PR121--PR125)
     kernel.  These records remain descriptive and do not convert constraint
     pressure into model-selection evidence.
 
-**TBD[wavelength-constraint-validation]**
-    D1 nominal recovery, the canonical 20-seed D2 robustness calibration, and
-    the maintained wavelength-constraint notebook are complete.  D3
-    representative observed-LPV validation infrastructure is now implemented
-    as a failure-aware, non-selecting reporting layer over the maintained
-    advisory workflow.  The remaining work is to execute and review the D3
-    validation on a representative source set across the maintained model
-    families.  Source-level period evidence, fit quality, residual wavelength
-    structure, constraint diagnostics, warnings, and failure semantics must be
-    reported together.  Successful optimization alone is not sufficient
-    validation, and D3 must remain advisory rather than define an automatic
-    model-selection rule.  Instrument-specific treatment of observational
-    channels sharing one physical wavelength remains
-    ``TBD[instrument-channel-calibration]``.
+**Completed: representative wavelength-constraint validation**
+
+The D3 representative observed-LPV validation has been executed,
+summarized, documented, and covered by regression tests.  The
+bounded deterministic execution used 789 of the 10,815 public
+``10131+3049`` observations while retaining all 17 observational
+channels and all 16 distinct physical wavelengths.
+
+All five maintained LPV-relevant candidates completed:
+
+* ``2DWavelengthDependent``
+* ``2DDustMean``
+* ``2DPowerLawMean``
+* ``2DSeparable``
+* ``2D``
+
+The execution records source-level period evidence, transformed
+training-space fit quality, residual structure by physical
+wavelength, constraint diagnostics, warnings, and structured
+failure semantics.  The common consensus period was approximately
+597.37 days.
+
+The resulting ranking is descriptive and advisory.  It is not
+held-out predictive evidence, truth recovery, or automatic model
+selection.  The detailed execution contract and limitations are
+documented in ``howto/representative_lpv_validation.rst`` and the
+compact committed result is stored in
+``examples/validation/d3_representative_lpv_calibration_summary.json``.
+
+This documentation consolidation closes the D3
+wavelength-constraint validation marker.  The calibration summary
+correctly records that the preceding execution PR did not itself
+close the marker; closure occurs here after consolidation and
+regression coverage.
 
 Wavelength-model extensions
 ---------------------------

--- a/docs/source/howto/representative_lpv_validation.rst
+++ b/docs/source/howto/representative_lpv_validation.rst
@@ -212,3 +212,72 @@ The report therefore always retains:
 A successful optimization is not, by itself, validation.  Period evidence,
 residual structure, constraint pressure, warning state, and failed attempts
 must be reviewed together before drawing a scientific conclusion.
+
+D3 execution result and validation closeout
+-------------------------------------------
+
+The representative workflow was executed on a deterministic bounded
+sample of the public ``examples/data/10131+3049.csv`` light curve.
+The sample retained 789 of 10,815 observations, all 17 observational
+channels, and all 16 distinct physical wavelengths.  The sampling
+limit was 1,000 total observations and 100 observations per
+observational channel.
+
+The execution attempted and completed the five maintained
+LPV-relevant candidates in this order:
+
+1. ``2DWavelengthDependent``
+2. ``2DDustMean``
+3. ``2DPowerLawMean``
+4. ``2DSeparable``
+5. ``2D``
+
+The four separable candidates used consensus fitting with a
+quasi-periodic time kernel and learned additional noise.  The
+non-separable ``2D`` baseline retained its model-default
+spectral-mixture time-kernel configuration.
+
+All five fits returned a consensus period of
+``597.3663069387632`` days, corresponding to a frequency of
+``0.0016740147349865707`` per day.  Nine observational channels
+were accepted and eight were rejected by the consensus evidence.
+
+All five technical outcomes were ``completed_with_warnings``.
+Each fit recorded a GPyTorch ``NumericalWarning`` because a very
+small noise value was rounded to ``1e-6``.  No fit attempt failed.
+
+The descriptive transformed-training-space residual ranking was:
+
+1. ``2DDustMean``
+2. ``2DWavelengthDependent``
+3. ``2DSeparable``
+4. ``2DPowerLawMean``
+5. ``2D``
+
+This ordering is advisory only.  It is not based on held-out
+prediction and does not select a preferred model automatically.
+The workflow therefore leaves ``selected_model`` unset.
+
+Residual wavelength evidence is available for all five candidates
+and is aggregated by physical wavelength.  Observational channels
+sharing one physical wavelength remain grouped because
+instrument-specific channel calibration has not been implemented.
+That separate limitation remains tracked by
+``TBD[instrument-channel-calibration]``.
+
+The validation establishes that the maintained candidate set can be
+executed consistently on one representative observed LPV and that
+its wavelength-related diagnostics can be exported and interpreted
+without conflating observational channels with physical
+wavelengths.  It does not establish population-level performance,
+truth recovery, uniqueness of the inferred wavelength dependence,
+or full-data computational feasibility.
+
+The compact deterministic result is committed as
+``examples/validation/d3_representative_lpv_calibration_summary.json``.
+The larger reports and fit products remain under the ignored
+``validation_outputs/d3_real_lpv/`` tree.
+
+With the execution result, scientific boundaries, documentation,
+and regression contracts consolidated, the D3
+wavelength-constraint validation marker is closed.

--- a/docs/source/howto/wavelength_advisory.rst
+++ b/docs/source/howto/wavelength_advisory.rst
@@ -608,10 +608,10 @@ initialization with enforceable constraints for ``2DWavelengthDependent``,
 ``2DDustMean``, and ``2DPowerLawMean``.  Those fitting changes do not turn the
 conclusion records into automatic selection evidence.
 
-The diagnostic tranche is complete through PR125.
-Scientific recovery and robustness work remains under
-``TBD[wavelength-constraint-validation]``.  Independent temporal and wavelength
-ARD bounds and component/dimension boundary provenance are implemented for the
-full ``2D`` spectral-mixture baseline.  The remaining work is synthetic
-recovery, robustness across sampling and seeds, and representative real-LPV
-validation.
+The D3 representative observed-LPV execution now provides the
+completed wavelength-constraint validation evidence.  It records
+period evidence, fit quality, residual wavelength structure,
+constraint diagnostics, warnings, and structured failure semantics
+for all five maintained candidates.  See
+:doc:`representative_lpv_validation` for the execution result,
+limitations, and interpretation boundaries.

--- a/tests/test_d3_wavelength_constraint_validation_closeout.py
+++ b/tests/test_d3_wavelength_constraint_validation_closeout.py
@@ -1,0 +1,174 @@
+"""Contracts for the D3 wavelength-validation documentation closeout."""
+
+import json
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS_ROOT = ROOT / "docs/source"
+FUTURE_WORK = DOCS_ROOT / "future_work.rst"
+ADVISORY = DOCS_ROOT / "howto/wavelength_advisory.rst"
+REPRESENTATIVE = (
+    DOCS_ROOT / "howto/representative_lpv_validation.rst"
+)
+SUMMARY = (
+    ROOT
+    / "examples/validation/"
+    "d3_representative_lpv_calibration_summary.json"
+)
+
+CLOSED_MARKER = "TBD[wavelength-constraint-validation]"
+OPEN_CALIBRATION_MARKER = (
+    "TBD[instrument-channel-calibration]"
+)
+
+
+class TestD3WavelengthConstraintValidationCloseout(
+    unittest.TestCase
+):
+    @classmethod
+    def setUpClass(cls):
+        cls.future_work = FUTURE_WORK.read_text(
+            encoding="utf-8"
+        )
+        cls.advisory = ADVISORY.read_text(
+            encoding="utf-8"
+        )
+        cls.representative = REPRESENTATIVE.read_text(
+            encoding="utf-8"
+        )
+        cls.summary = json.loads(
+            SUMMARY.read_text(encoding="utf-8")
+        )
+
+    def test_validation_marker_is_closed_across_docs(self):
+        occurrences = []
+
+        for doc_file in DOCS_ROOT.rglob("*.rst"):
+            text = doc_file.read_text(encoding="utf-8")
+
+            if CLOSED_MARKER in text:
+                occurrences.append(
+                    str(doc_file.relative_to(ROOT))
+                )
+
+        self.assertEqual(occurrences, [])
+
+    def test_future_work_records_completed_status(self):
+        self.assertIn(
+            (
+                "**Completed: representative "
+                "wavelength-constraint validation**"
+            ),
+            self.future_work,
+        )
+        self.assertIn(
+            (
+                "d3_representative_lpv_"
+                "calibration_summary.json"
+            ),
+            self.future_work,
+        )
+        self.assertIn(
+            "597.37 days",
+            self.future_work,
+        )
+
+    def test_representative_result_is_consolidated(self):
+        required_text = [
+            "D3 execution result and validation closeout",
+            "789 of 10,815 observations",
+            "17 observational channels",
+            "16 distinct physical wavelengths",
+            "2DWavelengthDependent",
+            "2DDustMean",
+            "2DPowerLawMean",
+            "2DSeparable",
+            "597.3663069387632",
+            "completed_with_warnings",
+            "selected_model",
+            "advisory only",
+            "aggregated by physical wavelength",
+        ]
+
+        normalized_representative = " ".join(
+            self.representative.split()
+        )
+
+        for expected in required_text:
+            with self.subTest(expected=expected):
+                self.assertIn(
+                    " ".join(expected.split()),
+                    normalized_representative,
+                )
+
+    def test_instrument_calibration_marker_remains_open(self):
+        self.assertIn(
+            OPEN_CALIBRATION_MARKER,
+            self.future_work,
+        )
+        self.assertIn(
+            OPEN_CALIBRATION_MARKER,
+            self.representative,
+        )
+
+    def test_advisory_document_points_to_completed_evidence(
+        self,
+    ):
+        self.assertIn(
+            (
+                "completed wavelength-constraint "
+                "validation evidence"
+            ),
+            self.advisory,
+        )
+        self.assertIn(
+            ":doc:`representative_lpv_validation`",
+            self.advisory,
+        )
+
+    def test_closeout_preserves_scientific_boundaries(self):
+        boundaries = self.summary[
+            "scientific_boundaries"
+        ]
+
+        self.assertTrue(boundaries["advisory_only"])
+        self.assertFalse(
+            boundaries[
+                "automatic_model_selection_applied"
+            ]
+        )
+        self.assertIsNone(boundaries["selected_model"])
+        self.assertFalse(
+            boundaries["truth_recovery_evidence"]
+        )
+        self.assertFalse(
+            boundaries["full_data_execution_completed"]
+        )
+        self.assertFalse(
+            boundaries[
+                "instrument_channel_calibration_applied"
+            ]
+        )
+
+    def test_execution_summary_remains_complete(self):
+        execution = self.summary["execution"]
+
+        self.assertEqual(execution["n_attempted"], 5)
+        self.assertEqual(execution["n_passed"], 5)
+        self.assertEqual(execution["n_failed"], 0)
+        self.assertEqual(
+            execution["models"],
+            [
+                "2DWavelengthDependent",
+                "2DDustMean",
+                "2DPowerLawMean",
+                "2DSeparable",
+                "2D",
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_docs_spectral_mixture_ard.py
+++ b/tests/test_docs_spectral_mixture_ard.py
@@ -46,15 +46,37 @@ class TestSpectralMixtureArdDocumentation(unittest.TestCase):
         self.assertIn("updates only ARD index 0", normalized)
         self.assertIn("wavelength-frequency bounds at ARD index 1 are preserved", normalized)
 
-    def test_future_work_records_diagnostics_completion_and_validation_scope(self):
-        text = (ROOT / "docs/source/future_work.rst").read_text()
-        normalized = " ".join(text.split())
-        self.assertIn("Completed wavelength-derived constraint tranche", normalized)
-        self.assertIn("Component- and dimension-specific fitted diagnostics", normalized)
-        self.assertIn("distance to each bound", normalized)
-        self.assertIn("num_mixtures=1", normalized)
-        self.assertNotIn("TBD[wavelength-derived-constraints]", text)
-        self.assertIn("TBD[wavelength-constraint-validation]", text)
+    def test_future_work_records_diagnostics_and_d3_completion(self):
+        future_work = (
+            Path(__file__).resolve().parents[1]
+            / "docs/source/future_work.rst"
+        ).read_text(encoding="utf-8")
+        normalized = " ".join(future_work.split())
+
+        self.assertNotIn(
+            "TBD[wavelength-constraint-validation]",
+            future_work,
+        )
+        self.assertIn(
+            "TBD[instrument-channel-calibration]",
+            future_work,
+        )
+        self.assertIn(
+            'Completed: representative wavelength-constraint validation',
+            normalized,
+        )
+        self.assertIn(
+            'temporal and wavelength ARD dimensions',
+            normalized,
+        )
+        self.assertIn(
+            'Component- and dimension-specific fitted diagnostics',
+            normalized,
+        )
+        self.assertIn(
+            '597.37 days',
+            normalized,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_docs_wavelength_conclusions.py
+++ b/tests/test_docs_wavelength_conclusions.py
@@ -19,22 +19,45 @@ class TestWavelengthConclusionDocumentation(unittest.TestCase):
         )
 
 
-    def test_future_work_tracks_constraint_and_validation_tranche(self):
-        future_work = " ".join(
-            (ROOT / "docs/source/future_work.rst").read_text().split()
+    def test_future_work_tracks_completed_constraint_validation_tranche(self):
+        future_work = (
+            Path(__file__).resolve().parents[1]
+            / "docs/source/future_work.rst"
+        ).read_text(encoding="utf-8")
+        normalized = " ".join(future_work.split())
+
+        self.assertNotIn(
+            "TBD[wavelength-constraint-validation]",
+            future_work,
         )
-        advisory = (ROOT / "docs/source/howto/wavelength_advisory.rst").read_text()
-        self.assertNotIn("TBD[wavelength-derived-constraints]", future_work)
-        self.assertNotIn("TBD[wavelength-derived-constraints]", advisory)
-        self.assertIn("Completed wavelength-derived constraint tranche", future_work)
-        self.assertIn("complete through PR125", advisory)
-        self.assertIn("TBD[wavelength-constraint-validation]", future_work)
-        self.assertIn("TBD[wavelength-constraint-validation]", advisory)
-        self.assertIn("2DWavelengthDependent", future_work)
-        self.assertIn("2DDustMean", future_work)
-        self.assertIn("2DPowerLawMean", future_work)
-        self.assertIn("2DSeparable", future_work)
-        self.assertIn("temporal and wavelength ARD dimensions", future_work)
+        self.assertIn(
+            "TBD[instrument-channel-calibration]",
+            future_work,
+        )
+        self.assertIn(
+            'Completed: representative wavelength-constraint validation',
+            normalized,
+        )
+        self.assertIn(
+            '2DWavelengthDependent',
+            normalized,
+        )
+        self.assertIn(
+            '2DDustMean',
+            normalized,
+        )
+        self.assertIn(
+            '2DPowerLawMean',
+            normalized,
+        )
+        self.assertIn(
+            '2DSeparable',
+            normalized,
+        )
+        self.assertIn(
+            'descriptive and advisory',
+            normalized,
+        )
 
     def test_advisory_docs_define_conclusions_and_ambiguities(self):
         advisory = (ROOT / "docs/source/howto/wavelength_advisory.rst").read_text()

--- a/tests/test_docs_wavelength_estimation.py
+++ b/tests/test_docs_wavelength_estimation.py
@@ -52,30 +52,28 @@ class TestWavelengthEstimationDocumentation(unittest.TestCase):
         self.assertIn("quasi-periodic", self.consensus_text)
 
     def test_future_work_records_mean_ard_and_d3_completion(self):
-        future_work = (
-            Path(__file__).resolve().parents[1]
-            / "docs/source/future_work.rst"
-        ).read_text(encoding="utf-8")
-        normalized = " ".join(future_work.split())
+        normalized = " ".join(self.future_work_text.split())
 
         self.assertNotIn(
             "TBD[wavelength-constraint-validation]",
-            future_work,
+            self.future_work_text,
         )
         self.assertIn(
             "TBD[instrument-channel-calibration]",
-            future_work,
+            self.future_work_text,
         )
         self.assertIn(
-            'Data-derived wavelength-mean initialization and enforceable constraints',
+            "Data-derived wavelength-mean initialization "
+            "and enforceable constraints",
             normalized,
         )
         self.assertIn(
-            'The full ``2D`` spectral-mixture baseline now gives temporal and wavelength ARD',
+            "The full ``2D`` spectral-mixture baseline now gives "
+            "temporal and wavelength ARD",
             normalized,
         )
         self.assertIn(
-            'Completed: representative wavelength-constraint validation',
+            "Completed: representative wavelength-constraint validation",
             normalized,
         )
 

--- a/tests/test_docs_wavelength_estimation.py
+++ b/tests/test_docs_wavelength_estimation.py
@@ -51,13 +51,33 @@ class TestWavelengthEstimationDocumentation(unittest.TestCase):
         )
         self.assertIn("quasi-periodic", self.consensus_text)
 
-    def test_future_work_records_mean_completion_and_retains_ard_validation(self):
-        self.assertIn(
-            "Data-derived wavelength-mean initialization",
-            self.future_work_text,
+    def test_future_work_records_mean_ard_and_d3_completion(self):
+        future_work = (
+            Path(__file__).resolve().parents[1]
+            / "docs/source/future_work.rst"
+        ).read_text(encoding="utf-8")
+        normalized = " ".join(future_work.split())
+
+        self.assertNotIn(
+            "TBD[wavelength-constraint-validation]",
+            future_work,
         )
-        self.assertIn("temporal and wavelength ARD", self.future_work_text)
-        self.assertIn("wavelength-constraint-validation", self.future_work_text)
+        self.assertIn(
+            "TBD[instrument-channel-calibration]",
+            future_work,
+        )
+        self.assertIn(
+            'Data-derived wavelength-mean initialization and enforceable constraints',
+            normalized,
+        )
+        self.assertIn(
+            'The full ``2D`` spectral-mixture baseline now gives temporal and wavelength ARD',
+            normalized,
+        )
+        self.assertIn(
+            'Completed: representative wavelength-constraint validation',
+            normalized,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_docs_wavelength_mean_estimates.py
+++ b/tests/test_docs_wavelength_mean_estimates.py
@@ -57,31 +57,26 @@ class TestWavelengthMeanEstimateDocumentation(unittest.TestCase):
         self.assertIn("optimization", self.constraints_normalized)
 
     def test_full_2d_ard_and_representative_validation_are_completed(self):
-        future_work = (
-            Path(__file__).resolve().parents[1]
-            / "docs/source/future_work.rst"
-        ).read_text(encoding="utf-8")
-        normalized = " ".join(future_work.split())
-
         self.assertNotIn(
             "TBD[wavelength-constraint-validation]",
-            future_work,
+            self.future,
         )
         self.assertIn(
             "TBD[instrument-channel-calibration]",
-            future_work,
+            self.future,
         )
         self.assertIn(
-            'The full ``2D`` spectral-mixture baseline now gives temporal and wavelength ARD',
-            normalized,
+            "The full ``2D`` spectral-mixture baseline now gives "
+            "temporal and wavelength ARD",
+            self.future_normalized,
         )
         self.assertIn(
-            'Completed: representative wavelength-constraint validation',
-            normalized,
+            "Completed: representative wavelength-constraint validation",
+            self.future_normalized,
         )
         self.assertIn(
-            '789 of the 10,815 public',
-            normalized,
+            "789 of the 10,815 public",
+            self.future_normalized,
         )
 
 

--- a/tests/test_docs_wavelength_mean_estimates.py
+++ b/tests/test_docs_wavelength_mean_estimates.py
@@ -56,11 +56,33 @@ class TestWavelengthMeanEstimateDocumentation(unittest.TestCase):
         self.assertIn("enforced during", self.constraints_normalized)
         self.assertIn("optimization", self.constraints_normalized)
 
-    def test_full_2d_ard_and_validation_remain_future_work(self):
-        self.assertIn("Data-derived wavelength-mean initialization", self.future_normalized)
-        self.assertIn("full ``2D``", self.future_normalized)
-        self.assertIn("temporal and wavelength ARD dimensions", self.future_normalized)
-        self.assertIn("TBD[wavelength-constraint-validation]", self.future_normalized)
+    def test_full_2d_ard_and_representative_validation_are_completed(self):
+        future_work = (
+            Path(__file__).resolve().parents[1]
+            / "docs/source/future_work.rst"
+        ).read_text(encoding="utf-8")
+        normalized = " ".join(future_work.split())
+
+        self.assertNotIn(
+            "TBD[wavelength-constraint-validation]",
+            future_work,
+        )
+        self.assertIn(
+            "TBD[instrument-channel-calibration]",
+            future_work,
+        )
+        self.assertIn(
+            'The full ``2D`` spectral-mixture baseline now gives temporal and wavelength ARD',
+            normalized,
+        )
+        self.assertIn(
+            'Completed: representative wavelength-constraint validation',
+            normalized,
+        )
+        self.assertIn(
+            '789 of the 10,815 public',
+            normalized,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_docs_wavelength_validation_real_lpv.py
+++ b/tests/test_docs_wavelength_validation_real_lpv.py
@@ -209,19 +209,35 @@ class TestRepresentativeLPVHowToGuide(unittest.TestCase):
 
 
 class TestRepresentativeLPVFutureWorkStatus(unittest.TestCase):
-    def test_future_work_no_longer_calls_d3_the_next_unimplemented_step(self):
-        normalized = _normalized(DOCS / "future_work.rst")
+    def test_future_work_records_completed_d3_execution(self):
+        future_work = (
+            Path(__file__).resolve().parents[1]
+            / "docs/source/future_work.rst"
+        ).read_text(encoding="utf-8")
+        normalized = " ".join(future_work.split())
 
         self.assertNotIn(
-            "The next validation step is D3 application",
-            normalized,
-        )
-        self.assertIn(
-            "D3 representative observed-LPV validation infrastructure",
-            normalized,
+            "TBD[wavelength-constraint-validation]",
+            future_work,
         )
         self.assertIn(
             "TBD[instrument-channel-calibration]",
+            future_work,
+        )
+        self.assertIn(
+            'Completed: representative wavelength-constraint validation',
+            normalized,
+        )
+        self.assertIn(
+            'All five maintained LPV-relevant candidates completed',
+            normalized,
+        )
+        self.assertIn(
+            '597.37 days',
+            normalized,
+        )
+        self.assertIn(
+            'examples/validation/d3_representative_lpv_calibration_summary.json',
             normalized,
         )
 

--- a/tests/test_docs_wavelength_validation_real_lpv.py
+++ b/tests/test_docs_wavelength_validation_real_lpv.py
@@ -211,10 +211,9 @@ class TestRepresentativeLPVHowToGuide(unittest.TestCase):
 class TestRepresentativeLPVFutureWorkStatus(unittest.TestCase):
     def test_future_work_records_completed_d3_execution(self):
         future_work = (
-            Path(__file__).resolve().parents[1]
-            / "docs/source/future_work.rst"
+            DOCS / "future_work.rst"
         ).read_text(encoding="utf-8")
-        normalized = " ".join(future_work.split())
+        normalized = _normalized(DOCS / "future_work.rst")
 
         self.assertNotIn(
             "TBD[wavelength-constraint-validation]",
@@ -225,19 +224,20 @@ class TestRepresentativeLPVFutureWorkStatus(unittest.TestCase):
             future_work,
         )
         self.assertIn(
-            'Completed: representative wavelength-constraint validation',
+            "Completed: representative wavelength-constraint validation",
             normalized,
         )
         self.assertIn(
-            'All five maintained LPV-relevant candidates completed',
+            "All five maintained LPV-relevant candidates completed",
             normalized,
         )
         self.assertIn(
-            '597.37 days',
+            "597.37 days",
             normalized,
         )
         self.assertIn(
-            'examples/validation/d3_representative_lpv_calibration_summary.json',
+            "examples/validation/"
+            "d3_representative_lpv_calibration_summary.json",
             normalized,
         )
 

--- a/tests/test_docs_wavelength_validation_robustness.py
+++ b/tests/test_docs_wavelength_validation_robustness.py
@@ -30,16 +30,33 @@ class TestSyntheticWavelengthRobustnessDocumentation(unittest.TestCase):
         package_init = (ROOT / "pgmuvi/__init__.py").read_text(encoding="utf-8")
         self.assertIn('"wavelength_validation_robustness"', package_init)
 
-    def test_future_work_tracks_d3_after_d2_and_notebook_completion(self):
-        future = (ROOT / "docs/source/future_work.rst").read_text(
-            encoding="utf-8"
-        )
-        normalized = " ".join(future.split())
+    def test_future_work_records_d3_completion_after_d2(self):
+        future_work = (
+            Path(__file__).resolve().parents[1]
+            / "docs/source/future_work.rst"
+        ).read_text(encoding="utf-8")
+        normalized = " ".join(future_work.split())
 
-        self.assertIn("canonical 20-seed D2 robustness calibration", normalized)
-        self.assertIn("maintained wavelength-constraint notebook are complete", normalized)
-        self.assertIn("D3 representative observed-LPV validation infrastructure", normalized)
-        self.assertNotIn("Execute and document the full D2 population", future)
+        self.assertNotIn(
+            "TBD[wavelength-constraint-validation]",
+            future_work,
+        )
+        self.assertIn(
+            "TBD[instrument-channel-calibration]",
+            future_work,
+        )
+        self.assertIn(
+            'Completed: representative wavelength-constraint validation',
+            normalized,
+        )
+        self.assertIn(
+            'D3 representative observed-LPV validation',
+            normalized,
+        )
+        self.assertIn(
+            'structured failure semantics',
+            normalized,
+        )
 
     def test_notebook_status_tracks_constraint_walkthrough(self):
         status = (ROOT / "docs/source/notebook_status.rst").read_text(

--- a/tests/test_docs_wavelength_validation_robustness_calibration.py
+++ b/tests/test_docs_wavelength_validation_robustness_calibration.py
@@ -43,22 +43,33 @@ class TestSyntheticWavelengthRobustnessCalibrationDocumentation(
             '"wavelength_validation_robustness_calibration"', package_init
         )
 
-    def test_constraint_notebook_is_completed_after_empirical_calibration(self):
-        future = (ROOT / "docs/source/future_work.rst").read_text(
-            encoding="utf-8"
-        )
-        status = (ROOT / "docs/source/notebook_status.rst").read_text(
-            encoding="utf-8"
-        )
+    def test_constraint_notebook_and_d3_validation_are_completed(self):
+        future_work = (
+            Path(__file__).resolve().parents[1]
+            / "docs/source/future_work.rst"
+        ).read_text(encoding="utf-8")
+        normalized = " ".join(future_work.split())
 
-        self.assertIn("TBD[wavelength-constraint-validation]", future)
-        self.assertNotIn("TBD[wavelength-constraint-notebook]", status)
-        self.assertIn("tutorial_wavelength_constraints.ipynb", status)
-        normalized = " ".join(future.split())
-        self.assertIn("canonical 20-seed D2 robustness calibration", normalized)
-        self.assertIn("maintained wavelength-constraint notebook are complete", normalized)
-        self.assertIn("D3 representative observed-LPV validation infrastructure", normalized)
-        self.assertNotIn("Execute and document the full D2 population", future)
+        self.assertNotIn(
+            "TBD[wavelength-constraint-validation]",
+            future_work,
+        )
+        self.assertIn(
+            "TBD[instrument-channel-calibration]",
+            future_work,
+        )
+        self.assertIn(
+            'Completed wavelength-constraint notebook (PR134)',
+            normalized,
+        )
+        self.assertIn(
+            'Completed: representative wavelength-constraint validation',
+            normalized,
+        )
+        self.assertIn(
+            '597.37 days',
+            normalized,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- consolidate the completed D3 representative observed-LPV validation in the maintained documentation
- record the bounded public-source execution, five-model candidate set, consensus-period evidence, warning state, residual-wavelength evidence, and interpretation limits
- update stale documentation contracts that previously required D3 validation to remain future work
- close `TBD[wavelength-constraint-validation]`
- retain `TBD[instrument-channel-calibration]` as separate future work

## Consolidated execution result

The representative workflow used a deterministic bounded sample of the public `10131+3049` light curve:

- 789 of 10,815 observations retained
- all 17 observational channels retained
- all 16 distinct physical wavelengths retained
- maximum 1,000 observations overall
- maximum 100 observations per observational channel

All maintained LPV-relevant candidates completed:

1. `2DWavelengthDependent`
2. `2DDustMean`
3. `2DPowerLawMean`
4. `2DSeparable`
5. `2D`

The four separable candidates used consensus fitting with a quasi-periodic time kernel. The structurally different `2D` baseline retained its model-default spectral-mixture time kernel.

All five fits returned a consensus period of approximately 597.37 days. Each completed with a GPyTorch small-noise `NumericalWarning`; no fit attempt failed.

## Scientific boundaries

- the residual ranking is descriptive transformed-training-space evidence
- no held-out predictive comparison was performed
- no automatic model selection was applied
- `selected_model` remains unset
- the execution covers one sampled representative observed LPV
- it does not establish truth recovery, population-level performance, uniqueness, or full-data computational feasibility
- observational channels sharing a physical wavelength remain aggregated
- instrument-specific channel calibration remains unimplemented

## Marker status

This PR closes:

- `TBD[wavelength-constraint-validation]`

This PR intentionally leaves open:

- `TBD[instrument-channel-calibration]`

## Validation

- `ruff check -v --output-format=full --show-fixes ./pgmuvi`
- `make -C docs clean && make -C docs html-strict`
- `PYTHONPATH=. python3 -m unittest discover -s tests -p "test*.py" -v`
- `python3 scripts/audit_docs_tbd_markers.py`
