### PR TITLE
Define instrument-channel pairing provenance

### DIFF
--- a/docs/source/future_work.rst
+++ b/docs/source/future_work.rst
@@ -113,10 +113,11 @@ Wavelength-model extensions
 ---------------------------
 
 **TBD[instrument-channel-calibration]**
-    The public low-level fitting and application callables now accept
-    caller-supplied paired measurements from distinct observational channels
-    and implement an explicit affine mapping.  This does not close the marker:
-    automatic pair construction, dataset-level orchestration across shared-
+    The public pairing record now preserves explicit row/time provenance,
+    while the low-level fitting and application callables accept caller-supplied
+    paired measurements and implement an affine mapping.  This does not close
+    the marker: scientifically validated automatic pair construction,
+    dataset-level orchestration across shared-
     wavelength observational channels, fitted-coefficient uncertainty
     propagation, workflow integration, and scientific validation remain future
     work.

--- a/docs/source/howto/multiband.rst
+++ b/docs/source/howto/multiband.rst
@@ -113,11 +113,12 @@ using the existing compatibility method::
 
 .. warning::
 
-   **TBD[instrument-channel-calibration]:** The low-level callables in
-   :mod:`pgmuvi.instrument_channel_calibration` can fit and apply an explicit
-   affine mapping from caller-supplied paired measurements.  They do not
-   construct time pairs, choose a calibration family, merge observational
-   channels, or integrate calibration automatically into a light-curve fit.
+   **TBD[instrument-channel-calibration]:** The pairing record and low-level
+   callables in :mod:`pgmuvi.instrument_channel_calibration` preserve explicit
+   caller-supplied pair provenance and can fit and apply an affine mapping.
+   They do not construct time pairs, choose a time tolerance, perform
+   interpolation, select a calibration family, merge observational channels,
+   or integrate calibration automatically into a light-curve fit.
 
 Visualising 2D Results
 -----------------------

--- a/docs/source/pgmuvi.instrument_channel_calibration.rst
+++ b/docs/source/pgmuvi.instrument_channel_calibration.rst
@@ -15,6 +15,14 @@ in which multiple observational channels share one physical wavelength, but it
 does not alter wavelengths, merge channels, average their measurements, or
 apply a correction.
 
+The :class:`~pgmuvi.instrument_channel_calibration.InstrumentChannelPairing`
+record provides a strict JSON-safe provenance contract for pairs already
+selected by the caller.  It records row indices, paired times, time units,
+reuse permissions, interpolation provenance, and derived time-separation
+summaries.  It validates structural consistency only: it does not determine
+whether a time separation, interpolation rule, or reuse policy is
+scientifically appropriate.
+
 The fitting API accepts **caller-supplied paired** flux measurements for one
 observational channel and an explicitly named reference channel.  It fits the
 affine mapping
@@ -29,8 +37,10 @@ where ``b`` is the stored offset and ``a`` is the strictly positive stored
 scale.  Optional measurement uncertainties contribute to weighted least
 squares, and iterative MAD clipping can reject discrepant pairs.
 
-PGMUVI does not construct time pairs from asynchronous light curves.  It also
-does not select between additive, multiplicative, affine, or other calibration
+PGMUVI does not construct time pairs from asynchronous light curves.  The
+pairing record does not perform nearest-neighbour matching, interpolation,
+cadence reconciliation, or reference-channel selection.  PGMUVI also does not
+select between additive, multiplicative, affine, or other calibration
 families.  Pair construction and the decision to use this explicit affine
 model remain the caller's scientific responsibility.
 
@@ -46,7 +56,8 @@ The low-level paired affine fit and application primitives do not complete the
 instrument-channel calibration work.  The marker remains open because PGMUVI
 still lacks:
 
-* scientifically validated rules for constructing calibration pairs;
+* scientifically validated rules and implementations for constructing
+  calibration pairs;
 * dataset-level orchestration across shared-wavelength channel groups;
 * propagation of fitted-coefficient uncertainty;
 * integration into the normal light-curve fitting workflow; and

--- a/docs/source/pgmuvi.wavelength_estimation.rst
+++ b/docs/source/pgmuvi.wavelength_estimation.rst
@@ -20,8 +20,10 @@ summaries and distinct physical wavelengths are reported separately.
 **TBD[instrument-channel-calibration]:** No instrument-channel calibration is
 performed by this wavelength-estimation workflow.  The low-level API in
 :mod:`pgmuvi.instrument_channel_calibration` can fit and apply an affine mapping
-from caller-supplied paired measurements, but this workflow does not construct
-such pairs or receive a fitted mapping.  When multiple usable observational
+from caller-supplied paired measurements, and its pairing record can preserve
+explicit row/time provenance.  This workflow does not construct or receive
+pairing records and does not receive a fitted mapping.  When multiple usable
+observational
 channels share one physical wavelength, their channel-level diagnostics are
 preserved while that wavelength is excluded from cross-wavelength trend
 summaries and wavelength-mean fits.  No flux summaries are silently combined,

--- a/pgmuvi/instrument_channel_calibration.py
+++ b/pgmuvi/instrument_channel_calibration.py
@@ -4,11 +4,11 @@ An observational channel identifies an instrument, detector, filter, or data
 stream.  It is distinct from the numeric physical wavelength coordinate used by
 the GP, and multiple observational channels may share one physical wavelength.
 
-This module provides an immutable, JSON-safe requirement assessment together
-with low-level fitting and application primitives for an explicit affine
-mapping between caller-paired measurements.  It does not construct temporal
-pairs, choose a calibration family, merge channels, alter wavelengths, or
-integrate calibration automatically into a light-curve fit.
+This module provides immutable, JSON-safe requirement and explicit-pairing
+records together with low-level fitting and application primitives for an
+affine mapping between caller-paired measurements.  It does not construct
+temporal pairs, choose a calibration family, merge channels, alter wavelengths,
+or integrate calibration automatically into a light-curve fit.
 """
 
 from __future__ import annotations
@@ -27,15 +27,20 @@ INSTRUMENT_CHANNEL_CALIBRATION_SCHEMA_VERSION = (
 INSTRUMENT_CHANNEL_CALIBRATION_TBD_MARKER = (
     "TBD[instrument-channel-calibration]"
 )
+INSTRUMENT_CHANNEL_PAIRING_SCHEMA_VERSION = (
+    "pgmuvi-instrument-channel-pairing-v1"
+)
 
 
 __all__ = [
     "INSTRUMENT_CHANNEL_CALIBRATION_MODEL_SCHEMA_VERSION",
     "INSTRUMENT_CHANNEL_CALIBRATION_SCHEMA_VERSION",
     "INSTRUMENT_CHANNEL_CALIBRATION_TBD_MARKER",
+    "INSTRUMENT_CHANNEL_PAIRING_SCHEMA_VERSION",
     "InstrumentChannelCalibration",
     "InstrumentChannelCalibrationAssessment",
     "InstrumentChannelCalibrationStatus",
+    "InstrumentChannelPairing",
     "SharedWavelengthChannelGroup",
     "apply_instrument_channel_calibration",
     "assess_instrument_channel_calibration_requirement",
@@ -277,6 +282,291 @@ def assess_instrument_channel_calibration_requirement(
         ),
     )
 
+
+
+@dataclass(frozen=True)
+class InstrumentChannelPairing:
+    """Caller-supplied pairing provenance for two observational channels.
+
+    This record describes pairs already selected by the caller. It validates
+    their structural consistency and preserves row and time provenance, but it
+    does not decide whether the pairing is scientifically appropriate.
+
+    No nearest-neighbour matching, interpolation, cadence reconciliation, or
+    automatic reference-channel selection is performed.
+    """
+
+    schema_version: str
+    reference_channel: str
+    channel: str
+    wavelength: float
+    reference_row_indices: tuple[int, ...]
+    channel_row_indices: tuple[int, ...]
+    reference_times: tuple[float, ...]
+    channel_times: tuple[float, ...]
+    time_unit: str
+    method: str = "caller_supplied_explicit_pairs"
+    allow_reference_reuse: bool = False
+    allow_channel_reuse: bool = False
+    interpolation_used: bool = False
+
+    def __post_init__(self) -> None:
+        if self.schema_version != (
+            INSTRUMENT_CHANNEL_PAIRING_SCHEMA_VERSION
+        ):
+            raise ValueError(
+                "Unsupported instrument-channel pairing schema version: "
+                f"{self.schema_version!r}."
+            )
+
+        reference_channel = _normalize_calibration_channel(
+            self.reference_channel,
+            name="reference_channel",
+        )
+        channel = _normalize_calibration_channel(
+            self.channel,
+            name="channel",
+        )
+        if reference_channel == channel:
+            raise ValueError(
+                "reference_channel and channel must identify different "
+                "observational channels."
+            )
+
+        wavelength = float(self.wavelength)
+        if not math.isfinite(wavelength):
+            raise ValueError("wavelength must be finite.")
+
+        reference_indices = self._normalize_indices(
+            self.reference_row_indices,
+            name="reference_row_indices",
+        )
+        channel_indices = self._normalize_indices(
+            self.channel_row_indices,
+            name="channel_row_indices",
+        )
+        reference_times = self._normalize_times(
+            self.reference_times,
+            name="reference_times",
+        )
+        channel_times = self._normalize_times(
+            self.channel_times,
+            name="channel_times",
+        )
+
+        lengths = {
+            len(reference_indices),
+            len(channel_indices),
+            len(reference_times),
+            len(channel_times),
+        }
+        if len(lengths) != 1:
+            raise ValueError(
+                "Pairing index and time sequences must have the same length."
+            )
+        if not reference_indices:
+            raise ValueError(
+                "Instrument-channel pairing requires at least one pair."
+            )
+
+        time_unit = self._normalize_text(
+            self.time_unit,
+            name="time_unit",
+        )
+        method = self._normalize_text(
+            self.method,
+            name="method",
+        )
+
+        for name in (
+            "allow_reference_reuse",
+            "allow_channel_reuse",
+            "interpolation_used",
+        ):
+            if not isinstance(getattr(self, name), bool):
+                raise TypeError(f"{name} must be a bool.")
+
+        if (
+            not self.allow_reference_reuse
+            and len(set(reference_indices)) != len(reference_indices)
+        ):
+            raise ValueError(
+                "reference_row_indices contain reused rows, but "
+                "allow_reference_reuse is False."
+            )
+        if (
+            not self.allow_channel_reuse
+            and len(set(channel_indices)) != len(channel_indices)
+        ):
+            raise ValueError(
+                "channel_row_indices contain reused rows, but "
+                "allow_channel_reuse is False."
+            )
+
+        object.__setattr__(
+            self,
+            "reference_channel",
+            reference_channel,
+        )
+        object.__setattr__(self, "channel", channel)
+        object.__setattr__(self, "wavelength", wavelength)
+        object.__setattr__(
+            self,
+            "reference_row_indices",
+            reference_indices,
+        )
+        object.__setattr__(
+            self,
+            "channel_row_indices",
+            channel_indices,
+        )
+        object.__setattr__(
+            self,
+            "reference_times",
+            reference_times,
+        )
+        object.__setattr__(self, "channel_times", channel_times)
+        object.__setattr__(self, "time_unit", time_unit)
+        object.__setattr__(self, "method", method)
+
+    @staticmethod
+    def _normalize_text(
+        value: Any,
+        *,
+        name: str,
+    ) -> str:
+        if not isinstance(value, str):
+            raise TypeError(f"{name} must be a string.")
+
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError(f"{name} must be non-empty.")
+
+        return normalized
+
+    @staticmethod
+    def _normalize_indices(
+        values: Any,
+        *,
+        name: str,
+    ) -> tuple[int, ...]:
+        try:
+            sequence = tuple(values)
+        except TypeError as exc:
+            raise TypeError(f"{name} must be an iterable of integers.") from exc
+
+        normalized: list[int] = []
+        for value in sequence:
+            if isinstance(value, bool) or not isinstance(
+                value,
+                (int, np.integer),
+            ):
+                raise TypeError(
+                    f"{name} must contain only integer row indices."
+                )
+
+            index = int(value)
+            if index < 0:
+                raise ValueError(
+                    f"{name} must contain only non-negative row indices."
+                )
+            normalized.append(index)
+
+        return tuple(normalized)
+
+    @staticmethod
+    def _normalize_times(
+        values: Any,
+        *,
+        name: str,
+    ) -> tuple[float, ...]:
+        try:
+            sequence = tuple(values)
+        except TypeError as exc:
+            raise TypeError(f"{name} must be an iterable of times.") from exc
+
+        normalized = tuple(float(value) for value in sequence)
+        if any(not math.isfinite(value) for value in normalized):
+            raise ValueError(f"{name} must contain only finite values.")
+
+        return normalized
+
+    @property
+    def n_pairs(self) -> int:
+        """Number of caller-supplied pairs."""
+
+        return len(self.reference_row_indices)
+
+    @property
+    def time_differences(self) -> tuple[float, ...]:
+        """Reference time minus channel time for every pair."""
+
+        return tuple(
+            reference_time - channel_time
+            for reference_time, channel_time in zip(
+                self.reference_times,
+                self.channel_times,
+                strict=True,
+            )
+        )
+
+    @property
+    def absolute_time_differences(self) -> tuple[float, ...]:
+        """Absolute time separation for every pair."""
+
+        return tuple(
+            abs(value)
+            for value in self.time_differences
+        )
+
+    @property
+    def usable_for_affine_calibration(self) -> bool:
+        """Whether the record meets the affine fitter's minimum pair count."""
+
+        return self.n_pairs >= 3
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a strict JSON-safe provenance representation."""
+
+        absolute_differences = np.asarray(
+            self.absolute_time_differences,
+            dtype=float,
+        )
+
+        return {
+            "schema_version": self.schema_version,
+            "reference_channel": self.reference_channel,
+            "channel": self.channel,
+            "wavelength": self.wavelength,
+            "reference_row_indices": list(
+                self.reference_row_indices
+            ),
+            "channel_row_indices": list(self.channel_row_indices),
+            "reference_times": list(self.reference_times),
+            "channel_times": list(self.channel_times),
+            "time_differences": list(self.time_differences),
+            "time_unit": self.time_unit,
+            "method": self.method,
+            "n_pairs": self.n_pairs,
+            "maximum_absolute_time_difference": float(
+                np.max(absolute_differences)
+            ),
+            "median_absolute_time_difference": float(
+                np.median(absolute_differences)
+            ),
+            "n_exact_time_matches": int(
+                np.count_nonzero(absolute_differences == 0.0)
+            ),
+            "allow_reference_reuse": self.allow_reference_reuse,
+            "allow_channel_reuse": self.allow_channel_reuse,
+            "interpolation_used": self.interpolation_used,
+            "usable_for_affine_calibration": (
+                self.usable_for_affine_calibration
+            ),
+            "caller_supplied_pairing": True,
+            "automatic_pair_construction": False,
+            "scientific_pairing_validation_performed": False,
+        }
 
 INSTRUMENT_CHANNEL_CALIBRATION_MODEL_SCHEMA_VERSION = "1.0"
 

--- a/pgmuvi/instrument_channel_calibration.py
+++ b/pgmuvi/instrument_channel_calibration.py
@@ -485,11 +485,22 @@ class InstrumentChannelPairing:
         except TypeError as exc:
             raise TypeError(f"{name} must be an iterable of times.") from exc
 
-        normalized = tuple(float(value) for value in sequence)
-        if any(not math.isfinite(value) for value in normalized):
-            raise ValueError(f"{name} must contain only finite values.")
+        normalized: list[float] = []
+        for value in sequence:
+            if isinstance(value, (bool, np.bool_)):
+                raise TypeError(
+                    f"{name} must contain numeric times, not boolean values."
+                )
 
-        return normalized
+            normalized_value = float(value)
+            if not math.isfinite(normalized_value):
+                raise ValueError(
+                    f"{name} must contain only finite values."
+                )
+
+            normalized.append(normalized_value)
+
+        return tuple(normalized)
 
     @property
     def n_pairs(self) -> int:

--- a/tests/test_docs_instrument_channel_calibration.py
+++ b/tests/test_docs_instrument_channel_calibration.py
@@ -31,6 +31,10 @@ class TestInstrumentChannelCalibrationDocumentation(unittest.TestCase):
             instrument_channel_calibration.__all__,
         )
         self.assertIn(
+            "InstrumentChannelPairing",
+            instrument_channel_calibration.__all__,
+        )
+        self.assertIn(
             "INSTRUMENT_CHANNEL_CALIBRATION_MODEL_SCHEMA_VERSION",
             instrument_channel_calibration.__all__,
         )
@@ -51,6 +55,9 @@ class TestInstrumentChannelCalibrationDocumentation(unittest.TestCase):
         text = PAGE.read_text(encoding="utf-8")
         self.assertIn("caller-supplied paired", text)
         self.assertIn("does not construct time pairs", text)
+        self.assertIn("row indices", text)
+        self.assertIn("time-separation", text)
+        self.assertIn("nearest-neighbour matching", text)
         self.assertIn("affine", text.lower())
         self.assertIn(
             "does not propagate uncertainty in the fitted offset or scale",
@@ -61,7 +68,8 @@ class TestInstrumentChannelCalibrationDocumentation(unittest.TestCase):
         text = " ".join(FUTURE.read_text(encoding="utf-8").split())
 
         self.assertIn("TBD[instrument-channel-calibration]", text)
-        self.assertIn("caller-supplied paired measurements", text)
+        self.assertIn("pairing record", text)
+        self.assertIn("caller-supplied", text)
         self.assertIn("does not close", text)
         self.assertIn("scientific validation", text)
 
@@ -84,7 +92,10 @@ class TestInstrumentChannelCalibrationDocumentation(unittest.TestCase):
             multiband,
         )
         normalized_multiband = " ".join(multiband.split())
-        self.assertIn("caller-supplied paired", normalized_multiband)
+        self.assertIn(
+            "caller-supplied pair provenance",
+            normalized_multiband,
+        )
         self.assertIn(
             "do not construct time pairs",
             normalized_multiband,

--- a/tests/test_instrument_channel_pairing_contract.py
+++ b/tests/test_instrument_channel_pairing_contract.py
@@ -1,0 +1,158 @@
+"""Contracts for caller-supplied instrument-channel pairing provenance."""
+
+from __future__ import annotations
+
+import json
+import unittest
+
+import numpy as np
+
+from pgmuvi.instrument_channel_calibration import (
+    INSTRUMENT_CHANNEL_PAIRING_SCHEMA_VERSION,
+    InstrumentChannelPairing,
+)
+
+
+class TestInstrumentChannelPairing(unittest.TestCase):
+    @staticmethod
+    def _pairing(**overrides):
+        values = {
+            "schema_version": (
+                INSTRUMENT_CHANNEL_PAIRING_SCHEMA_VERSION
+            ),
+            "reference_channel": "reference",
+            "channel": "target",
+            "wavelength": 0.656,
+            "reference_row_indices": (1, 4, 8),
+            "channel_row_indices": (2, 5, 9),
+            "reference_times": (10.0, 20.2, 30.0),
+            "channel_times": (10.0, 20.0, 30.4),
+            "time_unit": "day",
+        }
+        values.update(overrides)
+        return InstrumentChannelPairing(**values)
+
+    def test_explicit_pairing_is_immutable_and_json_safe(self):
+        pairing = self._pairing()
+
+        self.assertEqual(pairing.n_pairs, 3)
+        self.assertEqual(
+            pairing.time_differences,
+            (0.0, 0.1999999999999993, -0.3999999999999986),
+        )
+        self.assertTrue(pairing.usable_for_affine_calibration)
+
+        payload = pairing.to_dict()
+        self.assertEqual(
+            payload["schema_version"],
+            INSTRUMENT_CHANNEL_PAIRING_SCHEMA_VERSION,
+        )
+        self.assertTrue(payload["caller_supplied_pairing"])
+        self.assertFalse(payload["automatic_pair_construction"])
+        self.assertFalse(
+            payload["scientific_pairing_validation_performed"]
+        )
+        self.assertEqual(payload["n_pairs"], 3)
+        self.assertEqual(payload["n_exact_time_matches"], 1)
+        json.dumps(payload, allow_nan=False)
+
+    def test_pairing_normalizes_text_and_numpy_indices(self):
+        pairing = self._pairing(
+            reference_channel=" reference ",
+            channel=" target ",
+            reference_row_indices=(
+                np.int64(1),
+                np.int64(4),
+                np.int64(8),
+            ),
+            time_unit=" day ",
+            method=" explicit-user-selection ",
+        )
+
+        self.assertEqual(pairing.reference_channel, "reference")
+        self.assertEqual(pairing.channel, "target")
+        self.assertEqual(pairing.time_unit, "day")
+        self.assertEqual(
+            pairing.method,
+            "explicit-user-selection",
+        )
+        self.assertEqual(
+            pairing.reference_row_indices,
+            (1, 4, 8),
+        )
+
+    def test_mismatched_pairing_lengths_are_rejected(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "same length",
+        ):
+            self._pairing(channel_times=(10.0, 20.0))
+
+    def test_nonfinite_times_are_rejected(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "finite",
+        ):
+            self._pairing(
+                reference_times=(10.0, np.nan, 30.0),
+            )
+
+    def test_negative_or_boolean_indices_are_rejected(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "non-negative",
+        ):
+            self._pairing(
+                channel_row_indices=(2, -1, 9),
+            )
+
+        with self.assertRaisesRegex(
+            TypeError,
+            "integer row indices",
+        ):
+            self._pairing(
+                channel_row_indices=(2, True, 9),
+            )
+
+    def test_row_reuse_requires_explicit_permission(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "allow_reference_reuse is False",
+        ):
+            self._pairing(
+                reference_row_indices=(1, 1, 8),
+            )
+
+        pairing = self._pairing(
+            reference_row_indices=(1, 1, 8),
+            allow_reference_reuse=True,
+            interpolation_used=True,
+        )
+
+        self.assertTrue(pairing.allow_reference_reuse)
+        self.assertTrue(pairing.interpolation_used)
+
+    def test_fewer_than_three_pairs_are_recorded_but_not_fit_ready(self):
+        pairing = self._pairing(
+            reference_row_indices=(1, 4),
+            channel_row_indices=(2, 5),
+            reference_times=(10.0, 20.2),
+            channel_times=(10.0, 20.0),
+        )
+
+        self.assertEqual(pairing.n_pairs, 2)
+        self.assertFalse(pairing.usable_for_affine_calibration)
+        self.assertFalse(
+            pairing.to_dict()["usable_for_affine_calibration"]
+        )
+
+    def test_pairing_does_not_choose_channels_or_construct_matches(self):
+        payload = self._pairing().to_dict()
+
+        self.assertEqual(payload["reference_channel"], "reference")
+        self.assertEqual(payload["channel"], "target")
+        self.assertFalse(payload["automatic_pair_construction"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_instrument_channel_pairing_contract.py
+++ b/tests/test_instrument_channel_pairing_contract.py
@@ -97,6 +97,17 @@ class TestInstrumentChannelPairing(unittest.TestCase):
                 reference_times=(10.0, np.nan, 30.0),
             )
 
+    def test_boolean_times_are_rejected(self):
+        for value in (True, np.bool_(False)):
+            with self.subTest(value=value):
+                with self.assertRaisesRegex(
+                    TypeError,
+                    "numeric times, not boolean values",
+                ):
+                    self._pairing(
+                        channel_times=(10.0, value, 30.4),
+                    )
+
     def test_negative_or_boolean_indices_are_rejected(self):
         with self.assertRaisesRegex(
             ValueError,


### PR DESCRIPTION
## Summary

- add an immutable, strict JSON-safe `InstrumentChannelPairing` provenance record
- preserve caller-selected row indices, paired times, time units, row-reuse permissions, interpolation provenance, and time-separation summaries
- distinguish structural validation from scientific validation of pair construction
- record whether the supplied pair count meets the affine fitter's default minimum
- document that PGMUVI still does not choose reference channels, construct temporal matches, select tolerances, interpolate measurements, merge channels, or integrate calibration automatically
- keep `TBD[instrument-channel-calibration]` open for scientifically validated pair construction, dataset orchestration, fitted-coefficient uncertainty, workflow integration, and representative validation

## Validation

- focused pairing-contract tests: 8 passed
- calibration and documentation regressions: 29 passed
- full unit-test suite: 2,582 passed
- Ruff CI-equivalent check passed
- strict Sphinx documentation build passed
- `git diff --check` passed

## Scientific boundary

This PR defines provenance for pairs already selected by the caller. It does not implement automatic pair construction or claim that any supplied time separation, interpolation rule, row-reuse policy, or reference-channel choice is scientifically appropriate.
