### PR TITLE
Implement instrument-channel calibration orchestration

### DIFF
--- a/docs/source/future_work.rst
+++ b/docs/source/future_work.rst
@@ -116,12 +116,13 @@ Wavelength-model extensions
     The public low-level API now constructs deterministic one-to-one
     exact-timestamp or nearest-within-caller-tolerance pairs, preserves
     row/time and construction provenance, fits and applies an affine mapping,
-    and defines an inert JSON-safe dataset-level orchestration plan contract.
-    This does not close the marker: scientifically validated instrument-specific
-    tolerance guidance, execution of orchestration plans across
-    shared-wavelength observational channels, fitted-coefficient uncertainty
-    propagation, workflow integration, and representative calibration
-    validation remain future work.
+    defines an inert JSON-safe dataset-level orchestration plan contract, and
+    executes caller-authored plans across shared-wavelength observational channels
+    into copied calibrated arrays with completed pairing and fit
+    provenance. This does not close the marker: scientifically
+    validated instrument-specific tolerance guidance, fitted-coefficient
+    uncertainty propagation, workflow integration, and representative
+    calibration validation remain future work.
 
 **TBD[multi-periodic-wavelength-models]**
     Add a documented and validated multi-periodic workflow beyond the current

--- a/docs/source/howto/multiband.rst
+++ b/docs/source/howto/multiband.rst
@@ -116,11 +116,13 @@ using the existing compatibility method::
    **TBD[instrument-channel-calibration]:** The low-level API in
    :mod:`pgmuvi.instrument_channel_calibration` can construct deterministic
    one-to-one exact-time or nearest-within-caller-tolerance pairs, preserve
-   their provenance, fit and apply an affine mapping, and record explicit
-   dataset-level plans across shared-wavelength groups.  It does not choose the
-   reference channel, pairing method, tolerance, or calibration family; execute
-   an orchestration plan; interpolate measurements; merge observational
-   channels; or integrate calibration automatically into a light-curve fit.
+   their provenance, fit and apply an affine mapping, record explicit
+   dataset-level plans across shared-wavelength groups, and execute only the
+   choices recorded in those plans. Execution returns copied arrays and
+   completed provenance; it does not choose the reference channel, pairing
+   method, tolerance, or calibration family; interpolate measurements; mutate
+   input arrays; merge observational channels; propagate fitted-coefficient
+   uncertainty; or integrate calibration automatically into a light-curve fit.
 
 Visualising 2D Results
 -----------------------

--- a/docs/source/pgmuvi.instrument_channel_calibration.rst
+++ b/docs/source/pgmuvi.instrument_channel_calibration.rst
@@ -60,6 +60,26 @@ records can be attached to preserve pairing and fitted-coefficient provenance.
 The plan itself does not construct pairs, fit or apply mappings, merge channels,
 alter wavelengths, mutate a light curve, or integrate calibration into fitting.
 
+Executing an explicit plan
+--------------------------
+
+The
+:func:`~pgmuvi.instrument_channel_calibration.execute_instrument_channel_calibration_plan`
+callable executes only the choices recorded in an
+:class:`~pgmuvi.instrument_channel_calibration.InstrumentChannelCalibrationPlan`.
+For each ``planned`` entry it reuses attached provenance when present, or
+constructs pairs using the recorded method and tolerance, fits the recorded
+``affine`` family, and applies the mapping to all rows of that target channel at
+the shared wavelength. ``skipped`` and ``unavailable`` entries remain unchanged.
+
+Execution returns an immutable
+:class:`~pgmuvi.instrument_channel_calibration.InstrumentChannelCalibrationExecution`
+containing copied calibrated arrays, the exact source-row indices transformed,
+and a completed plan with pairing and fitted calibration provenance. It
+does not mutate input arrays, merge channels, alter wavelengths, choose
+scientific configuration automatically, propagate fitted-
+coefficient uncertainty, or integrate calibration into ``Lightcurve.fit()``.
+
 The fitting API accepts **caller-supplied paired** flux measurements for one
 observational channel and an explicitly named reference channel.  It fits the
 affine mapping
@@ -99,8 +119,6 @@ still lacks:
 
 * scientifically validated instrument-specific rules for choosing
   pairing methods and tolerances;
-* execution of dataset-level orchestration plans across
-  shared-wavelength channel groups;
 * propagation of fitted-coefficient uncertainty;
 * integration into the normal light-curve fitting workflow; and
 * validation across representative instruments, filters, and LPV sources.

--- a/pgmuvi/instrument_channel_calibration.py
+++ b/pgmuvi/instrument_channel_calibration.py
@@ -2073,7 +2073,17 @@ def _as_finite_execution_vector(
     non_negative: bool = False,
 ) -> np.ndarray:
     raw = np.asarray(values)
-    if raw.dtype.kind == "b":
+    contains_boolean = (
+        raw.dtype.kind == "b"
+        or (
+            raw.dtype.kind == "O"
+            and any(
+                isinstance(value, (bool, np.bool_))
+                for value in raw.flat
+            )
+        )
+    )
+    if contains_boolean:
         raise TypeError(
             f"{name} must contain numeric values, not booleans."
         )

--- a/pgmuvi/instrument_channel_calibration.py
+++ b/pgmuvi/instrument_channel_calibration.py
@@ -5,9 +5,9 @@ stream.  It is distinct from the numeric physical wavelength coordinate used by
 the GP, and multiple observational channels may share one physical wavelength.
 
 This module provides immutable, JSON-safe requirement, pairing, and
-dataset-level orchestration records, an explicit deterministic time-pair
-construction callable, and low-level fitting and application primitives for an
-affine mapping.  It does not choose
+dataset-level orchestration records and execution results, explicit
+deterministic time-pair construction and plan-execution callables, and low-level
+fitting and application primitives for an affine mapping.  It does not choose
 a reference channel, pairing method, time tolerance, or calibration family;
 merge channels; alter wavelengths; or integrate calibration automatically into
 a light-curve fit.
@@ -15,7 +15,7 @@ a light-curve fit.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from enum import Enum
 import math
 from typing import Any
@@ -35,9 +35,13 @@ INSTRUMENT_CHANNEL_PAIRING_SCHEMA_VERSION = (
 INSTRUMENT_CHANNEL_CALIBRATION_PLAN_SCHEMA_VERSION = (
     "pgmuvi-instrument-channel-calibration-plan-v1"
 )
+INSTRUMENT_CHANNEL_CALIBRATION_EXECUTION_SCHEMA_VERSION = (
+    "pgmuvi-instrument-channel-calibration-execution-v1"
+)
 
 
 __all__ = [
+    "INSTRUMENT_CHANNEL_CALIBRATION_EXECUTION_SCHEMA_VERSION",
     "INSTRUMENT_CHANNEL_CALIBRATION_MODEL_SCHEMA_VERSION",
     "INSTRUMENT_CHANNEL_CALIBRATION_PLAN_SCHEMA_VERSION",
     "INSTRUMENT_CHANNEL_CALIBRATION_SCHEMA_VERSION",
@@ -47,6 +51,7 @@ __all__ = [
     "InstrumentChannelCalibrationAssessment",
     "InstrumentChannelCalibrationChannelPlan",
     "InstrumentChannelCalibrationDisposition",
+    "InstrumentChannelCalibrationExecution",
     "InstrumentChannelCalibrationGroupPlan",
     "InstrumentChannelCalibrationPlan",
     "InstrumentChannelCalibrationStatus",
@@ -57,6 +62,7 @@ __all__ = [
     "assess_instrument_channel_calibration_requirement",
     "construct_instrument_channel_pairing",
     "define_instrument_channel_calibration_plan",
+    "execute_instrument_channel_calibration_plan",
     "fit_instrument_channel_calibration",
 ]
 
@@ -1835,6 +1841,647 @@ def define_instrument_channel_calibration_plan(
         ),
         assessment=assessment,
         group_plans=tuple(group_plans),
+    )
+
+
+@dataclass(frozen=True)
+class InstrumentChannelCalibrationExecution:
+    """Immutable result of executing an explicit calibration plan.
+
+    The result contains copied calibrated arrays and a completed plan carrying
+    the pairing and affine-calibration provenance used for every planned
+    non-reference channel. Input arrays are never mutated.
+
+    This record does not claim that the caller-selected reference channels,
+    pairing methods, tolerances, or affine family are scientifically optimal.
+    Fitted-coefficient uncertainty is not propagated.
+    """
+
+    schema_version: str
+    plan: InstrumentChannelCalibrationPlan
+    source_row_indices: tuple[int, ...]
+    calibrated_flux: tuple[float, ...]
+    calibrated_flux_error: tuple[float, ...] | None
+    applied_channels: tuple[str, ...]
+    applied_source_row_indices: tuple[int, ...]
+    n_applied_observations: int
+
+    def __post_init__(self) -> None:
+        if self.schema_version != (
+            INSTRUMENT_CHANNEL_CALIBRATION_EXECUTION_SCHEMA_VERSION
+        ):
+            raise ValueError(
+                "Unsupported instrument-channel calibration execution "
+                f"schema version: {self.schema_version!r}."
+            )
+
+        if not isinstance(
+            self.plan,
+            InstrumentChannelCalibrationPlan,
+        ):
+            raise TypeError(
+                "plan must be an InstrumentChannelCalibrationPlan "
+                "instance."
+            )
+
+        calibrated_flux = tuple(
+            float(value)
+            for value in self.calibrated_flux
+        )
+        if any(
+            not math.isfinite(value)
+            for value in calibrated_flux
+        ):
+            raise ValueError("calibrated_flux must contain finite values.")
+
+        source_row_indices = (
+            _normalize_pairing_source_indices(
+                self.source_row_indices,
+                size=len(calibrated_flux),
+                name="source_row_indices",
+            )
+        )
+
+        calibrated_flux_error = self.calibrated_flux_error
+        if calibrated_flux_error is not None:
+            calibrated_flux_error = tuple(
+                float(value)
+                for value in calibrated_flux_error
+            )
+            if len(calibrated_flux_error) != len(calibrated_flux):
+                raise ValueError(
+                    "calibrated_flux_error must have the same length as "
+                    "calibrated_flux."
+                )
+            if any(
+                not math.isfinite(value) or value < 0.0
+                for value in calibrated_flux_error
+            ):
+                raise ValueError(
+                    "calibrated_flux_error must contain finite "
+                    "non-negative values."
+                )
+
+        applied_channels = tuple(
+            sorted(
+                {
+                    _normalize_calibration_channel(
+                        channel,
+                        name="applied channel",
+                    )
+                    for channel in self.applied_channels
+                }
+            )
+        )
+
+        applied_source_row_indices = (
+            InstrumentChannelPairing._normalize_indices(
+                self.applied_source_row_indices,
+                name="applied_source_row_indices",
+            )
+        )
+        if (
+            len(set(applied_source_row_indices))
+            != len(applied_source_row_indices)
+        ):
+            raise ValueError(
+                "applied_source_row_indices must not contain "
+                "duplicate source rows."
+            )
+
+        source_row_index_set = set(source_row_indices)
+        missing_applied_indices = tuple(
+            index
+            for index in applied_source_row_indices
+            if index not in source_row_index_set
+        )
+        if missing_applied_indices:
+            raise ValueError(
+                "applied_source_row_indices must be drawn from "
+                "source_row_indices; missing="
+                f"{missing_applied_indices!r}."
+            )
+
+        planned_channels = {
+            channel_plan.channel
+            for group_plan in self.plan.group_plans
+            for channel_plan in group_plan.channel_plans
+            if channel_plan.disposition
+            is InstrumentChannelCalibrationDisposition.PLANNED
+        }
+        if set(applied_channels) != planned_channels:
+            raise ValueError(
+                "applied_channels must match exactly the planned "
+                "channels in plan."
+            )
+
+        if (
+            isinstance(self.n_applied_observations, (bool, np.bool_))
+            or not isinstance(
+                self.n_applied_observations,
+                (int, np.integer),
+            )
+        ):
+            raise TypeError(
+                "n_applied_observations must be an integer."
+            )
+        n_applied_observations = int(
+            self.n_applied_observations
+        )
+        if n_applied_observations < 0:
+            raise ValueError(
+                "n_applied_observations must be non-negative."
+            )
+        if n_applied_observations != len(
+            applied_source_row_indices
+        ):
+            raise ValueError(
+                "n_applied_observations must equal the number of "
+                "applied_source_row_indices."
+            )
+
+        object.__setattr__(
+            self,
+            "source_row_indices",
+            source_row_indices,
+        )
+        object.__setattr__(
+            self,
+            "calibrated_flux",
+            calibrated_flux,
+        )
+        object.__setattr__(
+            self,
+            "calibrated_flux_error",
+            calibrated_flux_error,
+        )
+        object.__setattr__(
+            self,
+            "applied_channels",
+            applied_channels,
+        )
+        object.__setattr__(
+            self,
+            "applied_source_row_indices",
+            applied_source_row_indices,
+        )
+        object.__setattr__(
+            self,
+            "n_applied_observations",
+            n_applied_observations,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a strict JSON-safe execution representation."""
+
+        return {
+            "schema_version": self.schema_version,
+            "plan": self.plan.to_dict(),
+            "source_row_indices": list(self.source_row_indices),
+            "calibrated_flux": list(self.calibrated_flux),
+            "calibrated_flux_error": (
+                None
+                if self.calibrated_flux_error is None
+                else list(self.calibrated_flux_error)
+            ),
+            "applied_channels": list(self.applied_channels),
+            "applied_source_row_indices": list(
+                self.applied_source_row_indices
+            ),
+            "n_applied_channels": len(self.applied_channels),
+            "n_applied_observations": (
+                self.n_applied_observations
+            ),
+            "plan_execution_performed": True,
+            "input_mutation_performed": False,
+            "channel_merging_performed": False,
+            "wavelength_reassignment_performed": False,
+            "automatic_reference_channel_selection": False,
+            "automatic_pairing_method_selection": False,
+            "automatic_time_tolerance_selection": False,
+            "automatic_calibration_family_selection": False,
+            "fitted_coefficient_uncertainty_propagated": False,
+            "scientific_pairing_validation_performed": False,
+            "marker": INSTRUMENT_CHANNEL_CALIBRATION_TBD_MARKER,
+        }
+
+
+def _as_finite_execution_vector(
+    values: Any,
+    *,
+    name: str,
+    non_negative: bool = False,
+) -> np.ndarray:
+    raw = np.asarray(values)
+    if raw.dtype.kind == "b":
+        raise TypeError(
+            f"{name} must contain numeric values, not booleans."
+        )
+
+    array = np.asarray(values, dtype=float)
+    if array.ndim != 1:
+        raise ValueError(f"{name} must be one-dimensional.")
+    if np.any(~np.isfinite(array)):
+        raise ValueError(f"{name} must contain finite values.")
+    if non_negative and np.any(array < 0.0):
+        raise ValueError(
+            f"{name} must contain non-negative values."
+        )
+
+    return array
+
+
+def _execution_pair_positions(
+    pairing: InstrumentChannelPairing,
+    *,
+    row_position_by_index: dict[int, int],
+    observational_channels: tuple[str, ...],
+    physical_wavelengths: np.ndarray,
+    times: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    try:
+        reference_positions = np.asarray(
+            [
+                row_position_by_index[index]
+                for index in pairing.reference_row_indices
+            ],
+            dtype=int,
+        )
+        channel_positions = np.asarray(
+            [
+                row_position_by_index[index]
+                for index in pairing.channel_row_indices
+            ],
+            dtype=int,
+        )
+    except KeyError as exception:
+        raise ValueError(
+            "Pairing provenance references a source row index that is "
+            "absent from the execution input: "
+            f"{exception.args[0]!r}."
+        ) from exception
+
+    for position in reference_positions:
+        if (
+            observational_channels[position]
+            != pairing.reference_channel
+        ):
+            raise ValueError(
+                "Pairing reference_row_indices do not identify the "
+                "declared reference_channel in the execution input."
+            )
+        if (
+            physical_wavelengths[position]
+            != pairing.wavelength
+        ):
+            raise ValueError(
+                "Pairing reference_row_indices do not identify the "
+                "declared wavelength in the execution input."
+            )
+
+    for position in channel_positions:
+        if observational_channels[position] != pairing.channel:
+            raise ValueError(
+                "Pairing channel_row_indices do not identify the "
+                "declared channel in the execution input."
+            )
+        if physical_wavelengths[position] != pairing.wavelength:
+            raise ValueError(
+                "Pairing channel_row_indices do not identify the "
+                "declared wavelength in the execution input."
+            )
+
+    if not np.array_equal(
+        times[reference_positions],
+        np.asarray(pairing.reference_times, dtype=float),
+    ):
+        raise ValueError(
+            "Pairing reference_times do not match the execution rows "
+            "identified by reference_row_indices."
+        )
+    if not np.array_equal(
+        times[channel_positions],
+        np.asarray(pairing.channel_times, dtype=float),
+    ):
+        raise ValueError(
+            "Pairing channel_times do not match the execution rows "
+            "identified by channel_row_indices."
+        )
+
+    return reference_positions, channel_positions
+
+
+def execute_instrument_channel_calibration_plan(
+    plan: InstrumentChannelCalibrationPlan,
+    times: Any,
+    flux: Any,
+    physical_wavelengths: Any,
+    observational_channel_labels: Any,
+    *,
+    flux_error: Any | None = None,
+    source_row_indices: Any | None = None,
+) -> InstrumentChannelCalibrationExecution:
+    """Execute a caller-authored dataset-level calibration plan.
+
+    Planned entries reuse attached pairing or calibration provenance when
+    present. Otherwise the callable constructs pairs using the explicitly
+    recorded method and tolerance, fits the explicitly recorded affine family,
+    and applies the mapping to every row of the planned target channel at the
+    shared physical wavelength.
+
+    Skipped and unavailable entries are preserved without modification.
+    Reference-channel rows are never transformed. Inputs are copied rather than
+    mutated, observational channels remain distinct, and wavelengths are not
+    reassigned.
+
+    The callable performs no automatic reference-channel, pairing-method,
+    tolerance, or calibration-family selection. It does not propagate
+    uncertainty in fitted affine coefficients or integrate the result into
+    :class:`pgmuvi.lightcurve.Lightcurve`.
+    """
+
+    if not isinstance(
+        plan,
+        InstrumentChannelCalibrationPlan,
+    ):
+        raise TypeError(
+            "plan must be an InstrumentChannelCalibrationPlan "
+            "instance."
+        )
+
+    normalized_times = np.asarray(
+        InstrumentChannelPairing._normalize_times(
+            times,
+            name="times",
+        ),
+        dtype=float,
+    )
+    normalized_flux = _as_finite_execution_vector(
+        flux,
+        name="flux",
+    )
+    normalized_wavelengths = _as_finite_execution_vector(
+        physical_wavelengths,
+        name="physical_wavelengths",
+    )
+
+    labels_array = np.asarray(
+        observational_channel_labels,
+        dtype=object,
+    )
+    if labels_array.ndim != 1:
+        raise ValueError(
+            "observational_channel_labels must be one-dimensional."
+        )
+    normalized_labels = tuple(
+        _normalize_calibration_channel(
+            value,
+            name="observational channel label",
+        )
+        for value in labels_array
+    )
+
+    size = normalized_flux.size
+    for name, array_size in (
+        ("times", normalized_times.size),
+        ("physical_wavelengths", normalized_wavelengths.size),
+        (
+            "observational_channel_labels",
+            len(normalized_labels),
+        ),
+    ):
+        if array_size != size:
+            raise ValueError(
+                f"{name} must have the same length as flux."
+            )
+
+    normalized_error = None
+    if flux_error is not None:
+        normalized_error = _as_finite_execution_vector(
+            flux_error,
+            name="flux_error",
+            non_negative=True,
+        )
+        if normalized_error.size != size:
+            raise ValueError(
+                "flux_error must have the same length as flux."
+            )
+
+    normalized_source_indices = (
+        _normalize_pairing_source_indices(
+            source_row_indices,
+            size=size,
+            name="source_row_indices",
+        )
+    )
+    row_position_by_index = {
+        index: position
+        for position, index in enumerate(
+            normalized_source_indices
+        )
+    }
+
+    observed_assessment = (
+        assess_instrument_channel_calibration_requirement(
+            normalized_wavelengths,
+            normalized_labels,
+        )
+    )
+    if observed_assessment != plan.assessment:
+        raise ValueError(
+            "Execution inputs do not reproduce the calibration "
+            "assessment stored in plan."
+        )
+
+    calibrated_flux = normalized_flux.copy()
+    calibrated_error = (
+        None
+        if normalized_error is None
+        else normalized_error.copy()
+    )
+
+    completed_group_plans = []
+    applied_channels = []
+    applied_observation_mask = np.zeros(size, dtype=bool)
+
+    labels_for_mask = np.asarray(normalized_labels, dtype=object)
+    source_indices_array = np.asarray(
+        normalized_source_indices,
+        dtype=int,
+    )
+
+    for group_plan in plan.group_plans:
+        reference_mask = (
+            (labels_for_mask == group_plan.reference_channel)
+            & (
+                normalized_wavelengths
+                == group_plan.physical_wavelength
+            )
+        )
+        if not np.any(reference_mask):
+            raise ValueError(
+                "Execution input contains no rows for reference channel "
+                f"{group_plan.reference_channel!r} at wavelength "
+                f"{group_plan.physical_wavelength!r}."
+            )
+
+        completed_channel_plans = []
+
+        for channel_plan in group_plan.channel_plans:
+            if channel_plan.disposition is not (
+                InstrumentChannelCalibrationDisposition.PLANNED
+            ):
+                completed_channel_plans.append(channel_plan)
+                continue
+
+            channel_mask = (
+                (labels_for_mask == channel_plan.channel)
+                & (
+                    normalized_wavelengths
+                    == group_plan.physical_wavelength
+                )
+            )
+            if not np.any(channel_mask):
+                raise ValueError(
+                    "Execution input contains no rows for planned channel "
+                    f"{channel_plan.channel!r} at wavelength "
+                    f"{group_plan.physical_wavelength!r}."
+                )
+
+            pairing = channel_plan.pairing
+            if pairing is None:
+                pairing = construct_instrument_channel_pairing(
+                    normalized_times[reference_mask],
+                    normalized_times[channel_mask],
+                    reference_channel=(
+                        group_plan.reference_channel
+                    ),
+                    channel=channel_plan.channel,
+                    wavelength=group_plan.physical_wavelength,
+                    time_unit=channel_plan.time_unit,
+                    method=channel_plan.pairing_method,
+                    maximum_time_separation=(
+                        channel_plan.maximum_time_separation
+                    ),
+                    reference_row_indices=(
+                        source_indices_array[reference_mask]
+                    ),
+                    channel_row_indices=(
+                        source_indices_array[channel_mask]
+                    ),
+                )
+
+            if not pairing.usable_for_affine_calibration:
+                raise ValueError(
+                    "Planned calibration requires at least three paired "
+                    "observations for channel "
+                    f"{channel_plan.channel!r}; pairing contains "
+                    f"{pairing.n_pairs}."
+                )
+
+            (
+                reference_pair_positions,
+                channel_pair_positions,
+            ) = _execution_pair_positions(
+                pairing,
+                row_position_by_index=row_position_by_index,
+                observational_channels=normalized_labels,
+                physical_wavelengths=normalized_wavelengths,
+                times=normalized_times,
+            )
+
+            calibration = channel_plan.calibration
+            if calibration is None:
+                if channel_plan.calibration_family != "affine":
+                    raise ValueError(
+                        "Only the explicit 'affine' calibration family "
+                        "can currently be executed."
+                    )
+
+                calibration = fit_instrument_channel_calibration(
+                    normalized_flux[reference_pair_positions],
+                    normalized_flux[channel_pair_positions],
+                    reference_channel=(
+                        group_plan.reference_channel
+                    ),
+                    channel=channel_plan.channel,
+                    wavelength=group_plan.physical_wavelength,
+                    reference_error=(
+                        None
+                        if normalized_error is None
+                        else normalized_error[
+                            reference_pair_positions
+                        ]
+                    ),
+                    channel_error=(
+                        None
+                        if normalized_error is None
+                        else normalized_error[
+                            channel_pair_positions
+                        ]
+                    ),
+                )
+
+            if calibrated_error is None:
+                calibrated_flux[channel_mask] = (
+                    apply_instrument_channel_calibration(
+                        normalized_flux[channel_mask],
+                        calibration,
+                    )
+                )
+            else:
+                (
+                    transformed_flux,
+                    transformed_error,
+                ) = apply_instrument_channel_calibration(
+                    normalized_flux[channel_mask],
+                    calibration,
+                    flux_error=normalized_error[channel_mask],
+                )
+                calibrated_flux[channel_mask] = transformed_flux
+                calibrated_error[channel_mask] = transformed_error
+
+            completed_channel_plans.append(
+                replace(
+                    channel_plan,
+                    pairing=pairing,
+                    calibration=calibration,
+                )
+            )
+            applied_channels.append(channel_plan.channel)
+            applied_observation_mask[channel_mask] = True
+
+        completed_group_plans.append(
+            replace(
+                group_plan,
+                channel_plans=tuple(completed_channel_plans),
+            )
+        )
+
+    completed_plan = define_instrument_channel_calibration_plan(
+        plan.assessment,
+        tuple(completed_group_plans),
+    )
+
+    return InstrumentChannelCalibrationExecution(
+        schema_version=(
+            INSTRUMENT_CHANNEL_CALIBRATION_EXECUTION_SCHEMA_VERSION
+        ),
+        plan=completed_plan,
+        source_row_indices=normalized_source_indices,
+        calibrated_flux=tuple(calibrated_flux),
+        calibrated_flux_error=(
+            None
+            if calibrated_error is None
+            else tuple(calibrated_error)
+        ),
+        applied_channels=tuple(applied_channels),
+        applied_source_row_indices=tuple(
+            source_indices_array[applied_observation_mask]
+        ),
+        n_applied_observations=int(
+            np.count_nonzero(applied_observation_mask)
+        ),
     )
 
 

--- a/tests/test_docs_instrument_channel_calibration.py
+++ b/tests/test_docs_instrument_channel_calibration.py
@@ -65,8 +65,21 @@ class TestInstrumentChannelCalibrationDocumentation(unittest.TestCase):
         self.assertIn("planned", text)
         self.assertIn("skipped", text)
         self.assertIn("unavailable", text)
-        self.assertIn("dataset-level orchestration", text)
+        self.assertIn("Dataset-level orchestration", text)
         self.assertIn("does not construct pairs", text)
+        self.assertIn(
+            "execute_instrument_channel_calibration_plan",
+            text,
+        )
+        self.assertIn(
+            "InstrumentChannelCalibrationExecution",
+            text,
+        )
+        self.assertIn("does not mutate input arrays", text)
+        self.assertIn(
+            "fitted-coefficient uncertainty",
+            text,
+        )
         self.assertIn("O(n_reference * n_channel)", text)
         self.assertIn("time and memory cost", text)
         self.assertIn("affine", text.lower())

--- a/tests/test_instrument_channel_calibration_orchestration_execution.py
+++ b/tests/test_instrument_channel_calibration_orchestration_execution.py
@@ -287,6 +287,60 @@ class TestInstrumentChannelCalibrationOrchestrationExecution(
             [3.0, 5.0, 7.0, 3.0, 5.0, 7.0],
         )
 
+    def test_execution_rejects_booleans_in_object_vectors(self):
+        times, flux, error, wavelengths, channels = self._data()
+
+        cases = (
+            (
+                "flux",
+                {
+                    "flux": np.asarray(
+                        [3.0, 5.0, 7.0, 1.0, True, 3.0],
+                        dtype=object,
+                    ),
+                },
+            ),
+            (
+                "flux_error",
+                {
+                    "flux_error": np.asarray(
+                        [0.3, 0.3, 0.3, 0.1, False, 0.1],
+                        dtype=object,
+                    ),
+                },
+            ),
+            (
+                "physical_wavelengths",
+                {
+                    "physical_wavelengths": np.asarray(
+                        [1.0, 1.0, 1.0, 1.0, True, 1.0],
+                        dtype=object,
+                    ),
+                },
+            ),
+        )
+
+        for expected_name, overrides in cases:
+            arguments = {
+                "plan": self._plan(),
+                "times": times,
+                "flux": flux,
+                "physical_wavelengths": wavelengths,
+                "observational_channel_labels": channels,
+                "flux_error": error,
+            }
+            arguments.update(overrides)
+
+            with self.subTest(name=expected_name):
+                with self.assertRaisesRegex(
+                    TypeError,
+                    rf"{expected_name} must contain numeric values, "
+                    "not booleans",
+                ):
+                    execute_instrument_channel_calibration_plan(
+                        **arguments
+                    )
+
     def test_execution_rejects_assessment_mismatch(self):
         times, flux, error, wavelengths, channels = self._data()
         channels = channels.copy()

--- a/tests/test_instrument_channel_calibration_orchestration_execution.py
+++ b/tests/test_instrument_channel_calibration_orchestration_execution.py
@@ -1,0 +1,413 @@
+"""Dataset-level instrument-channel calibration execution tests."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+import json
+import unittest
+
+import numpy as np
+
+from pgmuvi.instrument_channel_calibration import (
+    INSTRUMENT_CHANNEL_CALIBRATION_EXECUTION_SCHEMA_VERSION,
+    InstrumentChannelCalibrationChannelPlan,
+    InstrumentChannelCalibrationDisposition,
+    InstrumentChannelCalibrationExecution,
+    InstrumentChannelCalibrationGroupPlan,
+    InstrumentChannelPairing,
+    InstrumentChannelPairingMethod,
+    assess_instrument_channel_calibration_requirement,
+    define_instrument_channel_calibration_plan,
+    execute_instrument_channel_calibration_plan,
+)
+
+
+class TestInstrumentChannelCalibrationOrchestrationExecution(
+    unittest.TestCase
+):
+    @staticmethod
+    def _data(include_skipped=False):
+        times = np.asarray(
+            [0.0, 1.0, 2.0, 0.0, 1.0, 2.0],
+            dtype=float,
+        )
+        wavelengths = np.ones(6, dtype=float)
+        channels = np.asarray(
+            ["A", "A", "A", "B", "B", "B"],
+            dtype=object,
+        )
+        flux = np.asarray(
+            [3.0, 5.0, 7.0, 1.0, 2.0, 3.0],
+            dtype=float,
+        )
+        error = np.asarray(
+            [0.3, 0.3, 0.3, 0.1, 0.1, 0.1],
+            dtype=float,
+        )
+
+        if include_skipped:
+            times = np.concatenate(
+                (times, np.asarray([0.0, 1.0, 2.0]))
+            )
+            wavelengths = np.concatenate(
+                (wavelengths, np.ones(3))
+            )
+            channels = np.concatenate(
+                (
+                    channels,
+                    np.asarray(["C", "C", "C"], dtype=object),
+                )
+            )
+            flux = np.concatenate(
+                (flux, np.asarray([9.0, 8.0, 7.0]))
+            )
+            error = np.concatenate(
+                (error, np.asarray([0.4, 0.4, 0.4]))
+            )
+
+        return times, flux, error, wavelengths, channels
+
+    @classmethod
+    def _plan(cls, *, include_skipped=False, pairing=None):
+        (
+            _,
+            _,
+            _,
+            wavelengths,
+            channels,
+        ) = cls._data(include_skipped=include_skipped)
+
+        assessment = (
+            assess_instrument_channel_calibration_requirement(
+                wavelengths,
+                channels,
+            )
+        )
+
+        channel_plans = [
+            InstrumentChannelCalibrationChannelPlan(
+                channel="B",
+                disposition=(
+                    InstrumentChannelCalibrationDisposition.PLANNED
+                ),
+                pairing_method=(
+                    InstrumentChannelPairingMethod
+                    .EXACT_TIMESTAMP
+                ),
+                time_unit="day",
+                calibration_family="affine",
+                pairing=pairing,
+            )
+        ]
+
+        if include_skipped:
+            channel_plans.append(
+                InstrumentChannelCalibrationChannelPlan(
+                    channel="C",
+                    disposition=(
+                        InstrumentChannelCalibrationDisposition
+                        .SKIPPED
+                    ),
+                    reason="Caller excluded channel C.",
+                )
+            )
+
+        return define_instrument_channel_calibration_plan(
+            assessment,
+            (
+                InstrumentChannelCalibrationGroupPlan(
+                    physical_wavelength=1.0,
+                    reference_channel="A",
+                    channel_plans=tuple(channel_plans),
+                ),
+            ),
+        )
+
+    def test_execution_fits_applies_and_records_provenance(self):
+        times, flux, error, wavelengths, channels = self._data()
+        original_flux = flux.copy()
+        original_error = error.copy()
+
+        result = execute_instrument_channel_calibration_plan(
+            self._plan(),
+            times,
+            flux,
+            wavelengths,
+            channels,
+            flux_error=error,
+            source_row_indices=(10, 20, 30, 40, 50, 60),
+        )
+
+        self.assertIsInstance(
+            result,
+            InstrumentChannelCalibrationExecution,
+        )
+        self.assertEqual(
+            result.schema_version,
+            INSTRUMENT_CHANNEL_CALIBRATION_EXECUTION_SCHEMA_VERSION,
+        )
+        np.testing.assert_allclose(
+            result.calibrated_flux,
+            [3.0, 5.0, 7.0, 3.0, 5.0, 7.0],
+        )
+        np.testing.assert_allclose(
+            result.calibrated_flux_error,
+            [0.3, 0.3, 0.3, 0.2, 0.2, 0.2],
+        )
+        np.testing.assert_array_equal(flux, original_flux)
+        np.testing.assert_array_equal(error, original_error)
+
+        completed = result.plan.group_plans[0].channel_plans[0]
+        self.assertIsNotNone(completed.pairing)
+        self.assertIsNotNone(completed.calibration)
+        self.assertEqual(
+            completed.pairing.reference_row_indices,
+            (10, 20, 30),
+        )
+        self.assertEqual(
+            completed.pairing.channel_row_indices,
+            (40, 50, 60),
+        )
+        self.assertEqual(result.applied_channels, ("B",))
+        self.assertEqual(
+            result.applied_source_row_indices,
+            (40, 50, 60),
+        )
+        self.assertEqual(result.n_applied_observations, 3)
+
+        payload = result.to_dict()
+        json.dumps(payload, allow_nan=False)
+        self.assertFalse(
+            payload["automatic_reference_channel_selection"]
+        )
+        self.assertFalse(payload["input_mutation_performed"])
+        self.assertEqual(
+            payload["applied_source_row_indices"],
+            [40, 50, 60],
+        )
+        self.assertFalse(
+            payload["fitted_coefficient_uncertainty_propagated"]
+        )
+
+    def test_execution_result_rejects_inconsistent_applied_count(self):
+        times, flux, error, wavelengths, channels = self._data()
+
+        result = execute_instrument_channel_calibration_plan(
+            self._plan(),
+            times,
+            flux,
+            wavelengths,
+            channels,
+            flux_error=error,
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "must equal the number",
+        ):
+            replace(
+                result,
+                applied_source_row_indices=(3,),
+                n_applied_observations=3,
+            )
+
+    def test_completed_provenance_can_be_reused(self):
+        times, flux, error, wavelengths, channels = self._data()
+
+        first = execute_instrument_channel_calibration_plan(
+            self._plan(),
+            times,
+            flux,
+            wavelengths,
+            channels,
+            flux_error=error,
+        )
+        second = execute_instrument_channel_calibration_plan(
+            first.plan,
+            times,
+            flux,
+            wavelengths,
+            channels,
+            flux_error=error,
+        )
+
+        self.assertEqual(
+            first.plan.group_plans[0].channel_plans[0].pairing,
+            second.plan.group_plans[0].channel_plans[0].pairing,
+        )
+        self.assertEqual(
+            first.plan.group_plans[0].channel_plans[0].calibration,
+            second.plan.group_plans[0].channel_plans[0].calibration,
+        )
+        np.testing.assert_allclose(
+            first.calibrated_flux,
+            second.calibrated_flux,
+        )
+
+    def test_skipped_channel_is_preserved_unchanged(self):
+        times, flux, error, wavelengths, channels = self._data(
+            include_skipped=True
+        )
+
+        result = execute_instrument_channel_calibration_plan(
+            self._plan(include_skipped=True),
+            times,
+            flux,
+            wavelengths,
+            channels,
+            flux_error=error,
+        )
+
+        np.testing.assert_allclose(
+            result.calibrated_flux[6:],
+            flux[6:],
+        )
+        skipped = result.plan.group_plans[0].channel_plans[1]
+        self.assertEqual(
+            skipped.disposition,
+            InstrumentChannelCalibrationDisposition.SKIPPED,
+        )
+        self.assertIsNone(skipped.pairing)
+        self.assertIsNone(skipped.calibration)
+
+    def test_execution_without_errors_returns_no_error_vector(self):
+        times, flux, _, wavelengths, channels = self._data()
+
+        result = execute_instrument_channel_calibration_plan(
+            self._plan(),
+            times,
+            flux,
+            wavelengths,
+            channels,
+        )
+
+        self.assertIsNone(result.calibrated_flux_error)
+        np.testing.assert_allclose(
+            result.calibrated_flux,
+            [3.0, 5.0, 7.0, 3.0, 5.0, 7.0],
+        )
+
+    def test_execution_rejects_assessment_mismatch(self):
+        times, flux, error, wavelengths, channels = self._data()
+        channels = channels.copy()
+        channels[-1] = "D"
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "do not reproduce",
+        ):
+            execute_instrument_channel_calibration_plan(
+                self._plan(),
+                times,
+                flux,
+                wavelengths,
+                channels,
+                flux_error=error,
+            )
+
+    def test_execution_rejects_missing_pairing_source_rows(self):
+        pairing = InstrumentChannelPairing(
+            schema_version=(
+                "pgmuvi-instrument-channel-pairing-v2"
+            ),
+            reference_channel="A",
+            channel="B",
+            wavelength=1.0,
+            reference_row_indices=(100, 101, 102),
+            channel_row_indices=(200, 201, 202),
+            reference_times=(0.0, 1.0, 2.0),
+            channel_times=(0.0, 1.0, 2.0),
+            time_unit="day",
+            method="exact_timestamp",
+        )
+        times, flux, error, wavelengths, channels = self._data()
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "absent from the execution input",
+        ):
+            execute_instrument_channel_calibration_plan(
+                self._plan(pairing=pairing),
+                times,
+                flux,
+                wavelengths,
+                channels,
+                flux_error=error,
+            )
+
+    def test_execution_rejects_stale_pairing_times(self):
+        pairing = InstrumentChannelPairing(
+            schema_version=(
+                "pgmuvi-instrument-channel-pairing-v2"
+            ),
+            reference_channel="A",
+            channel="B",
+            wavelength=1.0,
+            reference_row_indices=(0, 1, 2),
+            channel_row_indices=(3, 4, 5),
+            reference_times=(0.0, 1.0, 99.0),
+            channel_times=(0.0, 1.0, 99.0),
+            time_unit="day",
+            method="exact_timestamp",
+        )
+        times, flux, error, wavelengths, channels = self._data()
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "reference_times do not match",
+        ):
+            execute_instrument_channel_calibration_plan(
+                self._plan(pairing=pairing),
+                times,
+                flux,
+                wavelengths,
+                channels,
+                flux_error=error,
+            )
+
+    def test_execution_rejects_pairing_with_too_few_pairs(self):
+        times = np.asarray([0.0, 1.0, 0.0, 1.0])
+        wavelengths = np.ones(4)
+        channels = np.asarray(["A", "A", "B", "B"])
+        flux = np.asarray([3.0, 5.0, 1.0, 2.0])
+
+        assessment = (
+            assess_instrument_channel_calibration_requirement(
+                wavelengths,
+                channels,
+            )
+        )
+        plan = define_instrument_channel_calibration_plan(
+            assessment,
+            (
+                InstrumentChannelCalibrationGroupPlan(
+                    physical_wavelength=1.0,
+                    reference_channel="A",
+                    channel_plans=(
+                        InstrumentChannelCalibrationChannelPlan(
+                            channel="B",
+                            disposition="planned",
+                            pairing_method="exact_timestamp",
+                            time_unit="day",
+                            calibration_family="affine",
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "at least three paired observations",
+        ):
+            execute_instrument_channel_calibration_plan(
+                plan,
+                times,
+                flux,
+                wavelengths,
+                channels,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implement execution of caller-authored dataset-level instrument-channel calibration plans.

The new public execution path:

- consumes an explicit `InstrumentChannelCalibrationPlan`;
- reuses or constructs the recorded deterministic pairing provenance;
- reuses or fits the recorded affine calibration;
- applies each planned mapping to copied flux and uncertainty arrays;
- preserves skipped and unavailable channels unchanged;
- returns immutable, strict JSON-safe execution provenance;
- records the exact source-row indices transformed; and
- verifies that reused pairing indices and times still identify the supplied observations.

## Scientific and workflow boundaries

This pull request does not add automatic:

- reference-channel selection;
- pairing-method selection;
- time-tolerance selection;
- calibration-family selection;
- channel merging;
- wavelength reassignment;
- fitted-coefficient uncertainty propagation;
- `Lightcurve` mutation; or
- `Lightcurve.fit()` integration.

The `TBD[instrument-channel-calibration]` marker therefore remains open for instrument-specific scientific guidance, coefficient-uncertainty propagation, workflow integration, and representative calibration validation.

## Validation

- `ruff check -v --output-format=full --show-fixes ./pgmuvi`
- `make -C docs clean`
- `make -C docs html-strict`
- `PYTHONPATH=. python3 -m unittest discover -s tests -p "test*.py" -v`

All 2,620 tests passed, Ruff passed, and the strict documentation build succeeded.
