### PR TITLE
Implement explicit paired instrument-channel calibration

### DIFF
--- a/docs/source/future_work.rst
+++ b/docs/source/future_work.rst
@@ -113,19 +113,13 @@ Wavelength-model extensions
 ---------------------------
 
 **TBD[instrument-channel-calibration]**
-    Add an explicit, tested calibration model for multiple observational channels
-    that share one physical wavelength but have instrument-dependent offsets,
-    scales, throughput differences, or noise properties.  Current wavelength
-    diagnostics preserve the separate channel identities and flag the shared
-    wavelength, but they do not estimate or apply a calibration correction.  Any
-    public calibration API introduced before implementation must raise
-    ``NotImplementedError`` rather than silently approximating a correction.
-
-    The public contract and requirement-assessment primitives now live in
-    :mod:`pgmuvi.instrument_channel_calibration`.  They report shared-wavelength
-    channel groups and preserve the current uncalibrated policy.  The fit and
-    application callables deliberately raise ``NotImplementedError``; this does
-    not close the marker or constitute a calibration implementation.
+    The public low-level fitting and application callables now accept
+    caller-supplied paired measurements from distinct observational channels
+    and implement an explicit affine mapping.  This does not close the marker:
+    automatic pair construction, dataset-level orchestration across shared-
+    wavelength observational channels, fitted-coefficient uncertainty
+    propagation, workflow integration, and scientific validation remain future
+    work.
 
 **TBD[multi-periodic-wavelength-models]**
     Add a documented and validated multi-periodic workflow beyond the current

--- a/docs/source/howto/multiband.rst
+++ b/docs/source/howto/multiband.rst
@@ -113,14 +113,11 @@ using the existing compatibility method::
 
 .. warning::
 
-   **TBD[instrument-channel-calibration]:** PGMUVI does not currently estimate
-   additive offsets, multiplicative scales, or other instrument-channel
-   calibration corrections when multiple observational channels share one
-   physical wavelength.  Preserve the separate channel labels.  No silent
-   calibration or wavelength reassignment is performed; an explicit calibration
-   model is future work.  The public fit and apply callables in
-   :mod:`pgmuvi.instrument_channel_calibration` raise ``NotImplementedError``
-   until that model exists.
+   **TBD[instrument-channel-calibration]:** The low-level callables in
+   :mod:`pgmuvi.instrument_channel_calibration` can fit and apply an explicit
+   affine mapping from caller-supplied paired measurements.  They do not
+   construct time pairs, choose a calibration family, merge observational
+   channels, or integrate calibration automatically into a light-curve fit.
 
 Visualising 2D Results
 -----------------------

--- a/docs/source/howto/representative_lpv_validation.rst
+++ b/docs/source/howto/representative_lpv_validation.rst
@@ -19,9 +19,11 @@ wavelength.  D3 preserves those channel identities and does not average,
 merge, calibrate, correct, or reassign their measurements or wavelength
 coordinates.
 
-Instrument-specific calibration is not implemented.  That work remains
-``TBD[instrument-channel-calibration]``.  No calibration correction is
-silently approximated.
+Automatic instrument-specific calibration is not integrated into this
+workflow.  The low-level paired affine API requires explicit caller-supplied
+pairs and is not applied by representative-LPV validation.  This limitation
+remains tracked by ``TBD[instrument-channel-calibration]``; no calibration
+correction is silently approximated.
 
 Maintained candidate set
 ------------------------
@@ -261,7 +263,7 @@ The workflow therefore leaves ``selected_model`` unset.
 Residual wavelength evidence is available for all five candidates
 and is aggregated by physical wavelength.  Observational channels
 sharing one physical wavelength remain grouped because
-instrument-specific channel calibration has not been implemented.
+instrument-specific channel calibration is not applied by this workflow.
 That separate limitation remains tracked by
 ``TBD[instrument-channel-calibration]``.
 

--- a/docs/source/pgmuvi.instrument_channel_calibration.rst
+++ b/docs/source/pgmuvi.instrument_channel_calibration.rst
@@ -1,29 +1,56 @@
-Instrument-channel calibration contract
-=======================================
+Instrument-channel calibration
+==============================
 
 .. automodule:: pgmuvi.instrument_channel_calibration
    :members:
    :undoc-members:
    :show-inheritance:
 
+Assessment and explicit paired calibration
+------------------------------------------
+
+The assessment API preserves the distinction between an observational channel
+and its physical wavelength coordinate.  It deterministically reports groups
+in which multiple observational channels share one physical wavelength, but it
+does not alter wavelengths, merge channels, average their measurements, or
+apply a correction.
+
+The fitting API accepts **caller-supplied paired** flux measurements for one
+observational channel and an explicitly named reference channel.  It fits the
+affine mapping
+
+.. math::
+
+   f_{\mathrm{reference}}
+   =
+   b + a f_{\mathrm{channel}},
+
+where ``b`` is the stored offset and ``a`` is the strictly positive stored
+scale.  Optional measurement uncertainties contribute to weighted least
+squares, and iterative MAD clipping can reject discrepant pairs.
+
+PGMUVI does not construct time pairs from asynchronous light curves.  It also
+does not select between additive, multiplicative, affine, or other calibration
+families.  Pair construction and the decision to use this explicit affine
+model remain the caller's scientific responsibility.
+
+Applying a fitted calibration maps fluxes onto the reference-channel scale.
+Flux uncertainties are multiplied by the absolute fitted scale.  The current
+application function does not propagate uncertainty in the fitted offset or
+scale themselves.
+
 ``TBD[instrument-channel-calibration]`` remains open
 ----------------------------------------------------
 
-This module does **not** implement an instrumental calibration model.  It
-provides a deterministic assessment of whether multiple observational channels
-share one physical wavelength and therefore require a future calibration
-model.
+The low-level paired affine fit and application primitives do not complete the
+instrument-channel calibration work.  The marker remains open because PGMUVI
+still lacks:
 
-The assessment preserves observational-channel identities, reports the shared
-physical-wavelength groups, records that no correction was applied, and is
-JSON-safe.  It does not inspect flux differences as evidence for an offset or
-scale and does not alter wavelengths or fluxes.
+* scientifically validated rules for constructing calibration pairs;
+* dataset-level orchestration across shared-wavelength channel groups;
+* propagation of fitted-coefficient uncertainty;
+* integration into the normal light-curve fitting workflow; and
+* validation across representative instruments, filters, and LPV sources.
 
-The public callables
-:func:`~pgmuvi.instrument_channel_calibration.fit_instrument_channel_calibration`
-and
-:func:`~pgmuvi.instrument_channel_calibration.apply_instrument_channel_calibration`
-raise :class:`NotImplementedError`.  This explicit failure is part of the
-contract: PGMUVI must not silently infer, approximate, or apply an
-instrument-channel correction before a scientifically validated implementation
-exists.
+No automatic calibration, channel merging, wavelength reassignment, or model
+selection is performed.

--- a/docs/source/pgmuvi.wavelength_estimation.rst
+++ b/docs/source/pgmuvi.wavelength_estimation.rst
@@ -18,14 +18,14 @@ wavelengths.  Multiple channels may share one wavelength, so channel-level
 summaries and distinct physical wavelengths are reported separately.
 
 **TBD[instrument-channel-calibration]:** No instrument-channel calibration is
-performed.  When two or more usable observational channels share a physical
-wavelength, PGMUVI preserves their channel-level diagnostics but excludes that
-uncalibrated wavelength from cross-wavelength trend summaries and
-wavelength-mean fits.  It does not silently combine flux summaries, infer
-offsets or scales, or assign artificial wavelength differences.  The
-metadata includes the JSON-safe requirement assessment from
-:mod:`pgmuvi.instrument_channel_calibration`; no calibration is fitted or
-applied.
+performed by this wavelength-estimation workflow.  The low-level API in
+:mod:`pgmuvi.instrument_channel_calibration` can fit and apply an affine mapping
+from caller-supplied paired measurements, but this workflow does not construct
+such pairs or receive a fitted mapping.  When multiple usable observational
+channels share one physical wavelength, their channel-level diagnostics are
+preserved while that wavelength is excluded from cross-wavelength trend
+summaries and wavelength-mean fits.  No flux summaries are silently combined,
+and no artificial wavelength differences are assigned.
 
 The diagnostics retain the length-scale recommendation in the **raw
 wavelength coordinate** and also record the corresponding value and interval in

--- a/pgmuvi/instrument_channel_calibration.py
+++ b/pgmuvi/instrument_channel_calibration.py
@@ -1,14 +1,14 @@
-"""Contracts for future observational-channel calibration.
+"""Explicit observational-channel calibration primitives.
 
 An observational channel identifies an instrument, detector, filter, or data
 stream.  It is distinct from the numeric physical wavelength coordinate used by
 the GP, and multiple observational channels may share one physical wavelength.
 
-PGMUVI does not yet estimate or apply channel-specific offsets, scales,
-throughput corrections, or noise corrections.  This module provides an
-immutable, JSON-safe assessment of whether such calibration is required and
-public placeholder callables that fail explicitly rather than silently
-approximating a correction.
+This module provides an immutable, JSON-safe requirement assessment together
+with low-level fitting and application primitives for an explicit affine
+mapping between caller-paired measurements.  It does not construct temporal
+pairs, choose a calibration family, merge channels, alter wavelengths, or
+integrate calibration automatically into a light-curve fit.
 """
 
 from __future__ import annotations
@@ -16,7 +16,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum
 import math
-from typing import Any, NoReturn
+from typing import Any
 
 import numpy as np
 
@@ -30,8 +30,10 @@ INSTRUMENT_CHANNEL_CALIBRATION_TBD_MARKER = (
 
 
 __all__ = [
+    "INSTRUMENT_CHANNEL_CALIBRATION_MODEL_SCHEMA_VERSION",
     "INSTRUMENT_CHANNEL_CALIBRATION_SCHEMA_VERSION",
     "INSTRUMENT_CHANNEL_CALIBRATION_TBD_MARKER",
+    "InstrumentChannelCalibration",
     "InstrumentChannelCalibrationAssessment",
     "InstrumentChannelCalibrationStatus",
     "SharedWavelengthChannelGroup",
@@ -139,7 +141,8 @@ class InstrumentChannelCalibrationAssessment:
 
         if self.implemented or self.calibration_applied:
             raise ValueError(
-                "Instrument-channel calibration is not implemented."
+                "Automatic instrument-channel calibration has not been "
+                "applied by this requirement assessment."
             )
         if self.silent_calibration_permitted:
             raise ValueError("Silent calibration is never permitted.")
@@ -275,38 +278,485 @@ def assess_instrument_channel_calibration_requirement(
     )
 
 
-def _raise_calibration_not_implemented(action: str) -> NoReturn:
-    raise NotImplementedError(
-        f"Instrument-channel calibration {action} is not implemented. "
-        f"{INSTRUMENT_CHANNEL_CALIBRATION_TBD_MARKER} requires an explicit, "
-        "tested model; PGMUVI will not silently infer or apply a correction."
+INSTRUMENT_CHANNEL_CALIBRATION_MODEL_SCHEMA_VERSION = "1.0"
+
+
+@dataclass(frozen=True)
+class InstrumentChannelCalibration:
+    """Affine mapping from one observational channel to a reference channel.
+
+    The stored coefficients follow the explicit convention
+
+    ``reference_flux = offset + scale * channel_flux``.
+
+    The model is estimated only from caller-supplied paired measurements.
+    PGMUVI does not create pairs from asynchronous light curves.
+    """
+
+    schema_version: str
+    reference_channel: str
+    channel: str
+    wavelength: float
+    offset: float
+    scale: float
+    n_pairs: int
+    n_inliers: int
+    residual_mad_sigma: float | None
+    fit_method: str = "iterative_mad_clipped_affine"
+
+    def __post_init__(self) -> None:
+        if self.schema_version != (
+            INSTRUMENT_CHANNEL_CALIBRATION_MODEL_SCHEMA_VERSION
+        ):
+            raise ValueError(
+                "Unsupported instrument-channel calibration model "
+                f"schema version: {self.schema_version!r}."
+            )
+
+        reference_channel = str(self.reference_channel).strip()
+        channel = str(self.channel).strip()
+
+        if not reference_channel:
+            raise ValueError("reference_channel must be non-empty.")
+        if not channel:
+            raise ValueError("channel must be non-empty.")
+        if channel == reference_channel:
+            raise ValueError(
+                "channel and reference_channel must identify different "
+                "observational channels."
+            )
+
+        object.__setattr__(
+            self,
+            "reference_channel",
+            reference_channel,
+        )
+        object.__setattr__(self, "channel", channel)
+
+        finite_values = {
+            "wavelength": self.wavelength,
+            "offset": self.offset,
+            "scale": self.scale,
+        }
+        for name, value in finite_values.items():
+            if not np.isfinite(float(value)):
+                raise ValueError(f"{name} must be finite.")
+
+        if self.scale <= 0.0:
+            raise ValueError("scale must be strictly positive.")
+        if self.n_pairs < 3:
+            raise ValueError("n_pairs must be at least 3.")
+        if not 3 <= self.n_inliers <= self.n_pairs:
+            raise ValueError(
+                "n_inliers must be between 3 and n_pairs, inclusive."
+            )
+
+        if self.residual_mad_sigma is not None:
+            residual_scale = float(self.residual_mad_sigma)
+            if not np.isfinite(residual_scale) or residual_scale < 0.0:
+                raise ValueError(
+                    "residual_mad_sigma must be finite and non-negative "
+                    "when supplied."
+                )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a strict JSON-safe representation."""
+
+        return {
+            "schema_version": self.schema_version,
+            "reference_channel": self.reference_channel,
+            "channel": self.channel,
+            "wavelength": float(self.wavelength),
+            "offset": float(self.offset),
+            "scale": float(self.scale),
+            "n_pairs": int(self.n_pairs),
+            "n_inliers": int(self.n_inliers),
+            "residual_mad_sigma": (
+                None
+                if self.residual_mad_sigma is None
+                else float(self.residual_mad_sigma)
+            ),
+            "fit_method": self.fit_method,
+            "application_equation": (
+                "reference_flux = offset + scale * channel_flux"
+            ),
+            "automatic_time_matching": False,
+            "automatic_model_selection": False,
+        }
+
+
+def _as_calibration_vector(
+    values: Any,
+    *,
+    name: str,
+) -> np.ndarray:
+    array = np.asarray(values, dtype=float)
+
+    if array.ndim != 1:
+        raise ValueError(f"{name} must be one-dimensional.")
+
+    return array
+
+
+def _validate_optional_calibration_error(
+    values: Any | None,
+    *,
+    name: str,
+    expected_shape: tuple[int, ...],
+) -> np.ndarray | None:
+    if values is None:
+        return None
+
+    array = _as_calibration_vector(values, name=name)
+
+    if array.shape != expected_shape:
+        raise ValueError(
+            f"{name} must have the same shape as the paired flux arrays."
+        )
+
+    return array
+
+
+def _weighted_affine_solution(
+    channel_flux: np.ndarray,
+    reference_flux: np.ndarray,
+    weights: np.ndarray,
+) -> tuple[float, float]:
+    design = np.column_stack(
+        (
+            np.ones(channel_flux.size, dtype=float),
+            channel_flux,
+        )
+    )
+    sqrt_weights = np.sqrt(weights)
+    weighted_design = design * sqrt_weights[:, None]
+    weighted_reference = reference_flux * sqrt_weights
+
+    offset, scale = np.linalg.lstsq(
+        weighted_design,
+        weighted_reference,
+        rcond=None,
+    )[0]
+
+    return float(offset), float(scale)
+
+
+def _calibration_mad_sigma(values: np.ndarray) -> float:
+    if values.size == 0:
+        return 0.0
+
+    centre = float(np.median(values))
+    return float(
+        1.4826 * np.median(np.abs(values - centre))
     )
 
 
-def fit_instrument_channel_calibration(
-    physical_wavelengths: Any,
-    fluxes: Any,
-    observational_channel_labels: Any,
-    uncertainties: Any | None = None,
-) -> NoReturn:
-    """Fit a channel calibration model.
+def _normalize_calibration_channel(
+    value: Any,
+    *,
+    name: str,
+) -> str:
+    channel_name = str(value).strip()
 
-    This callable defines the public failure contract only.  No calibration
-    model is currently implemented.
+    if not channel_name:
+        raise ValueError(f"{name} must be non-empty.")
+
+    return channel_name
+
+
+def fit_instrument_channel_calibration(
+    reference_flux: Any,
+    channel_flux: Any,
+    *,
+    reference_channel: str,
+    channel: str,
+    wavelength: float,
+    reference_error: Any | None = None,
+    channel_error: Any | None = None,
+    sigma_clip: float = 3.5,
+    max_iter: int = 8,
+    min_pairs: int = 3,
+) -> InstrumentChannelCalibration:
+    """Fit an explicit paired affine instrument-channel calibration.
+
+    Parameters
+    ----------
+    reference_flux, channel_flux
+        One-dimensional arrays containing measurements already paired by
+        the caller. PGMUVI does not infer simultaneity or construct pairs.
+    reference_channel, channel
+        Distinct observational-channel identifiers.
+    wavelength
+        Shared finite wavelength coordinate for the two channels.
+    reference_error, channel_error
+        Optional one-sigma measurement uncertainties. When supplied, they
+        contribute to iterative weighted least squares.
+    sigma_clip
+        Positive MAD-based clipping threshold.
+    max_iter
+        Maximum number of fitting and clipping iterations.
+    min_pairs
+        Minimum number of finite paired measurements required.
+
+    Returns
+    -------
+    InstrumentChannelCalibration
+        An immutable affine mapping satisfying
+        ``reference_flux = offset + scale * channel_flux``.
     """
 
-    _raise_calibration_not_implemented("fitting")
+    if isinstance(min_pairs, bool) or not isinstance(min_pairs, int):
+        raise TypeError("min_pairs must be an integer.")
+    if min_pairs < 3:
+        raise ValueError("min_pairs must be at least 3.")
+
+    if isinstance(max_iter, bool) or not isinstance(max_iter, int):
+        raise TypeError("max_iter must be an integer.")
+    if max_iter < 1:
+        raise ValueError("max_iter must be at least 1.")
+
+    sigma_clip = float(sigma_clip)
+    if not np.isfinite(sigma_clip) or sigma_clip <= 0.0:
+        raise ValueError("sigma_clip must be finite and positive.")
+
+    reference = _as_calibration_vector(
+        reference_flux,
+        name="reference_flux",
+    )
+    target = _as_calibration_vector(
+        channel_flux,
+        name="channel_flux",
+    )
+
+    if reference.shape != target.shape:
+        raise ValueError(
+            "reference_flux and channel_flux must have the same shape."
+        )
+
+    reference_sigma = _validate_optional_calibration_error(
+        reference_error,
+        name="reference_error",
+        expected_shape=reference.shape,
+    )
+    channel_sigma = _validate_optional_calibration_error(
+        channel_error,
+        name="channel_error",
+        expected_shape=reference.shape,
+    )
+
+    finite = np.isfinite(reference) & np.isfinite(target)
+
+    for error in (reference_sigma, channel_sigma):
+        if error is None:
+            continue
+        finite &= np.isfinite(error) & (error > 0.0)
+
+    reference = reference[finite]
+    target = target[finite]
+
+    if reference_sigma is not None:
+        reference_sigma = reference_sigma[finite]
+    if channel_sigma is not None:
+        channel_sigma = channel_sigma[finite]
+
+    n_pairs = int(reference.size)
+    if n_pairs < min_pairs:
+        raise ValueError(
+            "Insufficient finite paired measurements: "
+            f"received {n_pairs}, require at least {min_pairs}."
+        )
+
+    if not np.isfinite(float(wavelength)):
+        raise ValueError("wavelength must be finite.")
+
+    normalized_reference_channel = _normalize_calibration_channel(
+        reference_channel,
+        name="reference_channel",
+    )
+    normalized_channel = _normalize_calibration_channel(
+        channel,
+        name="channel",
+    )
+
+    if normalized_reference_channel == normalized_channel:
+        raise ValueError(
+            "reference_channel and channel must identify different "
+            "observational channels."
+        )
+
+    target_span = float(np.ptp(target))
+    if not np.isfinite(target_span) or target_span <= 0.0:
+        raise ValueError(
+            "channel_flux must span more than one finite value."
+        )
+
+    keep = np.ones(n_pairs, dtype=bool)
+    scale_for_weights = 1.0
+    offset = 0.0
+    scale = 1.0
+
+    for _ in range(max_iter):
+        if np.count_nonzero(keep) < min_pairs:
+            break
+
+        if reference_sigma is None and channel_sigma is None:
+            weights = np.ones(np.count_nonzero(keep), dtype=float)
+        else:
+            variance = np.zeros(n_pairs, dtype=float)
+
+            if reference_sigma is not None:
+                variance += reference_sigma**2
+            if channel_sigma is not None:
+                variance += (
+                    scale_for_weights * channel_sigma
+                ) ** 2
+
+            selected_variance = variance[keep]
+            if np.any(
+                ~np.isfinite(selected_variance)
+                | (selected_variance <= 0.0)
+            ):
+                raise ValueError(
+                    "Combined calibration variances must be finite "
+                    "and positive."
+                )
+
+            weights = 1.0 / selected_variance
+
+        offset, scale = _weighted_affine_solution(
+            target[keep],
+            reference[keep],
+            weights,
+        )
+
+        if not np.isfinite(offset) or not np.isfinite(scale):
+            raise RuntimeError(
+                "Instrument-channel calibration fit produced "
+                "non-finite coefficients."
+            )
+        if scale <= 0.0:
+            raise ValueError(
+                "Instrument-channel calibration requires a strictly "
+                "positive fitted scale."
+            )
+
+        scale_for_weights = scale
+        residual = reference - (offset + scale * target)
+        selected_residual = residual[keep]
+        centre = float(np.median(selected_residual))
+        residual_scale = _calibration_mad_sigma(
+            selected_residual
+        )
+
+        if residual_scale <= 0.0:
+            break
+
+        updated = (
+            np.abs(residual - centre)
+            <= sigma_clip * residual_scale
+        )
+
+        if np.count_nonzero(updated) < min_pairs:
+            break
+        if np.array_equal(updated, keep):
+            keep = updated
+            break
+
+        keep = updated
+
+    n_inliers = int(np.count_nonzero(keep))
+    if n_inliers < min_pairs:
+        raise RuntimeError(
+            "Instrument-channel calibration clipping left fewer "
+            "than the required number of paired measurements."
+        )
+
+    if reference_sigma is None and channel_sigma is None:
+        final_weights = np.ones(n_inliers, dtype=float)
+    else:
+        final_variance = np.zeros(n_pairs, dtype=float)
+
+        if reference_sigma is not None:
+            final_variance += reference_sigma**2
+        if channel_sigma is not None:
+            final_variance += (scale * channel_sigma) ** 2
+
+        final_weights = 1.0 / final_variance[keep]
+
+    offset, scale = _weighted_affine_solution(
+        target[keep],
+        reference[keep],
+        final_weights,
+    )
+
+    if scale <= 0.0:
+        raise ValueError(
+            "Instrument-channel calibration requires a strictly "
+            "positive fitted scale."
+        )
+
+    final_residual = (
+        reference[keep]
+        - (offset + scale * target[keep])
+    )
+
+    return InstrumentChannelCalibration(
+        schema_version=(
+            INSTRUMENT_CHANNEL_CALIBRATION_MODEL_SCHEMA_VERSION
+        ),
+        reference_channel=normalized_reference_channel,
+        channel=normalized_channel,
+        wavelength=float(wavelength),
+        offset=float(offset),
+        scale=float(scale),
+        n_pairs=n_pairs,
+        n_inliers=n_inliers,
+        residual_mad_sigma=_calibration_mad_sigma(
+            final_residual
+        ),
+    )
 
 
 def apply_instrument_channel_calibration(
-    fluxes: Any,
-    observational_channel_labels: Any,
-    calibration: Any,
-) -> NoReturn:
-    """Apply a fitted channel calibration model.
+    flux: Any,
+    calibration: InstrumentChannelCalibration,
+    *,
+    flux_error: Any | None = None,
+) -> np.ndarray | tuple[np.ndarray, np.ndarray]:
+    """Map one observational channel onto its reference-channel scale.
 
-    This callable defines the public failure contract only.  No calibration
-    model is currently implemented.
+    Measurement uncertainties are multiplied by ``abs(scale)``. This
+    propagation does not include uncertainty in the fitted calibration
+    coefficients.
     """
 
-    _raise_calibration_not_implemented("application")
+    if not isinstance(
+        calibration,
+        InstrumentChannelCalibration,
+    ):
+        raise TypeError(
+            "calibration must be an "
+            "InstrumentChannelCalibration instance."
+        )
+
+    values = np.asarray(flux, dtype=float)
+    calibrated_flux = (
+        calibration.offset + calibration.scale * values
+    )
+
+    if flux_error is None:
+        return calibrated_flux
+
+    errors = np.asarray(flux_error, dtype=float)
+
+    if errors.shape != values.shape:
+        raise ValueError(
+            "flux_error must have the same shape as flux."
+        )
+    if np.any(~np.isfinite(errors) | (errors < 0.0)):
+        raise ValueError(
+            "flux_error values must be finite and non-negative."
+        )
+
+    calibrated_error = abs(calibration.scale) * errors
+    return calibrated_flux, calibrated_error

--- a/pgmuvi/instrument_channel_calibration.py
+++ b/pgmuvi/instrument_channel_calibration.py
@@ -333,6 +333,15 @@ class InstrumentChannelCalibration:
         )
         object.__setattr__(self, "channel", channel)
 
+        if not isinstance(self.fit_method, str):
+            raise TypeError("fit_method must be a string.")
+
+        fit_method = self.fit_method.strip()
+        if not fit_method:
+            raise ValueError("fit_method must be non-empty.")
+
+        object.__setattr__(self, "fit_method", fit_method)
+
         finite_values = {
             "wavelength": self.wavelength,
             "offset": self.offset,
@@ -648,13 +657,49 @@ def fit_instrument_channel_calibration(
             selected_residual
         )
 
-        if residual_scale <= 0.0:
-            break
-
-        updated = (
-            np.abs(residual - centre)
-            <= sigma_clip * residual_scale
+        absolute_deviation = np.abs(residual - centre)
+        numerical_tolerance = (
+            64.0
+            * np.finfo(float).eps
+            * max(
+                1.0,
+                float(np.max(np.abs(reference))),
+                float(
+                    np.max(
+                        np.abs(offset + scale * target)
+                    )
+                ),
+            )
         )
+
+        if residual_scale <= numerical_tolerance:
+            updated = (
+                absolute_deviation <= numerical_tolerance
+            )
+
+            if (
+                np.count_nonzero(updated) < min_pairs
+                or float(np.ptp(target[updated])) <= 0.0
+            ):
+                positive_deviation = absolute_deviation[
+                    absolute_deviation > numerical_tolerance
+                ]
+
+                if positive_deviation.size == 0:
+                    break
+
+                fallback_scale = float(
+                    np.min(positive_deviation)
+                )
+                updated = (
+                    absolute_deviation
+                    <= sigma_clip * fallback_scale
+                )
+        else:
+            updated = (
+                absolute_deviation
+                <= sigma_clip * residual_scale
+            )
 
         if np.count_nonzero(updated) < min_pairs:
             break

--- a/pgmuvi/wavelength_estimation.py
+++ b/pgmuvi/wavelength_estimation.py
@@ -452,11 +452,10 @@ def build_wavelength_estimation_context(
     )
     shared_wavelengths = set(shared_wavelength_channels)
 
-    # TBD[instrument-channel-calibration]: An explicit calibration model is
-    # required before flux summaries from multiple observational channels at
-    # one physical wavelength can be combined. Until then, omit those physical
+    # TBD[instrument-channel-calibration]: This workflow does not construct
+    # calibration pairs or apply a caller-fitted mapping. Omit shared physical
     # wavelengths from cross-wavelength trend summaries rather than silently
-    # calibrating or double-counting them.
+    # calibrating, merging, or double-counting their observational channels.
     usable_for_trends = [
         item
         for item in usable
@@ -663,10 +662,9 @@ def _wavelength_mean_observational_channel_points(
     )
     shared_wavelengths = set(shared_wavelength_channels)
 
-    # TBD[instrument-channel-calibration]: Separate observational channels at
-    # one physical wavelength cannot contribute independent mean-fit points
-    # until an explicit calibration model exists. Excluding the wavelength is
-    # safer than silently combining channel medians or double-counting it.
+    # TBD[instrument-channel-calibration]: This workflow receives no explicit
+    # caller-fitted channel mapping. Excluding the shared physical wavelength
+    # is safer than silently combining channel medians or double-counting it.
     retained_rows = [
         item for item in rows if item[0] not in shared_wavelengths
     ]
@@ -1106,9 +1104,9 @@ def build_wavelength_mean_estimation_context(
     ]
     if channel_metadata["multiple_observational_channels_per_wavelength"]:
         warnings.append(
-            "Instrument-channel calibration is not implemented; physical "
-            "wavelengths shared by multiple observational channels were "
-            "excluded from wavelength-mean estimation."
+            "Instrument-channel calibration is not applied in this workflow; "
+            "physical wavelengths shared by multiple observational channels "
+            "were excluded from wavelength-mean estimation."
         )
 
     return WavelengthMeanEstimationDiagnostics(

--- a/tests/test_docs_instrument_channel_calibration.py
+++ b/tests/test_docs_instrument_channel_calibration.py
@@ -24,6 +24,17 @@ class TestInstrumentChannelCalibrationDocumentation(unittest.TestCase):
         )
         self.assertTrue(PAGE.exists())
 
+        from pgmuvi import instrument_channel_calibration
+
+        self.assertIn(
+            "InstrumentChannelCalibration",
+            instrument_channel_calibration.__all__,
+        )
+        self.assertIn(
+            "INSTRUMENT_CHANNEL_CALIBRATION_MODEL_SCHEMA_VERSION",
+            instrument_channel_calibration.__all__,
+        )
+
         api_text = API.read_text(encoding="utf-8")
         page_text = PAGE.read_text(encoding="utf-8")
 
@@ -36,24 +47,23 @@ class TestInstrumentChannelCalibrationDocumentation(unittest.TestCase):
             page_text,
         )
 
-    def test_page_documents_explicit_unsupported_callables(self):
-        text = " ".join(PAGE.read_text(encoding="utf-8").split())
-
-        self.assertIn("TBD[instrument-channel-calibration]", text)
-        self.assertIn("fit_instrument_channel_calibration", text)
-        self.assertIn("apply_instrument_channel_calibration", text)
-        self.assertIn("NotImplementedError", text)
-        self.assertIn("must not silently infer", text)
+    def test_page_documents_explicit_paired_calibration(self):
+        text = PAGE.read_text(encoding="utf-8")
+        self.assertIn("caller-supplied paired", text)
+        self.assertIn("does not construct time pairs", text)
+        self.assertIn("affine", text.lower())
+        self.assertIn(
+            "does not propagate uncertainty in the fitted offset or scale",
+            " ".join(text.split()),
+        )
 
     def test_future_work_marker_remains_open(self):
         text = " ".join(FUTURE.read_text(encoding="utf-8").split())
 
         self.assertIn("TBD[instrument-channel-calibration]", text)
-        self.assertIn(
-            "does not close the marker or constitute a calibration "
-            "implementation",
-            text,
-        )
+        self.assertIn("caller-supplied paired measurements", text)
+        self.assertIn("does not close", text)
+        self.assertIn("scientific validation", text)
 
     def test_estimation_and_multiband_guides_reference_contract(self):
         estimation = ESTIMATION.read_text(encoding="utf-8")
@@ -64,10 +74,22 @@ class TestInstrumentChannelCalibrationDocumentation(unittest.TestCase):
             estimation,
         )
         self.assertIn(
+            "No instrument-channel calibration is performed by this "
+            "wavelength-estimation workflow",
+            " ".join(estimation.split()),
+        )
+        self.assertIn("caller-supplied paired measurements", estimation)
+        self.assertIn(
             "pgmuvi.instrument_channel_calibration",
             multiband,
         )
-        self.assertIn("NotImplementedError", multiband)
+        normalized_multiband = " ".join(multiband.split())
+        self.assertIn("caller-supplied paired", normalized_multiband)
+        self.assertIn(
+            "do not construct time pairs",
+            normalized_multiband,
+        )
+        self.assertNotIn("NotImplementedError", normalized_multiband)
 
 
 if __name__ == "__main__":

--- a/tests/test_instrument_channel_calibration_contract.py
+++ b/tests/test_instrument_channel_calibration_contract.py
@@ -11,9 +11,7 @@ from pgmuvi.instrument_channel_calibration import (
     INSTRUMENT_CHANNEL_CALIBRATION_SCHEMA_VERSION,
     INSTRUMENT_CHANNEL_CALIBRATION_TBD_MARKER,
     InstrumentChannelCalibrationStatus,
-    apply_instrument_channel_calibration,
     assess_instrument_channel_calibration_requirement,
-    fit_instrument_channel_calibration,
 )
 
 
@@ -127,28 +125,6 @@ class TestInstrumentChannelCalibrationAssessment(unittest.TestCase):
             )
 
 
-class TestUnsupportedCalibrationCallables(unittest.TestCase):
-    def test_fit_raises_not_implemented(self):
-        with self.assertRaisesRegex(
-            NotImplementedError,
-            r"TBD\[instrument-channel-calibration\]",
-        ):
-            fit_instrument_channel_calibration(
-                [1.0, 1.0],
-                [2.0, 2.1],
-                ["channel-a", "channel-b"],
-            )
-
-    def test_apply_raises_not_implemented(self):
-        with self.assertRaisesRegex(
-            NotImplementedError,
-            r"TBD\[instrument-channel-calibration\]",
-        ):
-            apply_instrument_channel_calibration(
-                [2.0, 2.1],
-                ["channel-a", "channel-b"],
-                calibration={},
-            )
 
 
 if __name__ == "__main__":

--- a/tests/test_instrument_channel_calibration_fit_apply.py
+++ b/tests/test_instrument_channel_calibration_fit_apply.py
@@ -1,0 +1,227 @@
+"""Tests for explicit paired instrument-channel calibration."""
+
+import json
+import unittest
+
+import numpy as np
+
+from pgmuvi.instrument_channel_calibration import (
+    INSTRUMENT_CHANNEL_CALIBRATION_MODEL_SCHEMA_VERSION,
+    InstrumentChannelCalibration,
+    apply_instrument_channel_calibration,
+    fit_instrument_channel_calibration,
+)
+
+
+class TestInstrumentChannelCalibrationFit(unittest.TestCase):
+    def setUp(self):
+        self.channel_flux = np.linspace(0.2, 2.0, 60)
+        perturbation = 0.002 * np.sin(
+            np.linspace(0.0, 4.0 * np.pi, 60)
+        )
+        self.reference_flux = (
+            0.125 + 1.35 * self.channel_flux + perturbation
+        )
+
+    def test_affine_coefficients_are_recovered(self):
+        calibration = fit_instrument_channel_calibration(
+            self.reference_flux,
+            self.channel_flux,
+            reference_channel="reference",
+            channel="target",
+            wavelength=0.656,
+        )
+
+        self.assertIsInstance(
+            calibration,
+            InstrumentChannelCalibration,
+        )
+        self.assertAlmostEqual(calibration.offset, 0.125, delta=0.002)
+        self.assertAlmostEqual(calibration.scale, 1.35, delta=0.002)
+        self.assertEqual(calibration.n_pairs, 60)
+        self.assertEqual(calibration.n_inliers, 60)
+
+    def test_single_extreme_outlier_is_clipped(self):
+        reference_flux = self.reference_flux.copy()
+        reference_flux[12] += 5.0
+
+        calibration = fit_instrument_channel_calibration(
+            reference_flux,
+            self.channel_flux,
+            reference_channel="reference",
+            channel="target",
+            wavelength=0.656,
+        )
+
+        self.assertLess(calibration.n_inliers, calibration.n_pairs)
+        self.assertAlmostEqual(calibration.offset, 0.125, delta=0.002)
+        self.assertAlmostEqual(calibration.scale, 1.35, delta=0.002)
+
+    def test_optional_measurement_errors_are_supported(self):
+        calibration = fit_instrument_channel_calibration(
+            self.reference_flux,
+            self.channel_flux,
+            reference_channel="reference",
+            channel="target",
+            wavelength=0.656,
+            reference_error=np.full(60, 0.01),
+            channel_error=np.full(60, 0.02),
+        )
+
+        self.assertGreater(calibration.scale, 0.0)
+        self.assertEqual(calibration.n_pairs, 60)
+
+    def test_nonfinite_pairs_are_removed_before_fitting(self):
+        reference_flux = self.reference_flux.copy()
+        channel_flux = self.channel_flux.copy()
+        reference_flux[2] = np.nan
+        channel_flux[4] = np.inf
+
+        calibration = fit_instrument_channel_calibration(
+            reference_flux,
+            channel_flux,
+            reference_channel="reference",
+            channel="target",
+            wavelength=0.656,
+        )
+
+        self.assertEqual(calibration.n_pairs, 58)
+
+    def test_constant_channel_flux_is_rejected(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "span more than one",
+        ):
+            fit_instrument_channel_calibration(
+                self.reference_flux,
+                np.ones(60),
+                reference_channel="reference",
+                channel="target",
+                wavelength=0.656,
+            )
+
+    def test_mismatched_pair_shapes_are_rejected(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "same shape",
+        ):
+            fit_instrument_channel_calibration(
+                self.reference_flux,
+                self.channel_flux[:-1],
+                reference_channel="reference",
+                channel="target",
+                wavelength=0.656,
+            )
+
+    def test_channel_names_are_normalized(self):
+        calibration = fit_instrument_channel_calibration(
+            self.reference_flux,
+            self.channel_flux,
+            reference_channel=" reference ",
+            channel=" target ",
+            wavelength=0.656,
+        )
+
+        self.assertEqual(calibration.reference_channel, "reference")
+        self.assertEqual(calibration.channel, "target")
+
+    def test_channel_identity_must_be_explicit_and_distinct(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "different observational channels",
+        ):
+            fit_instrument_channel_calibration(
+                self.reference_flux,
+                self.channel_flux,
+                reference_channel="same",
+                channel="same",
+                wavelength=0.656,
+            )
+
+    def test_model_payload_is_strict_json_safe(self):
+        calibration = fit_instrument_channel_calibration(
+            self.reference_flux,
+            self.channel_flux,
+            reference_channel="reference",
+            channel="target",
+            wavelength=-1.5,
+        )
+
+        payload = calibration.to_dict()
+        encoded = json.dumps(payload, allow_nan=False)
+
+        self.assertIn(
+            INSTRUMENT_CHANNEL_CALIBRATION_MODEL_SCHEMA_VERSION,
+            encoded,
+        )
+        self.assertFalse(payload["automatic_time_matching"])
+        self.assertFalse(payload["automatic_model_selection"])
+
+
+class TestInstrumentChannelCalibrationApply(unittest.TestCase):
+    def setUp(self):
+        self.calibration = InstrumentChannelCalibration(
+            schema_version=(
+                INSTRUMENT_CHANNEL_CALIBRATION_MODEL_SCHEMA_VERSION
+            ),
+            reference_channel="reference",
+            channel="target",
+            wavelength=0.656,
+            offset=0.25,
+            scale=1.5,
+            n_pairs=20,
+            n_inliers=18,
+            residual_mad_sigma=0.01,
+        )
+
+    def test_flux_is_mapped_to_reference_scale(self):
+        result = apply_instrument_channel_calibration(
+            np.array([1.0, 2.0, 3.0]),
+            self.calibration,
+        )
+
+        np.testing.assert_allclose(
+            result,
+            np.array([1.75, 3.25, 4.75]),
+        )
+
+    def test_uncertainties_are_scaled(self):
+        flux, error = apply_instrument_channel_calibration(
+            np.array([1.0, 2.0]),
+            self.calibration,
+            flux_error=np.array([0.1, 0.2]),
+        )
+
+        np.testing.assert_allclose(
+            flux,
+            np.array([1.75, 3.25]),
+        )
+        np.testing.assert_allclose(
+            error,
+            np.array([0.15, 0.30]),
+        )
+
+    def test_calibration_type_is_checked(self):
+        with self.assertRaisesRegex(
+            TypeError,
+            "InstrumentChannelCalibration",
+        ):
+            apply_instrument_channel_calibration(
+                np.array([1.0]),
+                object(),
+            )
+
+    def test_error_shape_is_checked(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "same shape",
+        ):
+            apply_instrument_channel_calibration(
+                np.array([1.0, 2.0]),
+                self.calibration,
+                flux_error=np.array([0.1]),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_instrument_channel_calibration_fit_apply.py
+++ b/tests/test_instrument_channel_calibration_fit_apply.py
@@ -57,6 +57,34 @@ class TestInstrumentChannelCalibrationFit(unittest.TestCase):
         self.assertAlmostEqual(calibration.offset, 0.125, delta=0.002)
         self.assertAlmostEqual(calibration.scale, 1.35, delta=0.002)
 
+    def test_zero_mad_outliers_are_clipped(self):
+        channel_flux = np.linspace(0.0, 1.0, 61)
+        reference_flux = 0.25 + 1.4 * channel_flux
+        reference_flux[[0, 30, 60]] += np.array(
+            [5.0, -10.0, 5.0]
+        )
+
+        calibration = fit_instrument_channel_calibration(
+            reference_flux,
+            channel_flux,
+            reference_channel="reference",
+            channel="target",
+            wavelength=0.656,
+        )
+
+        self.assertEqual(calibration.n_pairs, 61)
+        self.assertEqual(calibration.n_inliers, 58)
+        self.assertAlmostEqual(
+            calibration.offset,
+            0.25,
+            places=12,
+        )
+        self.assertAlmostEqual(
+            calibration.scale,
+            1.4,
+            places=12,
+        )
+
     def test_optional_measurement_errors_are_supported(self):
         calibration = fit_instrument_channel_calibration(
             self.reference_flux,
@@ -156,6 +184,41 @@ class TestInstrumentChannelCalibrationFit(unittest.TestCase):
         )
         self.assertFalse(payload["automatic_time_matching"])
         self.assertFalse(payload["automatic_model_selection"])
+
+    def test_fit_method_is_normalized_and_type_checked(self):
+        common = {
+            "schema_version": (
+                INSTRUMENT_CHANNEL_CALIBRATION_MODEL_SCHEMA_VERSION
+            ),
+            "reference_channel": "reference",
+            "channel": "target",
+            "wavelength": 0.656,
+            "offset": 0.25,
+            "scale": 1.5,
+            "n_pairs": 20,
+            "n_inliers": 18,
+            "residual_mad_sigma": 0.01,
+        }
+
+        calibration = InstrumentChannelCalibration(
+            **common,
+            fit_method=" custom-affine ",
+        )
+
+        self.assertEqual(
+            calibration.fit_method,
+            "custom-affine",
+        )
+        json.dumps(calibration.to_dict(), allow_nan=False)
+
+        with self.assertRaisesRegex(
+            TypeError,
+            "fit_method must be a string",
+        ):
+            InstrumentChannelCalibration(
+                **common,
+                fit_method=object(),
+            )
 
 
 class TestInstrumentChannelCalibrationApply(unittest.TestCase):


### PR DESCRIPTION
## Summary

Implement the low-level instrument-channel calibration primitives defined by the preceding contract PR.

The implementation fits an explicit affine mapping:

```text
reference_flux = offset + scale * channel_flux
```

using caller-supplied paired measurements from two observational channels that share one physical wavelength.

## Implementation

- add a frozen, JSON-safe `InstrumentChannelCalibration` result model
- fit affine offset and strictly positive scale coefficients
- support optional reference- and channel-measurement uncertainties
- use iterative MAD clipping for discrepant paired measurements
- normalize and validate observational-channel identifiers
- reject malformed, insufficient, degenerate, and non-finite inputs
- apply fitted calibration onto the reference-channel flux scale
- propagate supplied flux errors through `abs(scale)`
- expose calibration-model schema and public symbols

## Scientific boundaries

This PR deliberately does **not**:

- construct temporal pairs from asynchronous light curves
- infer simultaneity
- choose a reference channel
- select between additive, multiplicative, affine, or other calibration families
- merge observational channels
- alter physical wavelength coordinates
- apply calibration automatically in `Lightcurve.fit`
- propagate uncertainty in the fitted offset or scale coefficients
- perform automatic model selection

The caller remains responsible for constructing scientifically justified paired measurements and explicitly selecting the affine calibration model.

## Wavelength-workflow behavior

Existing wavelength-estimation and representative-LPV workflows continue to exclude shared physical wavelengths when no explicit fitted mapping is supplied. Documentation and runtime language now distinguish that workflow limitation from the available low-level fit/apply API.

`TBD[instrument-channel-calibration]` remains open for:

- scientifically validated pair-construction rules
- dataset-level orchestration
- fitted-coefficient uncertainty propagation
- integration into normal light-curve workflows
- representative instrument/filter/LPV validation

## Validation

- 23 targeted instrument-channel calibration tests passed
- 2,572 full tests passed
- Ruff passed
- strict Sphinx documentation build passed
- documentation TBD-marker audit passed
- staged and committed diff checks passed
