### PR TITLE
Implement deterministic instrument-channel pair construction

### DIFF
--- a/docs/source/future_work.rst
+++ b/docs/source/future_work.rst
@@ -113,14 +113,14 @@ Wavelength-model extensions
 ---------------------------
 
 **TBD[instrument-channel-calibration]**
-    The public pairing record now preserves explicit row/time provenance,
-    while the low-level fitting and application callables accept caller-supplied
-    paired measurements and implement an affine mapping.  This does not close
-    the marker: scientifically validated automatic pair construction,
-    dataset-level orchestration across shared-
-    wavelength observational channels, fitted-coefficient uncertainty
-    propagation, workflow integration, and scientific validation remain future
-    work.
+    The public low-level API now constructs deterministic one-to-one
+    exact-timestamp or nearest-within-caller-tolerance pairs, preserves
+    row/time and construction provenance, and fits and applies an affine
+    mapping.  This does not close the marker: scientifically validated
+    instrument-specific tolerance guidance, dataset-level orchestration across
+    shared-wavelength observational channels, fitted-coefficient uncertainty
+    propagation, workflow integration, and representative calibration
+    validation remain future work.
 
 **TBD[multi-periodic-wavelength-models]**
     Add a documented and validated multi-periodic workflow beyond the current

--- a/docs/source/howto/multiband.rst
+++ b/docs/source/howto/multiband.rst
@@ -113,12 +113,13 @@ using the existing compatibility method::
 
 .. warning::
 
-   **TBD[instrument-channel-calibration]:** The pairing record and low-level
-   callables in :mod:`pgmuvi.instrument_channel_calibration` preserve explicit
-   caller-supplied pair provenance and can fit and apply an affine mapping.
-   They do not construct time pairs, choose a time tolerance, perform
-   interpolation, select a calibration family, merge observational channels,
-   or integrate calibration automatically into a light-curve fit.
+   **TBD[instrument-channel-calibration]:** The low-level API in
+   :mod:`pgmuvi.instrument_channel_calibration` can construct deterministic
+   one-to-one exact-time or nearest-within-caller-tolerance pairs, preserve
+   their provenance, and fit and apply an affine mapping.  It does not choose
+   the reference channel, pairing method, tolerance, or calibration family;
+   interpolate measurements; merge observational channels; or integrate
+   calibration automatically into a light-curve fit.
 
 Visualising 2D Results
 -----------------------

--- a/docs/source/pgmuvi.instrument_channel_calibration.rst
+++ b/docs/source/pgmuvi.instrument_channel_calibration.rst
@@ -16,12 +16,22 @@ does not alter wavelengths, merge channels, average their measurements, or
 apply a correction.
 
 The :class:`~pgmuvi.instrument_channel_calibration.InstrumentChannelPairing`
-record provides a strict JSON-safe provenance contract for pairs already
-selected by the caller.  It records row indices, paired times, time units,
-reuse permissions, interpolation provenance, and derived time-separation
-summaries.  It validates structural consistency only: it does not determine
-whether a time separation, interpolation rule, or reuse policy is
-scientifically appropriate.
+record provides a strict JSON-safe provenance contract for explicit pairs.  It
+records source-row indices, paired times, time units, construction provenance,
+the caller-supplied tolerance when applicable, unmatched counts, reuse policy,
+interpolation provenance, and derived time-separation summaries.
+
+:func:`~pgmuvi.instrument_channel_calibration.construct_instrument_channel_pairing`
+implements two caller-selected methods:
+
+* ``exact_timestamp`` pairs only numerically identical time coordinates;
+* ``nearest_within_tolerance`` requires a finite positive tolerance supplied by
+  the caller, maximizes the number of chronological one-to-one pairs, and then
+  minimizes their summed absolute time separation.
+
+The inputs must already share one time coordinate and unit.  PGMUVI does not
+infer or convert time systems in this callable.  It does not determine whether
+the selected method or tolerance is scientifically appropriate.
 
 The fitting API accepts **caller-supplied paired** flux measurements for one
 observational channel and an explicitly named reference channel.  It fits the
@@ -37,12 +47,16 @@ where ``b`` is the stored offset and ``a`` is the strictly positive stored
 scale.  Optional measurement uncertainties contribute to weighted least
 squares, and iterative MAD clipping can reject discrepant pairs.
 
-PGMUVI does not construct time pairs from asynchronous light curves.  The
-pairing record does not perform nearest-neighbour matching, interpolation,
-cadence reconciliation, or reference-channel selection.  PGMUVI also does not
-select between additive, multiplicative, affine, or other calibration
-families.  Pair construction and the decision to use this explicit affine
-model remain the caller's scientific responsibility.
+Pair construction is explicit rather than implicit: the caller selects
+the reference channel, method, and any non-zero tolerance.  The construction
+callable does not interpolate, reuse an observation, reconcile time systems,
+select a tolerance, or select a reference channel.  Non-exact pairs are
+described as nearest-within-tolerance pairs rather than as simultaneous
+measurements.
+
+PGMUVI also does not select between additive, multiplicative, affine, or other
+calibration families.  The pairing configuration and the decision to use this
+explicit affine model remain the caller's scientific responsibility.
 
 Applying a fitted calibration maps fluxes onto the reference-channel scale.
 Flux uncertainties are multiplied by the absolute fitted scale.  The current
@@ -56,8 +70,8 @@ The low-level paired affine fit and application primitives do not complete the
 instrument-channel calibration work.  The marker remains open because PGMUVI
 still lacks:
 
-* scientifically validated rules and implementations for constructing
-  calibration pairs;
+* scientifically validated instrument-specific rules for choosing
+  pairing methods and tolerances;
 * dataset-level orchestration across shared-wavelength channel groups;
 * propagation of fitted-coefficient uncertainty;
 * integration into the normal light-curve fitting workflow; and

--- a/docs/source/pgmuvi.instrument_channel_calibration.rst
+++ b/docs/source/pgmuvi.instrument_channel_calibration.rst
@@ -33,6 +33,11 @@ The inputs must already share one time coordinate and unit.  PGMUVI does not
 infer or convert time systems in this callable.  It does not determine whether
 the selected method or tolerance is scientifically appropriate.
 
+Both construction methods currently use a dynamic-programming grid with
+``O(n_reference * n_channel)`` time and memory cost.  Callers with large
+channels should restrict the input observations to the time range relevant to
+the calibration before constructing pairs.
+
 The fitting API accepts **caller-supplied paired** flux measurements for one
 observational channel and an explicitly named reference channel.  It fits the
 affine mapping

--- a/pgmuvi/instrument_channel_calibration.py
+++ b/pgmuvi/instrument_channel_calibration.py
@@ -29,7 +29,7 @@ INSTRUMENT_CHANNEL_CALIBRATION_TBD_MARKER = (
     "TBD[instrument-channel-calibration]"
 )
 INSTRUMENT_CHANNEL_PAIRING_SCHEMA_VERSION = (
-    "pgmuvi-instrument-channel-pairing-v1"
+    "pgmuvi-instrument-channel-pairing-v2"
 )
 
 
@@ -659,7 +659,7 @@ class InstrumentChannelPairing:
 
     @property
     def n_pairs(self) -> int:
-        """Number of caller-supplied pairs."""
+        """Number of recorded pairs."""
 
         return len(self.reference_row_indices)
 
@@ -952,6 +952,11 @@ def construct_instrument_channel_pairing(
     pairs and, among maximum-cardinality solutions, minimizes the summed
     absolute time separation. Deterministic tie-breaking favours earlier sorted
     observations.
+
+    Pair construction uses a dynamic-programming grid with
+    ``O(n_reference * n_channel)`` time and memory cost. Callers with large
+    channels should restrict inputs to the time range relevant to calibration
+    before invoking this callable.
 
     This callable does not interpolate, reuse observations, select a reference
     channel, choose a method or tolerance, fit a calibration, merge channels,

--- a/pgmuvi/instrument_channel_calibration.py
+++ b/pgmuvi/instrument_channel_calibration.py
@@ -4,11 +4,12 @@ An observational channel identifies an instrument, detector, filter, or data
 stream.  It is distinct from the numeric physical wavelength coordinate used by
 the GP, and multiple observational channels may share one physical wavelength.
 
-This module provides immutable, JSON-safe requirement and explicit-pairing
-records together with low-level fitting and application primitives for an
-affine mapping between caller-paired measurements.  It does not construct
-temporal pairs, choose a calibration family, merge channels, alter wavelengths,
-or integrate calibration automatically into a light-curve fit.
+This module provides immutable, JSON-safe requirement and pairing records,
+an explicit deterministic time-pair construction callable, and low-level
+fitting and application primitives for an affine mapping.  It does not choose
+a reference channel, pairing method, time tolerance, or calibration family;
+merge channels; alter wavelengths; or integrate calibration automatically into
+a light-curve fit.
 """
 
 from __future__ import annotations
@@ -41,9 +42,11 @@ __all__ = [
     "InstrumentChannelCalibrationAssessment",
     "InstrumentChannelCalibrationStatus",
     "InstrumentChannelPairing",
+    "InstrumentChannelPairingMethod",
     "SharedWavelengthChannelGroup",
     "apply_instrument_channel_calibration",
     "assess_instrument_channel_calibration_requirement",
+    "construct_instrument_channel_pairing",
     "fit_instrument_channel_calibration",
 ]
 
@@ -60,6 +63,13 @@ class InstrumentChannelCalibrationStatus(_StringEnum):
 
     NOT_REQUIRED = "not_required"
     REQUIRED_NOT_IMPLEMENTED = "required_not_implemented"
+
+
+class InstrumentChannelPairingMethod(_StringEnum):
+    """Caller-selected deterministic time-pair construction method."""
+
+    EXACT_TIMESTAMP = "exact_timestamp"
+    NEAREST_WITHIN_TOLERANCE = "nearest_within_tolerance"
 
 
 @dataclass(frozen=True)
@@ -286,14 +296,15 @@ def assess_instrument_channel_calibration_requirement(
 
 @dataclass(frozen=True)
 class InstrumentChannelPairing:
-    """Caller-supplied pairing provenance for two observational channels.
+    """Pairing provenance for two observational channels.
 
-    This record describes pairs already selected by the caller. It validates
-    their structural consistency and preserves row and time provenance, but it
-    does not decide whether the pairing is scientifically appropriate.
+    The record can describe pairs supplied directly by a caller or pairs
+    produced by :func:`construct_instrument_channel_pairing`. It preserves
+    source-row and time provenance without claiming that the caller-selected
+    method or tolerance is scientifically appropriate.
 
-    No nearest-neighbour matching, interpolation, cadence reconciliation, or
-    automatic reference-channel selection is performed.
+    Pair construction never interpolates measurements, reuses observations,
+    chooses a reference channel, or selects a method or tolerance.
     """
 
     schema_version: str
@@ -306,6 +317,10 @@ class InstrumentChannelPairing:
     channel_times: tuple[float, ...]
     time_unit: str
     method: str = "caller_supplied_explicit_pairs"
+    maximum_time_separation: float | None = None
+    pairing_source: str = "caller_supplied_explicit_pairs"
+    n_reference_observations: int | None = None
+    n_channel_observations: int | None = None
     allow_reference_reuse: bool = False
     allow_channel_reuse: bool = False
     interpolation_used: bool = False
@@ -377,6 +392,38 @@ class InstrumentChannelPairing:
             self.method,
             name="method",
         )
+        pairing_source = self._normalize_text(
+            self.pairing_source,
+            name="pairing_source",
+        )
+
+        maximum_time_separation = self.maximum_time_separation
+        if maximum_time_separation is not None:
+            if isinstance(
+                maximum_time_separation,
+                (bool, np.bool_),
+            ):
+                raise TypeError(
+                    "maximum_time_separation must be numeric, not boolean."
+                )
+            maximum_time_separation = float(maximum_time_separation)
+            if (
+                not math.isfinite(maximum_time_separation)
+                or maximum_time_separation < 0.0
+            ):
+                raise ValueError(
+                    "maximum_time_separation must be finite and "
+                    "non-negative when supplied."
+                )
+
+        n_reference_observations = self._normalize_optional_count(
+            self.n_reference_observations,
+            name="n_reference_observations",
+        )
+        n_channel_observations = self._normalize_optional_count(
+            self.n_channel_observations,
+            name="n_channel_observations",
+        )
 
         for name in (
             "allow_reference_reuse",
@@ -403,6 +450,78 @@ class InstrumentChannelPairing:
                 "allow_channel_reuse is False."
             )
 
+        if (
+            n_reference_observations is not None
+            and n_reference_observations < len(set(reference_indices))
+        ):
+            raise ValueError(
+                "n_reference_observations cannot be smaller than the "
+                "number of distinct matched reference rows."
+            )
+        if (
+            n_channel_observations is not None
+            and n_channel_observations < len(set(channel_indices))
+        ):
+            raise ValueError(
+                "n_channel_observations cannot be smaller than the "
+                "number of distinct matched channel rows."
+            )
+
+        absolute_time_differences = tuple(
+            abs(reference_time - channel_time)
+            for reference_time, channel_time in zip(
+                reference_times,
+                channel_times,
+                strict=True,
+            )
+        )
+
+        if method == InstrumentChannelPairingMethod.EXACT_TIMESTAMP.value:
+            if (
+                maximum_time_separation is not None
+                and maximum_time_separation != 0.0
+            ):
+                raise ValueError(
+                    "exact_timestamp pairing permits no non-zero "
+                    "maximum_time_separation."
+                )
+            if any(value != 0.0 for value in absolute_time_differences):
+                raise ValueError(
+                    "exact_timestamp pairing requires identical paired "
+                    "time coordinates."
+                )
+        elif (
+            method
+            == InstrumentChannelPairingMethod.NEAREST_WITHIN_TOLERANCE.value
+        ):
+            if (
+                maximum_time_separation is None
+                or maximum_time_separation <= 0.0
+            ):
+                raise ValueError(
+                    "nearest_within_tolerance pairing requires a finite "
+                    "positive maximum_time_separation."
+                )
+            if any(
+                value > maximum_time_separation
+                for value in absolute_time_differences
+            ):
+                raise ValueError(
+                    "A paired time separation exceeds "
+                    "maximum_time_separation."
+                )
+
+        if pairing_source == "pgmuvi_deterministic_time_matching":
+            if (
+                self.allow_reference_reuse
+                or self.allow_channel_reuse
+                or self.interpolation_used
+            ):
+                raise ValueError(
+                    "PGMUVI deterministic pair construction prohibits "
+                    "row reuse and interpolation."
+                )
+
         object.__setattr__(
             self,
             "reference_channel",
@@ -428,6 +547,22 @@ class InstrumentChannelPairing:
         object.__setattr__(self, "channel_times", channel_times)
         object.__setattr__(self, "time_unit", time_unit)
         object.__setattr__(self, "method", method)
+        object.__setattr__(
+            self,
+            "maximum_time_separation",
+            maximum_time_separation,
+        )
+        object.__setattr__(self, "pairing_source", pairing_source)
+        object.__setattr__(
+            self,
+            "n_reference_observations",
+            n_reference_observations,
+        )
+        object.__setattr__(
+            self,
+            "n_channel_observations",
+            n_channel_observations,
+        )
 
     @staticmethod
     def _normalize_text(
@@ -441,6 +576,26 @@ class InstrumentChannelPairing:
         normalized = value.strip()
         if not normalized:
             raise ValueError(f"{name} must be non-empty.")
+
+        return normalized
+
+    @staticmethod
+    def _normalize_optional_count(
+        value: Any,
+        *,
+        name: str,
+    ) -> int | None:
+        if value is None:
+            return None
+        if isinstance(value, (bool, np.bool_)) or not isinstance(
+            value,
+            (int, np.integer),
+        ):
+            raise TypeError(f"{name} must be an integer when supplied.")
+
+        normalized = int(value)
+        if normalized < 1:
+            raise ValueError(f"{name} must be at least 1 when supplied.")
 
         return normalized
 
@@ -558,6 +713,22 @@ class InstrumentChannelPairing:
             "time_differences": list(self.time_differences),
             "time_unit": self.time_unit,
             "method": self.method,
+            "maximum_time_separation": self.maximum_time_separation,
+            "pairing_source": self.pairing_source,
+            "n_reference_observations": self.n_reference_observations,
+            "n_channel_observations": self.n_channel_observations,
+            "n_unmatched_reference_observations": (
+                None
+                if self.n_reference_observations is None
+                else self.n_reference_observations
+                - len(set(self.reference_row_indices))
+            ),
+            "n_unmatched_channel_observations": (
+                None
+                if self.n_channel_observations is None
+                else self.n_channel_observations
+                - len(set(self.channel_row_indices))
+            ),
             "n_pairs": self.n_pairs,
             "maximum_absolute_time_difference": float(
                 np.max(absolute_differences)
@@ -574,10 +745,368 @@ class InstrumentChannelPairing:
             "usable_for_affine_calibration": (
                 self.usable_for_affine_calibration
             ),
-            "caller_supplied_pairing": True,
-            "automatic_pair_construction": False,
+            "caller_supplied_pairing": (
+                self.pairing_source == "caller_supplied_explicit_pairs"
+            ),
+            "automatic_pair_construction": (
+                self.pairing_source
+                == "pgmuvi_deterministic_time_matching"
+            ),
+            "automatic_reference_channel_selection": False,
+            "automatic_pairing_method_selection": False,
+            "automatic_time_tolerance_selection": False,
             "scientific_pairing_validation_performed": False,
         }
+
+
+def _normalize_pairing_method(
+    method: Any,
+) -> InstrumentChannelPairingMethod:
+    if isinstance(method, InstrumentChannelPairingMethod):
+        return method
+    if not isinstance(method, str):
+        raise TypeError(
+            "method must be an InstrumentChannelPairingMethod or string."
+        )
+
+    normalized = method.strip()
+    try:
+        return InstrumentChannelPairingMethod(normalized)
+    except ValueError as exc:
+        allowed = ", ".join(
+            member.value for member in InstrumentChannelPairingMethod
+        )
+        raise ValueError(
+            f"Unknown instrument-channel pairing method {method!r}; "
+            f"expected one of: {allowed}."
+        ) from exc
+
+
+def _normalize_pairing_source_indices(
+    values: Any | None,
+    *,
+    size: int,
+    name: str,
+) -> tuple[int, ...]:
+    if values is None:
+        return tuple(range(size))
+
+    normalized = InstrumentChannelPairing._normalize_indices(
+        values,
+        name=name,
+    )
+    if len(normalized) != size:
+        raise ValueError(
+            f"{name} must contain one source-row index per input time."
+        )
+    if len(set(normalized)) != len(normalized):
+        raise ValueError(
+            f"{name} must not identify the same source row more than once."
+        )
+
+    return normalized
+
+
+def _construct_monotonic_time_pairs(
+    reference_records: tuple[tuple[float, int, int], ...],
+    channel_records: tuple[tuple[float, int, int], ...],
+    *,
+    maximum_time_separation: float,
+) -> tuple[tuple[int, int], ...]:
+    """Maximize pair count, then minimize summed absolute separation."""
+
+    n_reference = len(reference_records)
+    n_channel = len(channel_records)
+
+    pair_counts = np.zeros(
+        (n_reference + 1, n_channel + 1),
+        dtype=np.int64,
+    )
+    total_separations = np.zeros(
+        (n_reference + 1, n_channel + 1),
+        dtype=float,
+    )
+    actions = np.zeros(
+        (n_reference, n_channel),
+        dtype=np.int8,
+    )
+
+    match_action = 1
+    skip_reference_action = 2
+    skip_channel_action = 3
+
+    for reference_position in range(n_reference - 1, -1, -1):
+        for channel_position in range(n_channel - 1, -1, -1):
+            candidates = [
+                (
+                    int(pair_counts[reference_position + 1, channel_position]),
+                    float(
+                        total_separations[
+                            reference_position + 1,
+                            channel_position,
+                        ]
+                    ),
+                    1,
+                    skip_reference_action,
+                ),
+                (
+                    int(pair_counts[reference_position, channel_position + 1]),
+                    float(
+                        total_separations[
+                            reference_position,
+                            channel_position + 1,
+                        ]
+                    ),
+                    2,
+                    skip_channel_action,
+                ),
+            ]
+
+            separation = abs(
+                reference_records[reference_position][0]
+                - channel_records[channel_position][0]
+            )
+            if separation <= maximum_time_separation:
+                candidates.append(
+                    (
+                        1
+                        + int(
+                            pair_counts[
+                                reference_position + 1,
+                                channel_position + 1,
+                            ]
+                        ),
+                        separation
+                        + float(
+                            total_separations[
+                                reference_position + 1,
+                                channel_position + 1,
+                            ]
+                        ),
+                        0,
+                        match_action,
+                    )
+                )
+
+            best = max(
+                candidates,
+                key=lambda candidate: (
+                    candidate[0],
+                    -candidate[1],
+                    -candidate[2],
+                ),
+            )
+            pair_counts[reference_position, channel_position] = best[0]
+            total_separations[
+                reference_position,
+                channel_position,
+            ] = best[1]
+            actions[reference_position, channel_position] = best[3]
+
+    pairs: list[tuple[int, int]] = []
+    reference_position = 0
+    channel_position = 0
+
+    while (
+        reference_position < n_reference
+        and channel_position < n_channel
+    ):
+        action = int(actions[reference_position, channel_position])
+        if action == match_action:
+            pairs.append((reference_position, channel_position))
+            reference_position += 1
+            channel_position += 1
+        elif action == skip_reference_action:
+            reference_position += 1
+        elif action == skip_channel_action:
+            channel_position += 1
+        else:
+            raise RuntimeError(
+                "Internal instrument-channel pairing reconstruction failed."
+            )
+
+    return tuple(pairs)
+
+
+def construct_instrument_channel_pairing(
+    reference_times: Any,
+    channel_times: Any,
+    *,
+    reference_channel: str,
+    channel: str,
+    wavelength: float,
+    time_unit: str,
+    method: InstrumentChannelPairingMethod | str,
+    maximum_time_separation: float | None = None,
+    reference_row_indices: Any | None = None,
+    channel_row_indices: Any | None = None,
+) -> InstrumentChannelPairing:
+    """Construct deterministic one-to-one time pairs.
+
+    The caller must explicitly choose the reference channel, pairing method,
+    and—when using nearest-within-tolerance matching—the positive maximum time
+    separation. Inputs must already use the same time coordinate and unit.
+
+    Exact matching accepts only numerically identical timestamps. Nearest-
+    within-tolerance matching maximizes the number of chronological one-to-one
+    pairs and, among maximum-cardinality solutions, minimizes the summed
+    absolute time separation. Deterministic tie-breaking favours earlier sorted
+    observations.
+
+    This callable does not interpolate, reuse observations, select a reference
+    channel, choose a method or tolerance, fit a calibration, merge channels,
+    or claim that the selected tolerance is scientifically appropriate.
+    """
+
+    normalized_method = _normalize_pairing_method(method)
+
+    normalized_reference_times = InstrumentChannelPairing._normalize_times(
+        reference_times,
+        name="reference_times",
+    )
+    normalized_channel_times = InstrumentChannelPairing._normalize_times(
+        channel_times,
+        name="channel_times",
+    )
+
+    if not normalized_reference_times:
+        raise ValueError("reference_times must contain at least one value.")
+    if not normalized_channel_times:
+        raise ValueError("channel_times must contain at least one value.")
+
+    normalized_reference_indices = _normalize_pairing_source_indices(
+        reference_row_indices,
+        size=len(normalized_reference_times),
+        name="reference_row_indices",
+    )
+    normalized_channel_indices = _normalize_pairing_source_indices(
+        channel_row_indices,
+        size=len(normalized_channel_times),
+        name="channel_row_indices",
+    )
+
+    if normalized_method is InstrumentChannelPairingMethod.EXACT_TIMESTAMP:
+        if maximum_time_separation is None:
+            normalized_maximum_separation = 0.0
+            recorded_maximum_separation = None
+        else:
+            if isinstance(
+                maximum_time_separation,
+                (bool, np.bool_),
+            ):
+                raise TypeError(
+                    "maximum_time_separation must be numeric, not boolean."
+                )
+            normalized_maximum_separation = float(
+                maximum_time_separation
+            )
+            if normalized_maximum_separation != 0.0:
+                raise ValueError(
+                    "exact_timestamp pairing requires "
+                    "maximum_time_separation to be None or zero."
+                )
+            recorded_maximum_separation = 0.0
+    else:
+        if maximum_time_separation is None:
+            raise ValueError(
+                "nearest_within_tolerance pairing requires "
+                "maximum_time_separation."
+            )
+        if isinstance(maximum_time_separation, (bool, np.bool_)):
+            raise TypeError(
+                "maximum_time_separation must be numeric, not boolean."
+            )
+
+        normalized_maximum_separation = float(maximum_time_separation)
+        if (
+            not math.isfinite(normalized_maximum_separation)
+            or normalized_maximum_separation <= 0.0
+        ):
+            raise ValueError(
+                "nearest_within_tolerance pairing requires a finite "
+                "positive maximum_time_separation."
+            )
+        recorded_maximum_separation = normalized_maximum_separation
+
+    reference_records = tuple(
+        sorted(
+            (
+                (time_value, row_index, input_position)
+                for input_position, (time_value, row_index) in enumerate(
+                    zip(
+                        normalized_reference_times,
+                        normalized_reference_indices,
+                        strict=True,
+                    )
+                )
+            ),
+            key=lambda record: (record[0], record[1], record[2]),
+        )
+    )
+    channel_records = tuple(
+        sorted(
+            (
+                (time_value, row_index, input_position)
+                for input_position, (time_value, row_index) in enumerate(
+                    zip(
+                        normalized_channel_times,
+                        normalized_channel_indices,
+                        strict=True,
+                    )
+                )
+            ),
+            key=lambda record: (record[0], record[1], record[2]),
+        )
+    )
+
+    matched_positions = _construct_monotonic_time_pairs(
+        reference_records,
+        channel_records,
+        maximum_time_separation=normalized_maximum_separation,
+    )
+    if not matched_positions:
+        raise ValueError(
+            "No eligible one-to-one instrument-channel time pairs were "
+            "found for the caller-selected method and tolerance."
+        )
+
+    matched_reference_records = tuple(
+        reference_records[reference_position]
+        for reference_position, _ in matched_positions
+    )
+    matched_channel_records = tuple(
+        channel_records[channel_position]
+        for _, channel_position in matched_positions
+    )
+
+    return InstrumentChannelPairing(
+        schema_version=INSTRUMENT_CHANNEL_PAIRING_SCHEMA_VERSION,
+        reference_channel=reference_channel,
+        channel=channel,
+        wavelength=wavelength,
+        reference_row_indices=tuple(
+            record[1] for record in matched_reference_records
+        ),
+        channel_row_indices=tuple(
+            record[1] for record in matched_channel_records
+        ),
+        reference_times=tuple(
+            record[0] for record in matched_reference_records
+        ),
+        channel_times=tuple(
+            record[0] for record in matched_channel_records
+        ),
+        time_unit=time_unit,
+        method=normalized_method.value,
+        maximum_time_separation=recorded_maximum_separation,
+        pairing_source="pgmuvi_deterministic_time_matching",
+        n_reference_observations=len(normalized_reference_times),
+        n_channel_observations=len(normalized_channel_times),
+        allow_reference_reuse=False,
+        allow_channel_reuse=False,
+        interpolation_used=False,
+    )
+
 
 INSTRUMENT_CHANNEL_CALIBRATION_MODEL_SCHEMA_VERSION = "1.0"
 

--- a/tests/test_docs_instrument_channel_calibration.py
+++ b/tests/test_docs_instrument_channel_calibration.py
@@ -54,10 +54,10 @@ class TestInstrumentChannelCalibrationDocumentation(unittest.TestCase):
     def test_page_documents_explicit_paired_calibration(self):
         text = PAGE.read_text(encoding="utf-8")
         self.assertIn("caller-supplied paired", text)
-        self.assertIn("does not construct time pairs", text)
+        self.assertIn("construct_instrument_channel_pairing", text)
         self.assertIn("row indices", text)
         self.assertIn("time-separation", text)
-        self.assertIn("nearest-neighbour matching", text)
+        self.assertIn("nearest_within_tolerance", text)
         self.assertIn("affine", text.lower())
         self.assertIn(
             "does not propagate uncertainty in the fitted offset or scale",
@@ -68,10 +68,13 @@ class TestInstrumentChannelCalibrationDocumentation(unittest.TestCase):
         text = " ".join(FUTURE.read_text(encoding="utf-8").split())
 
         self.assertIn("TBD[instrument-channel-calibration]", text)
-        self.assertIn("pairing record", text)
-        self.assertIn("caller-supplied", text)
+        self.assertIn("low-level API", text)
+        self.assertIn("caller-tolerance", text)
         self.assertIn("does not close", text)
-        self.assertIn("scientific validation", text)
+        self.assertIn(
+            "representative calibration validation",
+            text,
+        )
 
     def test_estimation_and_multiband_guides_reference_contract(self):
         estimation = ESTIMATION.read_text(encoding="utf-8")
@@ -93,11 +96,15 @@ class TestInstrumentChannelCalibrationDocumentation(unittest.TestCase):
         )
         normalized_multiband = " ".join(multiband.split())
         self.assertIn(
-            "caller-supplied pair provenance",
+            "preserve their provenance",
             normalized_multiband,
         )
         self.assertIn(
-            "do not construct time pairs",
+            "construct deterministic one-to-one",
+            normalized_multiband,
+        )
+        self.assertIn(
+            "does not choose the reference channel",
             normalized_multiband,
         )
         self.assertNotIn("NotImplementedError", normalized_multiband)

--- a/tests/test_docs_instrument_channel_calibration.py
+++ b/tests/test_docs_instrument_channel_calibration.py
@@ -58,6 +58,8 @@ class TestInstrumentChannelCalibrationDocumentation(unittest.TestCase):
         self.assertIn("row indices", text)
         self.assertIn("time-separation", text)
         self.assertIn("nearest_within_tolerance", text)
+        self.assertIn("O(n_reference * n_channel)", text)
+        self.assertIn("time and memory cost", text)
         self.assertIn("affine", text.lower())
         self.assertIn(
             "does not propagate uncertainty in the fitted offset or scale",

--- a/tests/test_instrument_channel_pair_construction.py
+++ b/tests/test_instrument_channel_pair_construction.py
@@ -41,6 +41,10 @@ class TestInstrumentChannelPairConstruction(unittest.TestCase):
             pairing.method,
             InstrumentChannelPairingMethod.EXACT_TIMESTAMP.value,
         )
+        self.assertEqual(
+            pairing.schema_version,
+            "pgmuvi-instrument-channel-pairing-v2",
+        )
         self.assertIsNone(pairing.maximum_time_separation)
         self.assertEqual(len(set(pairing.reference_row_indices)), 3)
         self.assertEqual(len(set(pairing.channel_row_indices)), 3)

--- a/tests/test_instrument_channel_pair_construction.py
+++ b/tests/test_instrument_channel_pair_construction.py
@@ -1,0 +1,176 @@
+"""Deterministic instrument-channel time-pair construction tests."""
+
+from __future__ import annotations
+
+import json
+import unittest
+
+import numpy as np
+
+from pgmuvi.instrument_channel_calibration import (
+    InstrumentChannelPairingMethod,
+    construct_instrument_channel_pairing,
+)
+
+
+class TestInstrumentChannelPairConstruction(unittest.TestCase):
+    @staticmethod
+    def _construct(**overrides):
+        values = {
+            "reference_times": (30.0, 10.0, 20.0),
+            "channel_times": (20.0, 30.0, 10.0),
+            "reference_channel": "reference",
+            "channel": "target",
+            "wavelength": 0.656,
+            "time_unit": "day",
+            "method": InstrumentChannelPairingMethod.EXACT_TIMESTAMP,
+            "reference_row_indices": (30, 10, 20),
+            "channel_row_indices": (200, 300, 100),
+        }
+        values.update(overrides)
+        return construct_instrument_channel_pairing(**values)
+
+    def test_exact_timestamp_matching_is_sorted_and_one_to_one(self):
+        pairing = self._construct()
+
+        self.assertEqual(pairing.reference_times, (10.0, 20.0, 30.0))
+        self.assertEqual(pairing.channel_times, (10.0, 20.0, 30.0))
+        self.assertEqual(pairing.reference_row_indices, (10, 20, 30))
+        self.assertEqual(pairing.channel_row_indices, (100, 200, 300))
+        self.assertEqual(
+            pairing.method,
+            InstrumentChannelPairingMethod.EXACT_TIMESTAMP.value,
+        )
+        self.assertIsNone(pairing.maximum_time_separation)
+        self.assertEqual(len(set(pairing.reference_row_indices)), 3)
+        self.assertEqual(len(set(pairing.channel_row_indices)), 3)
+
+    def test_duplicate_exact_times_are_matched_deterministically(self):
+        pairing = self._construct(
+            reference_times=(1.0, 1.0, 2.0),
+            channel_times=(1.0, 2.0, 1.0),
+            reference_row_indices=(8, 4, 12),
+            channel_row_indices=(9, 13, 5),
+        )
+
+        self.assertEqual(pairing.reference_row_indices, (4, 8, 12))
+        self.assertEqual(pairing.channel_row_indices, (5, 9, 13))
+
+    def test_nearest_matching_maximizes_pair_count_before_separation(self):
+        pairing = self._construct(
+            reference_times=(0.9, 1.1),
+            channel_times=(0.0, 1.0),
+            reference_row_indices=(9, 11),
+            channel_row_indices=(0, 10),
+            method=(
+                InstrumentChannelPairingMethod.NEAREST_WITHIN_TOLERANCE
+            ),
+            maximum_time_separation=1.0,
+        )
+
+        self.assertEqual(pairing.n_pairs, 2)
+        self.assertEqual(pairing.reference_row_indices, (9, 11))
+        self.assertEqual(pairing.channel_row_indices, (0, 10))
+        np.testing.assert_allclose(
+            pairing.time_differences,
+            (0.9, 0.1),
+            rtol=0.0,
+            atol=1.0e-15,
+        )
+
+    def test_equal_separation_tie_uses_earlier_sorted_observation(self):
+        pairing = self._construct(
+            reference_times=(1.0,),
+            channel_times=(1.5, 0.5),
+            reference_row_indices=(10,),
+            channel_row_indices=(15, 5),
+            method="nearest_within_tolerance",
+            maximum_time_separation=0.5,
+        )
+
+        self.assertEqual(pairing.channel_times, (0.5,))
+        self.assertEqual(pairing.channel_row_indices, (5,))
+
+    def test_nearest_matching_requires_positive_tolerance(self):
+        for value in (None, 0.0, -1.0, np.inf):
+            with self.subTest(value=value):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "finite positive|requires maximum_time_separation",
+                ):
+                    self._construct(
+                        method="nearest_within_tolerance",
+                        maximum_time_separation=value,
+                    )
+
+    def test_exact_matching_rejects_nonzero_tolerance(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "None or zero",
+        ):
+            self._construct(maximum_time_separation=0.1)
+
+    def test_no_eligible_pairs_are_reported(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "No eligible one-to-one",
+        ):
+            self._construct(
+                reference_times=(1.0, 2.0),
+                channel_times=(10.0, 20.0),
+                reference_row_indices=(1, 2),
+                channel_row_indices=(10, 20),
+            )
+
+    def test_duplicate_source_row_indices_are_rejected(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "same source row",
+        ):
+            self._construct(
+                reference_row_indices=(1, 1, 2),
+            )
+
+    def test_unknown_method_is_rejected(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "Unknown instrument-channel pairing method",
+        ):
+            self._construct(method="automatic")
+
+    def test_boolean_tolerance_is_rejected(self):
+        with self.assertRaisesRegex(
+            TypeError,
+            "numeric, not boolean",
+        ):
+            self._construct(
+                method="nearest_within_tolerance",
+                maximum_time_separation=True,
+            )
+
+    def test_payload_records_construction_scope_and_unmatched_counts(self):
+        pairing = self._construct(
+            reference_times=(1.0, 2.0, 3.0),
+            channel_times=(1.0, 3.0),
+            reference_row_indices=(10, 20, 30),
+            channel_row_indices=(100, 300),
+        )
+
+        payload = pairing.to_dict()
+        self.assertFalse(payload["caller_supplied_pairing"])
+        self.assertTrue(payload["automatic_pair_construction"])
+        self.assertFalse(payload["automatic_reference_channel_selection"])
+        self.assertFalse(payload["automatic_pairing_method_selection"])
+        self.assertFalse(payload["automatic_time_tolerance_selection"])
+        self.assertFalse(payload["allow_reference_reuse"])
+        self.assertFalse(payload["allow_channel_reuse"])
+        self.assertFalse(payload["interpolation_used"])
+        self.assertEqual(payload["n_reference_observations"], 3)
+        self.assertEqual(payload["n_channel_observations"], 2)
+        self.assertEqual(payload["n_unmatched_reference_observations"], 1)
+        self.assertEqual(payload["n_unmatched_channel_observations"], 0)
+        json.dumps(payload, allow_nan=False)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_instrument_channel_pairing_contract.py
+++ b/tests/test_instrument_channel_pairing_contract.py
@@ -14,6 +14,12 @@ from pgmuvi.instrument_channel_calibration import (
 
 
 class TestInstrumentChannelPairing(unittest.TestCase):
+    def test_current_schema_version_is_v2(self):
+        self.assertEqual(
+            INSTRUMENT_CHANNEL_PAIRING_SCHEMA_VERSION,
+            "pgmuvi-instrument-channel-pairing-v2",
+        )
+
     @staticmethod
     def _pairing(**overrides):
         values = {
@@ -80,6 +86,15 @@ class TestInstrumentChannelPairing(unittest.TestCase):
             pairing.reference_row_indices,
             (1, 4, 8),
         )
+
+    def test_previous_schema_version_is_rejected(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "Unsupported instrument-channel pairing schema version",
+        ):
+            self._pairing(
+                schema_version="pgmuvi-instrument-channel-pairing-v1",
+            )
 
     def test_mismatched_pairing_lengths_are_rejected(self):
         with self.assertRaisesRegex(


### PR DESCRIPTION
## Summary

Implement a public, deterministic low-level API for constructing one-to-one temporal pairs between observational channels that share a physical wavelength.

The caller must explicitly choose:

- the reference channel;
- the target channel;
- the pairing method; and
- any non-zero maximum time separation.

Supported methods are:

- `exact_timestamp`;
- `nearest_within_tolerance`.

## Pair-construction behavior

Nearest-within-tolerance matching:

1. maximizes the number of chronological one-to-one pairs;
2. minimizes the summed absolute time separation among maximum-cardinality solutions; and
3. uses deterministic ordering to resolve remaining ties.

The implementation does not:

- interpolate measurements;
- reuse observations;
- select a reference channel;
- select a pairing method or tolerance;
- reconcile time-coordinate systems;
- select a calibration family;
- merge observational channels;
- alter physical wavelengths; or
- integrate calibration automatically into `Lightcurve.fit()`.

Non-exact pairs are described only as nearest-within-tolerance pairs, not as simultaneous measurements.

## Provenance

Extend the immutable JSON-safe `InstrumentChannelPairing` record with:

- construction source;
- caller-supplied maximum separation;
- input observation counts;
- unmatched observation counts;
- explicit automatic-selection flags; and
- existing row, time, reuse, and interpolation provenance.

Caller-supplied explicit pairing remains supported.

## Documentation

Update the calibration API page, multiband guide, and future-work registry.

`TBD[instrument-channel-calibration]` remains open for:

- scientifically validated instrument-specific tolerance guidance;
- dataset-level orchestration;
- fitted-coefficient uncertainty propagation;
- normal workflow integration; and
- representative calibration validation.

## Validation

- Exhaustive small-grid oracle: 4,624 cases passed
- Pair-construction tests: 11 passed
- Pairing-contract regressions: 9 passed
- Calibration and documentation regressions: 29 passed
- Ruff: passed
- Documentation marker audit: passed
- Strict Sphinx documentation build: passed
- Full test suite: 2,594 tests passed
