### PR TITLE
Define instrument-channel calibration contract

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -59,6 +59,7 @@ Data, diagnostics, and validation
    pgmuvi.multiband_ls_significance
    pgmuvi.wavelength_conclusions
    pgmuvi.wavelength_diagnostics
+   pgmuvi.instrument_channel_calibration
    pgmuvi.wavelength_estimation
    pgmuvi.spectral_mixture_ard
    pgmuvi.spectral_mixture_ard_diagnostics

--- a/docs/source/future_work.rst
+++ b/docs/source/future_work.rst
@@ -121,6 +121,12 @@ Wavelength-model extensions
     public calibration API introduced before implementation must raise
     ``NotImplementedError`` rather than silently approximating a correction.
 
+    The public contract and requirement-assessment primitives now live in
+    :mod:`pgmuvi.instrument_channel_calibration`.  They report shared-wavelength
+    channel groups and preserve the current uncalibrated policy.  The fit and
+    application callables deliberately raise ``NotImplementedError``; this does
+    not close the marker or constitute a calibration implementation.
+
 **TBD[multi-periodic-wavelength-models]**
     Add a documented and validated multi-periodic workflow beyond the current
     limited multi-component diagnostics and consensus infrastructure.

--- a/docs/source/howto/multiband.rst
+++ b/docs/source/howto/multiband.rst
@@ -118,7 +118,9 @@ using the existing compatibility method::
    calibration corrections when multiple observational channels share one
    physical wavelength.  Preserve the separate channel labels.  No silent
    calibration or wavelength reassignment is performed; an explicit calibration
-   model is future work.
+   model is future work.  The public fit and apply callables in
+   :mod:`pgmuvi.instrument_channel_calibration` raise ``NotImplementedError``
+   until that model exists.
 
 Visualising 2D Results
 -----------------------

--- a/docs/source/pgmuvi.instrument_channel_calibration.rst
+++ b/docs/source/pgmuvi.instrument_channel_calibration.rst
@@ -1,0 +1,29 @@
+Instrument-channel calibration contract
+=======================================
+
+.. automodule:: pgmuvi.instrument_channel_calibration
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+``TBD[instrument-channel-calibration]`` remains open
+----------------------------------------------------
+
+This module does **not** implement an instrumental calibration model.  It
+provides a deterministic assessment of whether multiple observational channels
+share one physical wavelength and therefore require a future calibration
+model.
+
+The assessment preserves observational-channel identities, reports the shared
+physical-wavelength groups, records that no correction was applied, and is
+JSON-safe.  It does not inspect flux differences as evidence for an offset or
+scale and does not alter wavelengths or fluxes.
+
+The public callables
+:func:`~pgmuvi.instrument_channel_calibration.fit_instrument_channel_calibration`
+and
+:func:`~pgmuvi.instrument_channel_calibration.apply_instrument_channel_calibration`
+raise :class:`NotImplementedError`.  This explicit failure is part of the
+contract: PGMUVI must not silently infer, approximate, or apply an
+instrument-channel correction before a scientifically validated implementation
+exists.

--- a/docs/source/pgmuvi.wavelength_estimation.rst
+++ b/docs/source/pgmuvi.wavelength_estimation.rst
@@ -22,7 +22,10 @@ performed.  When two or more usable observational channels share a physical
 wavelength, PGMUVI preserves their channel-level diagnostics but excludes that
 uncalibrated wavelength from cross-wavelength trend summaries and
 wavelength-mean fits.  It does not silently combine flux summaries, infer
-offsets or scales, or assign artificial wavelength differences.
+offsets or scales, or assign artificial wavelength differences.  The
+metadata includes the JSON-safe requirement assessment from
+:mod:`pgmuvi.instrument_channel_calibration`; no calibration is fitted or
+applied.
 
 The diagnostics retain the length-scale recommendation in the **raw
 wavelength coordinate** and also record the corresponding value and interval in

--- a/pgmuvi/__init__.py
+++ b/pgmuvi/__init__.py
@@ -17,6 +17,7 @@ __all__ = [
     "constraints",
     "gps",
     "initialization",
+    "instrument_channel_calibration",
     "lightcurve",
     "priors",
     "spectral_mixture_ard",

--- a/pgmuvi/instrument_channel_calibration.py
+++ b/pgmuvi/instrument_channel_calibration.py
@@ -1,0 +1,312 @@
+"""Contracts for future observational-channel calibration.
+
+An observational channel identifies an instrument, detector, filter, or data
+stream.  It is distinct from the numeric physical wavelength coordinate used by
+the GP, and multiple observational channels may share one physical wavelength.
+
+PGMUVI does not yet estimate or apply channel-specific offsets, scales,
+throughput corrections, or noise corrections.  This module provides an
+immutable, JSON-safe assessment of whether such calibration is required and
+public placeholder callables that fail explicitly rather than silently
+approximating a correction.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+import math
+from typing import Any, NoReturn
+
+import numpy as np
+
+
+INSTRUMENT_CHANNEL_CALIBRATION_SCHEMA_VERSION = (
+    "pgmuvi-instrument-channel-calibration-v1"
+)
+INSTRUMENT_CHANNEL_CALIBRATION_TBD_MARKER = (
+    "TBD[instrument-channel-calibration]"
+)
+
+
+__all__ = [
+    "INSTRUMENT_CHANNEL_CALIBRATION_SCHEMA_VERSION",
+    "INSTRUMENT_CHANNEL_CALIBRATION_TBD_MARKER",
+    "InstrumentChannelCalibrationAssessment",
+    "InstrumentChannelCalibrationStatus",
+    "SharedWavelengthChannelGroup",
+    "apply_instrument_channel_calibration",
+    "assess_instrument_channel_calibration_requirement",
+    "fit_instrument_channel_calibration",
+]
+
+
+class _StringEnum(str, Enum):
+    """Enum whose members serialize as stable public strings."""
+
+    def __str__(self) -> str:
+        return self.value
+
+
+class InstrumentChannelCalibrationStatus(_StringEnum):
+    """Implementation state for an observational-channel calibration need."""
+
+    NOT_REQUIRED = "not_required"
+    REQUIRED_NOT_IMPLEMENTED = "required_not_implemented"
+
+
+@dataclass(frozen=True)
+class SharedWavelengthChannelGroup:
+    """Observational channels attached to one physical wavelength."""
+
+    physical_wavelength: float
+    observational_channels: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        wavelength = float(self.physical_wavelength)
+        if not math.isfinite(wavelength):
+            raise ValueError("physical_wavelength must be finite.")
+
+        channels = tuple(
+            sorted(
+                {
+                    str(channel).strip()
+                    for channel in self.observational_channels
+                    if str(channel).strip()
+                }
+            )
+        )
+        if len(channels) < 2:
+            raise ValueError(
+                "A shared-wavelength group requires at least two distinct "
+                "observational channels."
+            )
+
+        object.__setattr__(self, "physical_wavelength", wavelength)
+        object.__setattr__(self, "observational_channels", channels)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a stable JSON-safe representation."""
+
+        return {
+            "physical_wavelength": self.physical_wavelength,
+            "observational_channels": list(self.observational_channels),
+        }
+
+
+@dataclass(frozen=True)
+class InstrumentChannelCalibrationAssessment:
+    """Whether channel calibration is required for the supplied structure."""
+
+    status: InstrumentChannelCalibrationStatus
+    required: bool
+    shared_wavelength_groups: tuple[SharedWavelengthChannelGroup, ...] = ()
+    schema_version: str = INSTRUMENT_CHANNEL_CALIBRATION_SCHEMA_VERSION
+    implemented: bool = False
+    calibration_applied: bool = False
+    silent_calibration_permitted: bool = False
+    policy: str = "not_applicable"
+    marker: str = INSTRUMENT_CHANNEL_CALIBRATION_TBD_MARKER
+
+    def __post_init__(self) -> None:
+        status = self.status
+        if not isinstance(status, InstrumentChannelCalibrationStatus):
+            try:
+                status = InstrumentChannelCalibrationStatus(str(status))
+            except ValueError as exc:
+                raise ValueError(
+                    f"Unsupported calibration status {self.status!r}."
+                ) from exc
+
+        groups = tuple(self.shared_wavelength_groups)
+        required = bool(self.required)
+        expected_required = bool(groups)
+        if required != expected_required:
+            raise ValueError(
+                "required must agree with the presence of shared-wavelength "
+                "channel groups."
+            )
+
+        expected_status = (
+            InstrumentChannelCalibrationStatus.REQUIRED_NOT_IMPLEMENTED
+            if required
+            else InstrumentChannelCalibrationStatus.NOT_REQUIRED
+        )
+        if status is not expected_status:
+            raise ValueError(
+                "status must agree with the shared-wavelength requirement."
+            )
+
+        if self.implemented or self.calibration_applied:
+            raise ValueError(
+                "Instrument-channel calibration is not implemented."
+            )
+        if self.silent_calibration_permitted:
+            raise ValueError("Silent calibration is never permitted.")
+
+        expected_policy = (
+            "preserve_channels_without_calibration"
+            if required
+            else "not_applicable"
+        )
+        if self.policy != expected_policy:
+            raise ValueError(
+                "policy must describe the maintained uncalibrated behavior."
+            )
+
+        object.__setattr__(self, "status", status)
+        object.__setattr__(self, "required", required)
+        object.__setattr__(self, "shared_wavelength_groups", groups)
+
+    @property
+    def shared_wavelength_channels(
+        self,
+    ) -> dict[float, tuple[str, ...]]:
+        """Return channels keyed by their shared physical wavelength."""
+
+        return {
+            group.physical_wavelength: group.observational_channels
+            for group in self.shared_wavelength_groups
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a stable JSON-safe representation."""
+
+        return {
+            "schema_version": self.schema_version,
+            "status": self.status.value,
+            "required": self.required,
+            "implemented": self.implemented,
+            "calibration_applied": self.calibration_applied,
+            "silent_calibration_permitted": (
+                self.silent_calibration_permitted
+            ),
+            "policy": self.policy,
+            "marker": self.marker,
+            "n_shared_physical_wavelengths": len(
+                self.shared_wavelength_groups
+            ),
+            "shared_wavelength_groups": [
+                group.to_dict()
+                for group in self.shared_wavelength_groups
+            ],
+        }
+
+
+def assess_instrument_channel_calibration_requirement(
+    physical_wavelengths: Any,
+    observational_channel_labels: Any,
+) -> InstrumentChannelCalibrationAssessment:
+    """Describe whether shared wavelengths require channel calibration.
+
+    The function only inspects channel-to-wavelength structure.  It does not
+    estimate, infer, fit, or apply a calibration correction.
+    """
+
+    wavelengths = np.asarray(physical_wavelengths, dtype=float)
+    channels = np.asarray(observational_channel_labels, dtype=str)
+
+    if wavelengths.ndim != 1:
+        raise ValueError("physical_wavelengths must be one-dimensional.")
+    if channels.ndim != 1:
+        raise ValueError(
+            "observational_channel_labels must be one-dimensional."
+        )
+    if wavelengths.size != channels.size:
+        raise ValueError(
+            "physical_wavelengths and observational_channel_labels must "
+            "have the same length."
+        )
+
+    channel_wavelengths: dict[str, float] = {}
+    for wavelength_value, channel_value in zip(
+        wavelengths,
+        channels,
+        strict=True,
+    ):
+        wavelength = float(wavelength_value)
+        channel = str(channel_value).strip()
+
+        if not math.isfinite(wavelength):
+            raise ValueError("Physical wavelength coordinates must be finite.")
+        if not channel:
+            raise ValueError(
+                "Observational-channel labels must be non-empty."
+            )
+
+        previous = channel_wavelengths.get(channel)
+        if previous is not None and previous != wavelength:
+            raise ValueError(
+                "Each observational channel must map to exactly one physical "
+                f"wavelength; {channel!r} maps to both {previous!r} and "
+                f"{wavelength!r}."
+            )
+        channel_wavelengths[channel] = wavelength
+
+    channels_by_wavelength: dict[float, list[str]] = {}
+    for channel, wavelength in channel_wavelengths.items():
+        channels_by_wavelength.setdefault(wavelength, []).append(channel)
+
+    groups = tuple(
+        SharedWavelengthChannelGroup(
+            physical_wavelength=wavelength,
+            observational_channels=tuple(attached_channels),
+        )
+        for wavelength, attached_channels in sorted(
+            channels_by_wavelength.items()
+        )
+        if len(attached_channels) > 1
+    )
+    required = bool(groups)
+
+    return InstrumentChannelCalibrationAssessment(
+        status=(
+            InstrumentChannelCalibrationStatus.REQUIRED_NOT_IMPLEMENTED
+            if required
+            else InstrumentChannelCalibrationStatus.NOT_REQUIRED
+        ),
+        required=required,
+        shared_wavelength_groups=groups,
+        policy=(
+            "preserve_channels_without_calibration"
+            if required
+            else "not_applicable"
+        ),
+    )
+
+
+def _raise_calibration_not_implemented(action: str) -> NoReturn:
+    raise NotImplementedError(
+        f"Instrument-channel calibration {action} is not implemented. "
+        f"{INSTRUMENT_CHANNEL_CALIBRATION_TBD_MARKER} requires an explicit, "
+        "tested model; PGMUVI will not silently infer or apply a correction."
+    )
+
+
+def fit_instrument_channel_calibration(
+    physical_wavelengths: Any,
+    fluxes: Any,
+    observational_channel_labels: Any,
+    uncertainties: Any | None = None,
+) -> NoReturn:
+    """Fit a channel calibration model.
+
+    This callable defines the public failure contract only.  No calibration
+    model is currently implemented.
+    """
+
+    _raise_calibration_not_implemented("fitting")
+
+
+def apply_instrument_channel_calibration(
+    fluxes: Any,
+    observational_channel_labels: Any,
+    calibration: Any,
+) -> NoReturn:
+    """Apply a fitted channel calibration model.
+
+    This callable defines the public failure contract only.  No calibration
+    model is currently implemented.
+    """
+
+    _raise_calibration_not_implemented("application")

--- a/pgmuvi/wavelength_estimation.py
+++ b/pgmuvi/wavelength_estimation.py
@@ -16,6 +16,10 @@ from typing import Any
 
 import numpy as np
 
+from .instrument_channel_calibration import (
+    assess_instrument_channel_calibration_requirement,
+)
+
 from pgmuvi.parameter_context import (
     BandDiagnostics,
     WAVELENGTH_ESTIMATION_SCHEMA_VERSION,
@@ -437,15 +441,15 @@ def build_wavelength_estimation_context(
         else None
     )
 
-    channels_by_wavelength: dict[float, list[str]] = {}
-    for item in usable:
-        wavelength = float(item.wavelength)
-        channels_by_wavelength.setdefault(wavelength, []).append(item.band)
-    shared_wavelength_channels = {
-        wavelength: tuple(channels)
-        for wavelength, channels in channels_by_wavelength.items()
-        if len(channels) > 1
-    }
+    calibration_assessment = (
+        assess_instrument_channel_calibration_requirement(
+            [float(item.wavelength) for item in usable],
+            [item.band for item in usable],
+        )
+    )
+    shared_wavelength_channels = (
+        calibration_assessment.shared_wavelength_channels
+    )
     shared_wavelengths = set(shared_wavelength_channels)
 
     # TBD[instrument-channel-calibration]: An explicit calibration model is
@@ -548,6 +552,9 @@ def build_wavelength_estimation_context(
                 else "not_required"
             ),
             "instrument_calibration_tbd": bool(shared_wavelength_channels),
+            "instrument_channel_calibration": (
+                calibration_assessment.to_dict()
+            ),
             "shared_wavelength_trend_policy": (
                 "exclude_uncalibrated_shared_wavelengths"
                 if shared_wavelength_channels
@@ -644,11 +651,16 @@ def _wavelength_mean_observational_channel_points(
     channels_by_wavelength: dict[float, list[str]] = {}
     for raw_value, _, _, label in rows:
         channels_by_wavelength.setdefault(raw_value, []).append(label)
-    shared_wavelength_channels = {
-        wavelength: tuple(channels)
-        for wavelength, channels in channels_by_wavelength.items()
-        if len(channels) > 1
-    }
+
+    calibration_assessment = (
+        assess_instrument_channel_calibration_requirement(
+            [item[0] for item in rows],
+            [item[3] for item in rows],
+        )
+    )
+    shared_wavelength_channels = (
+        calibration_assessment.shared_wavelength_channels
+    )
     shared_wavelengths = set(shared_wavelength_channels)
 
     # TBD[instrument-channel-calibration]: Separate observational channels at
@@ -681,6 +693,9 @@ def _wavelength_mean_observational_channel_points(
             else "not_required"
         ),
         "instrument_calibration_tbd": bool(shared_wavelength_channels),
+        "instrument_channel_calibration": (
+            calibration_assessment.to_dict()
+        ),
         "shared_wavelength_mean_policy": (
             "exclude_uncalibrated_shared_wavelengths"
             if shared_wavelength_channels

--- a/pgmuvi/wavelength_validation_real_lpv.py
+++ b/pgmuvi/wavelength_validation_real_lpv.py
@@ -22,6 +22,7 @@ from typing import Any
 import numpy as np
 
 from .instrument_channel_calibration import (
+    INSTRUMENT_CHANNEL_CALIBRATION_TBD_MARKER,
     assess_instrument_channel_calibration_requirement,
 )
 
@@ -296,7 +297,7 @@ def build_representative_lpv_source_summary(
                 calibration_assessment.required
             ),
             "instrument_calibration_marker": (
-                "TBD[instrument-channel-calibration]"
+                INSTRUMENT_CHANNEL_CALIBRATION_TBD_MARKER
             ),
             "instrument_channel_calibration": (
                 calibration_assessment.to_dict()

--- a/pgmuvi/wavelength_validation_real_lpv.py
+++ b/pgmuvi/wavelength_validation_real_lpv.py
@@ -21,6 +21,10 @@ from typing import Any
 
 import numpy as np
 
+from .instrument_channel_calibration import (
+    assess_instrument_channel_calibration_requirement,
+)
+
 from .wavelength_validation import (
     WavelengthValidationPhase,
     WavelengthValidationScenario,
@@ -243,7 +247,6 @@ def build_representative_lpv_source_summary(
     unique_wavelengths = np.unique(wavelengths)
 
     channels_by_wavelength: dict[str, list[str]] = {}
-    shared: dict[str, list[str]] = {}
     for wavelength in unique_wavelengths:
         mask = wavelengths == wavelength
         attached_channels = sorted(
@@ -251,8 +254,19 @@ def build_representative_lpv_source_summary(
         )
         key = format(float(wavelength), ".17g")
         channels_by_wavelength[key] = attached_channels
-        if len(attached_channels) > 1:
-            shared[key] = attached_channels
+
+    calibration_assessment = (
+        assess_instrument_channel_calibration_requirement(
+            wavelengths,
+            channels,
+        )
+    )
+    shared = {
+        format(wavelength, ".17g"): list(attached_channels)
+        for wavelength, attached_channels in (
+            calibration_assessment.shared_wavelength_channels.items()
+        )
+    }
 
     return _json_safe(
         {
@@ -273,14 +287,21 @@ def build_representative_lpv_source_summary(
                 shared
             ),
             "observational_channels_by_shared_wavelength": shared,
-            "instrument_calibration_status": "not_implemented",
-            "instrument_calibration_tbd": True,
+            "instrument_calibration_status": (
+                "not_implemented"
+                if calibration_assessment.required
+                else "not_required"
+            ),
+            "instrument_calibration_tbd": (
+                calibration_assessment.required
+            ),
             "instrument_calibration_marker": (
                 "TBD[instrument-channel-calibration]"
             ),
-            "shared_wavelength_policy": (
-                "preserve_channels_without_calibration"
+            "instrument_channel_calibration": (
+                calibration_assessment.to_dict()
             ),
+            "shared_wavelength_policy": calibration_assessment.policy,
             "linear_flux": True,
         }
     )

--- a/tests/test_docs_instrument_channel_calibration.py
+++ b/tests/test_docs_instrument_channel_calibration.py
@@ -1,0 +1,74 @@
+"""Documentation contracts for instrument-channel calibration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import unittest
+
+import pgmuvi
+
+
+DOCS = Path("docs/source")
+API = DOCS / "api.rst"
+PAGE = DOCS / "pgmuvi.instrument_channel_calibration.rst"
+FUTURE = DOCS / "future_work.rst"
+ESTIMATION = DOCS / "pgmuvi.wavelength_estimation.rst"
+MULTIBAND = DOCS / "howto/multiband.rst"
+
+
+class TestInstrumentChannelCalibrationDocumentation(unittest.TestCase):
+    def test_module_is_public_and_has_an_api_page(self):
+        self.assertIn(
+            "instrument_channel_calibration",
+            pgmuvi.__all__,
+        )
+        self.assertTrue(PAGE.exists())
+
+        api_text = API.read_text(encoding="utf-8")
+        page_text = PAGE.read_text(encoding="utf-8")
+
+        self.assertIn(
+            "pgmuvi.instrument_channel_calibration",
+            api_text,
+        )
+        self.assertIn(
+            ".. automodule:: pgmuvi.instrument_channel_calibration",
+            page_text,
+        )
+
+    def test_page_documents_explicit_unsupported_callables(self):
+        text = " ".join(PAGE.read_text(encoding="utf-8").split())
+
+        self.assertIn("TBD[instrument-channel-calibration]", text)
+        self.assertIn("fit_instrument_channel_calibration", text)
+        self.assertIn("apply_instrument_channel_calibration", text)
+        self.assertIn("NotImplementedError", text)
+        self.assertIn("must not silently infer", text)
+
+    def test_future_work_marker_remains_open(self):
+        text = " ".join(FUTURE.read_text(encoding="utf-8").split())
+
+        self.assertIn("TBD[instrument-channel-calibration]", text)
+        self.assertIn(
+            "does not close the marker or constitute a calibration "
+            "implementation",
+            text,
+        )
+
+    def test_estimation_and_multiband_guides_reference_contract(self):
+        estimation = ESTIMATION.read_text(encoding="utf-8")
+        multiband = MULTIBAND.read_text(encoding="utf-8")
+
+        self.assertIn(
+            "pgmuvi.instrument_channel_calibration",
+            estimation,
+        )
+        self.assertIn(
+            "pgmuvi.instrument_channel_calibration",
+            multiband,
+        )
+        self.assertIn("NotImplementedError", multiband)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_instrument_channel_calibration_contract.py
+++ b/tests/test_instrument_channel_calibration_contract.py
@@ -1,0 +1,155 @@
+"""Contracts for future observational-channel calibration."""
+
+from __future__ import annotations
+
+import json
+import unittest
+
+import numpy as np
+
+from pgmuvi.instrument_channel_calibration import (
+    INSTRUMENT_CHANNEL_CALIBRATION_SCHEMA_VERSION,
+    INSTRUMENT_CHANNEL_CALIBRATION_TBD_MARKER,
+    InstrumentChannelCalibrationStatus,
+    apply_instrument_channel_calibration,
+    assess_instrument_channel_calibration_requirement,
+    fit_instrument_channel_calibration,
+)
+
+
+class TestInstrumentChannelCalibrationAssessment(unittest.TestCase):
+    def test_unique_wavelengths_do_not_require_calibration(self):
+        assessment = assess_instrument_channel_calibration_requirement(
+            np.asarray([0.5, 1.0, 2.0]),
+            np.asarray(["r", "J", "K"]),
+        )
+
+        self.assertFalse(assessment.required)
+        self.assertEqual(
+            assessment.status,
+            InstrumentChannelCalibrationStatus.NOT_REQUIRED,
+        )
+        self.assertEqual(assessment.shared_wavelength_groups, ())
+        self.assertEqual(assessment.policy, "not_applicable")
+        self.assertFalse(assessment.implemented)
+        self.assertFalse(assessment.calibration_applied)
+
+    def test_shared_wavelength_groups_are_deterministic_and_json_safe(self):
+        assessment = assess_instrument_channel_calibration_requirement(
+            np.asarray([0.65, 0.65, 0.65, 2.2]),
+            np.asarray(
+                [
+                    "instrument-b",
+                    "instrument-a",
+                    "instrument-b",
+                    "channel-k",
+                ]
+            ),
+        )
+
+        self.assertTrue(assessment.required)
+        self.assertEqual(
+            assessment.status,
+            InstrumentChannelCalibrationStatus.REQUIRED_NOT_IMPLEMENTED,
+        )
+        self.assertEqual(
+            assessment.shared_wavelength_channels,
+            {0.65: ("instrument-a", "instrument-b")},
+        )
+
+        payload = assessment.to_dict()
+        self.assertEqual(
+            payload["schema_version"],
+            INSTRUMENT_CHANNEL_CALIBRATION_SCHEMA_VERSION,
+        )
+        self.assertEqual(payload["status"], "required_not_implemented")
+        self.assertTrue(payload["required"])
+        self.assertFalse(payload["implemented"])
+        self.assertFalse(payload["calibration_applied"])
+        self.assertFalse(payload["silent_calibration_permitted"])
+        self.assertEqual(
+            payload["marker"],
+            INSTRUMENT_CHANNEL_CALIBRATION_TBD_MARKER,
+        )
+        self.assertEqual(
+            payload["policy"],
+            "preserve_channels_without_calibration",
+        )
+        json.dumps(payload, allow_nan=False)
+
+    def test_repeated_rows_from_one_channel_are_not_a_shared_group(self):
+        assessment = assess_instrument_channel_calibration_requirement(
+            [1.0, 1.0, 1.0],
+            ["channel-a", "channel-a", "channel-a"],
+        )
+
+        self.assertFalse(assessment.required)
+
+    def test_mismatched_row_counts_are_rejected(self):
+        with self.assertRaisesRegex(ValueError, "same length"):
+            assess_instrument_channel_calibration_requirement(
+                [1.0, 2.0],
+                ["channel-a"],
+            )
+
+    def test_nonfinite_wavelengths_are_rejected(self):
+        for wavelength in (np.nan, np.inf, -np.inf):
+            with self.subTest(wavelength=wavelength):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "coordinates must be finite",
+                ):
+                    assess_instrument_channel_calibration_requirement(
+                        [wavelength],
+                        ["channel-a"],
+                    )
+
+    def test_finite_zero_and_negative_coordinates_are_supported(self):
+        assessment = assess_instrument_channel_calibration_requirement(
+            [0.0, 0.0, -1.0],
+            ["channel-a", "channel-b", "channel-c"],
+        )
+
+        self.assertTrue(assessment.required)
+        self.assertEqual(
+            assessment.shared_wavelength_channels,
+            {0.0: ("channel-a", "channel-b")},
+        )
+
+    def test_one_channel_cannot_map_to_multiple_wavelengths(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "exactly one physical wavelength",
+        ):
+            assess_instrument_channel_calibration_requirement(
+                [1.0, 2.0],
+                ["channel-a", "channel-a"],
+            )
+
+
+class TestUnsupportedCalibrationCallables(unittest.TestCase):
+    def test_fit_raises_not_implemented(self):
+        with self.assertRaisesRegex(
+            NotImplementedError,
+            r"TBD\[instrument-channel-calibration\]",
+        ):
+            fit_instrument_channel_calibration(
+                [1.0, 1.0],
+                [2.0, 2.1],
+                ["channel-a", "channel-b"],
+            )
+
+    def test_apply_raises_not_implemented(self):
+        with self.assertRaisesRegex(
+            NotImplementedError,
+            r"TBD\[instrument-channel-calibration\]",
+        ):
+            apply_instrument_channel_calibration(
+                [2.0, 2.1],
+                ["channel-a", "channel-b"],
+                calibration={},
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_instrument_channel_calibration_integration.py
+++ b/tests/test_instrument_channel_calibration_integration.py
@@ -1,0 +1,137 @@
+"""Integration contracts for shared-wavelength calibration metadata."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+import unittest
+
+import numpy as np
+
+from pgmuvi.wavelength_estimation import (
+    build_wavelength_estimation_context,
+    build_wavelength_mean_estimation_context,
+)
+from pgmuvi.wavelength_validation_real_lpv import (
+    build_representative_lpv_source_summary,
+)
+
+
+class TestCalibrationAssessmentIntegration(unittest.TestCase):
+    @staticmethod
+    def _shared_rows():
+        wavelengths = np.asarray(
+            [0.5] * 6 + [1.0] * 3 + [2.0] * 3 + [4.0] * 3,
+            dtype=float,
+        )
+        channels = np.asarray(
+            ["instrument-r-0"] * 3
+            + ["instrument-r-1"] * 3
+            + ["channel-j"] * 3
+            + ["channel-h"] * 3
+            + ["channel-k"] * 3,
+            dtype=str,
+        )
+        fluxes = np.asarray(
+            [
+                1.0,
+                1.1,
+                0.9,
+                1.4,
+                1.5,
+                1.3,
+                2.0,
+                2.1,
+                1.9,
+                3.0,
+                3.1,
+                2.9,
+                5.0,
+                5.1,
+                4.9,
+            ],
+            dtype=float,
+        )
+        return wavelengths, channels, fluxes
+
+    def test_wavelength_context_exposes_canonical_assessment(self):
+        wavelengths, channels, fluxes = self._shared_rows()
+
+        diagnostics, _ = build_wavelength_estimation_context(
+            wavelengths,
+            fluxes,
+            observational_channel_labels=channels,
+            min_points_per_observational_channel=3,
+        )
+
+        assessment = diagnostics.metadata[
+            "instrument_channel_calibration"
+        ]
+        self.assertEqual(
+            assessment["status"],
+            "required_not_implemented",
+        )
+        self.assertTrue(assessment["required"])
+        self.assertFalse(assessment["calibration_applied"])
+        self.assertEqual(
+            assessment["shared_wavelength_groups"][0][
+                "observational_channels"
+            ],
+            ["instrument-r-0", "instrument-r-1"],
+        )
+        json.dumps(assessment, allow_nan=False)
+
+    def test_mean_context_retains_current_exclusion_policy(self):
+        wavelengths, channels, fluxes = self._shared_rows()
+        model_wavelengths = wavelengths / 5.0
+
+        diagnostics = build_wavelength_mean_estimation_context(
+            wavelengths,
+            model_wavelengths,
+            fluxes,
+            observational_channel_labels=channels,
+            min_points_per_observational_channel=3,
+        )
+
+        self.assertEqual(diagnostics.raw_wavelengths, (1.0, 2.0, 4.0))
+        self.assertNotIn(0.5, diagnostics.raw_wavelengths)
+
+        assessment = diagnostics.metadata[
+            "instrument_channel_calibration"
+        ]
+        self.assertEqual(
+            assessment["policy"],
+            "preserve_channels_without_calibration",
+        )
+        self.assertFalse(assessment["implemented"])
+
+    def test_real_lpv_summary_uses_the_same_contract(self):
+        wavelengths, channels, fluxes = self._shared_rows()
+        times = np.arange(wavelengths.size, dtype=float)
+        lightcurve = SimpleNamespace(
+            _xdata_raw=np.column_stack([times, wavelengths]),
+            _ydata_raw=fluxes,
+            band=channels,
+            observational_channel_labels=channels,
+        )
+
+        summary = build_representative_lpv_source_summary(lightcurve)
+
+        self.assertEqual(
+            summary["instrument_calibration_status"],
+            "not_implemented",
+        )
+        self.assertTrue(summary["instrument_calibration_tbd"])
+        self.assertEqual(
+            summary["shared_wavelength_policy"],
+            "preserve_channels_without_calibration",
+        )
+        self.assertEqual(
+            summary["instrument_channel_calibration"]["status"],
+            "required_not_implemented",
+        )
+        json.dumps(summary, allow_nan=False)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Define the public contract for instrument-channel calibration when multiple observational channels share one physical wavelength.

This PR:

- adds immutable, JSON-safe calibration status and assessment primitives;
- detects shared-wavelength observational-channel groups deterministically;
- exposes the canonical assessment through wavelength-estimation and representative-LPV validation metadata;
- preserves the existing channel-level evidence and shared-wavelength exclusion policies;
- preserves residual aggregation by physical wavelength;
- adds explicit calibration fitting and application entry points that raise `NotImplementedError`;
- prohibits silent calibration, averaging, merging, rescaling, or wavelength reassignment;
- documents the contract in the public API and multiband guidance;
- retains `TBD[instrument-channel-calibration]` as open future work.

This PR defines the boundary only. It does not implement a calibration model or alter the GP science.

## Compatibility correction

The assessment accepts all finite wavelength-coordinate values, including zero and negative synthetic coordinates. It therefore detects shared coordinates without imposing a new physical-wavelength validation policy on existing PGMUVI workflows.

## Validation

- `ruff check -v --output-format=full --show-fixes ./pgmuvi`
  - all checks passed
- `make -C docs clean`
  - passed
- `make -C docs html-strict`
  - build succeeded
- `PYTHONPATH=. python3 -m unittest discover -s tests -p "test*.py" -v`
  - 2,561 tests passed
- documentation TBD-marker audit
  - passed
  - 13 registered markers
  - `TBD[instrument-channel-calibration]` remains open
