### PR TITLE
Define calibration coefficient uncertainty contract

### DIFF
--- a/docs/source/future_work.rst
+++ b/docs/source/future_work.rst
@@ -121,7 +121,8 @@ Wavelength-model extensions
     into copied calibrated arrays with completed pairing and fit
     provenance. This does not close the marker: scientifically
     validated instrument-specific tolerance guidance, fitted-coefficient
-    uncertainty propagation, workflow integration, and representative
+    uncertainty estimation and propagation, workflow integration, and
+    representative
     calibration validation remain future work.
 
 **TBD[multi-periodic-wavelength-models]**

--- a/docs/source/pgmuvi.instrument_channel_calibration.rst
+++ b/docs/source/pgmuvi.instrument_channel_calibration.rst
@@ -60,6 +60,27 @@ records can be attached to preserve pairing and fitted-coefficient provenance.
 The plan itself does not construct pairs, fit or apply mappings, merge channels,
 alter wavelengths, mutate a light curve, or integrate calibration into fitting.
 
+Coefficient-uncertainty provenance contract
+-------------------------------------------
+
+The version-2
+:class:`~pgmuvi.instrument_channel_calibration.InstrumentChannelCalibration`
+record requires an explicit
+:class:`~pgmuvi.instrument_channel_calibration.InstrumentChannelCalibrationCoefficientUncertainty`
+record.  Available uncertainty stores the complete symmetric 2-by-2 covariance
+matrix in the fixed coefficient order ``offset, scale``.  Offset and scale
+standard errors are derived from the covariance diagonal rather than stored as
+independent values.  The record also preserves an explicit uncertainty source,
+estimation method, and optional degrees of freedom and residual variance.
+
+When coefficient uncertainty has not been estimated, the nested record uses the
+explicit ``unavailable`` status and a required reason.  It cannot contain
+placeholder covariance or estimation metadata.  This applies equally to
+caller-supplied calibration provenance and calibrations produced by PGMUVI.
+The current affine fitter records coefficient uncertainty as unavailable; it
+does not estimate covariance, and application still propagates only measurement
+uncertainty through the fitted scale.
+
 Executing an explicit plan
 --------------------------
 
@@ -119,7 +140,7 @@ still lacks:
 
 * scientifically validated instrument-specific rules for choosing
   pairing methods and tolerances;
-* propagation of fitted-coefficient uncertainty;
+* estimation and propagation of fitted-coefficient uncertainty;
 * integration into the normal light-curve fitting workflow; and
 * validation across representative instruments, filters, and LPV sources.
 

--- a/pgmuvi/instrument_channel_calibration.py
+++ b/pgmuvi/instrument_channel_calibration.py
@@ -38,6 +38,9 @@ INSTRUMENT_CHANNEL_CALIBRATION_PLAN_SCHEMA_VERSION = (
 INSTRUMENT_CHANNEL_CALIBRATION_EXECUTION_SCHEMA_VERSION = (
     "pgmuvi-instrument-channel-calibration-execution-v1"
 )
+INSTRUMENT_CHANNEL_CALIBRATION_UNCERTAINTY_SCHEMA_VERSION = (
+    "pgmuvi-instrument-channel-calibration-uncertainty-v1"
+)
 
 
 __all__ = [
@@ -46,15 +49,18 @@ __all__ = [
     "INSTRUMENT_CHANNEL_CALIBRATION_PLAN_SCHEMA_VERSION",
     "INSTRUMENT_CHANNEL_CALIBRATION_SCHEMA_VERSION",
     "INSTRUMENT_CHANNEL_CALIBRATION_TBD_MARKER",
+    "INSTRUMENT_CHANNEL_CALIBRATION_UNCERTAINTY_SCHEMA_VERSION",
     "INSTRUMENT_CHANNEL_PAIRING_SCHEMA_VERSION",
     "InstrumentChannelCalibration",
     "InstrumentChannelCalibrationAssessment",
     "InstrumentChannelCalibrationChannelPlan",
+    "InstrumentChannelCalibrationCoefficientUncertainty",
     "InstrumentChannelCalibrationDisposition",
     "InstrumentChannelCalibrationExecution",
     "InstrumentChannelCalibrationGroupPlan",
     "InstrumentChannelCalibrationPlan",
     "InstrumentChannelCalibrationStatus",
+    "InstrumentChannelCalibrationUncertaintyStatus",
     "InstrumentChannelPairing",
     "InstrumentChannelPairingMethod",
     "SharedWavelengthChannelGroup",
@@ -93,6 +99,13 @@ class InstrumentChannelCalibrationDisposition(_StringEnum):
 
     PLANNED = "planned"
     SKIPPED = "skipped"
+    UNAVAILABLE = "unavailable"
+
+
+class InstrumentChannelCalibrationUncertaintyStatus(_StringEnum):
+    """Availability of affine coefficient-uncertainty provenance."""
+
+    AVAILABLE = "available"
     UNAVAILABLE = "unavailable"
 
 
@@ -1137,7 +1150,313 @@ def construct_instrument_channel_pairing(
     )
 
 
-INSTRUMENT_CHANNEL_CALIBRATION_MODEL_SCHEMA_VERSION = "1.0"
+@dataclass(frozen=True)
+class InstrumentChannelCalibrationCoefficientUncertainty:
+    """Uncertainty provenance for affine offset and scale coefficients.
+
+    Available uncertainty uses the fixed coefficient order ``offset, scale``
+    and stores the complete symmetric 2-by-2 covariance matrix. Standard
+    errors are derived from its diagonal rather than stored independently.
+    Unavailable uncertainty instead requires an explicit reason and cannot
+    carry placeholder numerical values.
+    """
+
+    schema_version: str
+    status: InstrumentChannelCalibrationUncertaintyStatus | str
+    uncertainty_source: str
+    coefficient_covariance: (
+        tuple[tuple[float, float], tuple[float, float]] | None
+    )
+    estimation_method: str | None = None
+    degrees_of_freedom: int | None = None
+    residual_variance: float | None = None
+    reason: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.schema_version != (
+            INSTRUMENT_CHANNEL_CALIBRATION_UNCERTAINTY_SCHEMA_VERSION
+        ):
+            raise ValueError(
+                "Unsupported instrument-channel calibration uncertainty "
+                f"schema version: {self.schema_version!r}."
+            )
+
+        status = self.status
+        if not isinstance(
+            status,
+            InstrumentChannelCalibrationUncertaintyStatus,
+        ):
+            try:
+                status = InstrumentChannelCalibrationUncertaintyStatus(
+                    str(status)
+                )
+            except ValueError as exc:
+                raise ValueError(
+                    "Unsupported instrument-channel calibration uncertainty "
+                    f"status: {self.status!r}."
+                ) from exc
+
+        uncertainty_source = self._normalize_required_text(
+            self.uncertainty_source,
+            name="uncertainty_source",
+        )
+        estimation_method = self._normalize_optional_text(
+            self.estimation_method,
+            name="estimation_method",
+        )
+        reason = self._normalize_optional_text(
+            self.reason,
+            name="reason",
+        )
+
+        covariance = self._normalize_covariance(
+            self.coefficient_covariance
+        )
+        degrees_of_freedom = self._normalize_degrees_of_freedom(
+            self.degrees_of_freedom
+        )
+        residual_variance = self._normalize_residual_variance(
+            self.residual_variance
+        )
+
+        if (
+            status
+            is InstrumentChannelCalibrationUncertaintyStatus.AVAILABLE
+        ):
+            if covariance is None:
+                raise ValueError(
+                    "Available coefficient uncertainty requires a complete "
+                    "coefficient_covariance matrix."
+                )
+            if estimation_method is None:
+                raise ValueError(
+                    "Available coefficient uncertainty requires an explicit "
+                    "estimation_method."
+                )
+            if reason is not None:
+                raise ValueError(
+                    "Available coefficient uncertainty must not carry an "
+                    "unavailable reason."
+                )
+        else:
+            if reason is None:
+                raise ValueError(
+                    "Unavailable coefficient uncertainty requires a reason."
+                )
+            if any(
+                value is not None
+                for value in (
+                    covariance,
+                    estimation_method,
+                    degrees_of_freedom,
+                    residual_variance,
+                )
+            ):
+                raise ValueError(
+                    "Unavailable coefficient uncertainty cannot contain "
+                    "covariance or estimation metadata."
+                )
+
+        object.__setattr__(self, "status", status)
+        object.__setattr__(
+            self,
+            "uncertainty_source",
+            uncertainty_source,
+        )
+        object.__setattr__(
+            self,
+            "coefficient_covariance",
+            covariance,
+        )
+        object.__setattr__(
+            self,
+            "estimation_method",
+            estimation_method,
+        )
+        object.__setattr__(
+            self,
+            "degrees_of_freedom",
+            degrees_of_freedom,
+        )
+        object.__setattr__(
+            self,
+            "residual_variance",
+            residual_variance,
+        )
+        object.__setattr__(self, "reason", reason)
+
+    @staticmethod
+    def _normalize_required_text(value: Any, *, name: str) -> str:
+        if not isinstance(value, str):
+            raise TypeError(f"{name} must be a string.")
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError(f"{name} must be non-empty.")
+        return normalized
+
+    @classmethod
+    def _normalize_optional_text(
+        cls,
+        value: Any,
+        *,
+        name: str,
+    ) -> str | None:
+        if value is None:
+            return None
+        return cls._normalize_required_text(value, name=name)
+
+    @staticmethod
+    def _normalize_covariance(
+        value: Any,
+    ) -> tuple[tuple[float, float], tuple[float, float]] | None:
+        if value is None:
+            return None
+
+        def contains_boolean(item: Any) -> bool:
+            if isinstance(item, (bool, np.bool_)):
+                return True
+            if isinstance(item, np.ndarray):
+                return any(
+                    contains_boolean(element)
+                    for element in item.flat
+                )
+            if isinstance(item, (list, tuple)):
+                return any(
+                    contains_boolean(element)
+                    for element in item
+                )
+            return False
+
+        if contains_boolean(value):
+            raise TypeError(
+                "coefficient_covariance must contain numeric values, "
+                "not booleans."
+            )
+
+        covariance = np.asarray(value, dtype=float)
+        if covariance.shape != (2, 2):
+            raise ValueError(
+                "coefficient_covariance must have shape (2, 2)."
+            )
+        if np.any(~np.isfinite(covariance)):
+            raise ValueError(
+                "coefficient_covariance must contain finite values."
+            )
+        if np.any(np.diag(covariance) < 0.0):
+            raise ValueError(
+                "coefficient_covariance diagonal variances must be "
+                "non-negative."
+            )
+
+        scale = max(1.0, float(np.max(np.abs(covariance))))
+        tolerance = 64.0 * np.finfo(float).eps * scale
+        if not np.allclose(
+            covariance,
+            covariance.T,
+            rtol=0.0,
+            atol=tolerance,
+        ):
+            raise ValueError(
+                "coefficient_covariance must be symmetric."
+            )
+
+        covariance = 0.5 * (covariance + covariance.T)
+        eigenvalues = np.linalg.eigvalsh(covariance)
+        eigenvalue_scale = max(
+            1.0,
+            float(np.max(np.abs(covariance))),
+            float(np.max(np.abs(eigenvalues))),
+        )
+        eigenvalue_tolerance = (
+            64.0 * np.finfo(float).eps * eigenvalue_scale
+        )
+        if float(np.min(eigenvalues)) < -eigenvalue_tolerance:
+            raise ValueError(
+                "coefficient_covariance must be positive semidefinite."
+            )
+
+        return (
+            (float(covariance[0, 0]), float(covariance[0, 1])),
+            (float(covariance[1, 0]), float(covariance[1, 1])),
+        )
+
+    @staticmethod
+    def _normalize_degrees_of_freedom(value: Any) -> int | None:
+        if value is None:
+            return None
+        if isinstance(value, (bool, np.bool_)) or not isinstance(
+            value,
+            (int, np.integer),
+        ):
+            raise TypeError(
+                "degrees_of_freedom must be an integer when supplied."
+            )
+        normalized = int(value)
+        if normalized < 1:
+            raise ValueError(
+                "degrees_of_freedom must be at least 1 when supplied."
+            )
+        return normalized
+
+    @staticmethod
+    def _normalize_residual_variance(value: Any) -> float | None:
+        if value is None:
+            return None
+        if isinstance(value, (bool, np.bool_)):
+            raise TypeError(
+                "residual_variance must be numeric, not boolean."
+            )
+        normalized = float(value)
+        if not math.isfinite(normalized) or normalized < 0.0:
+            raise ValueError(
+                "residual_variance must be finite and non-negative when "
+                "supplied."
+            )
+        return normalized
+
+    @property
+    def offset_standard_error(self) -> float | None:
+        """Return the derived offset standard error when available."""
+
+        if self.coefficient_covariance is None:
+            return None
+        return math.sqrt(self.coefficient_covariance[0][0])
+
+    @property
+    def scale_standard_error(self) -> float | None:
+        """Return the derived scale standard error when available."""
+
+        if self.coefficient_covariance is None:
+            return None
+        return math.sqrt(self.coefficient_covariance[1][1])
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a strict JSON-safe uncertainty representation."""
+
+        return {
+            "schema_version": self.schema_version,
+            "status": self.status.value,
+            "uncertainty_source": self.uncertainty_source,
+            "coefficient_order": ["offset", "scale"],
+            "coefficient_covariance": (
+                None
+                if self.coefficient_covariance is None
+                else [
+                    list(row)
+                    for row in self.coefficient_covariance
+                ]
+            ),
+            "offset_standard_error": self.offset_standard_error,
+            "scale_standard_error": self.scale_standard_error,
+            "estimation_method": self.estimation_method,
+            "degrees_of_freedom": self.degrees_of_freedom,
+            "residual_variance": self.residual_variance,
+            "reason": self.reason,
+            "predictive_uncertainty_propagated": False,
+        }
+
+
+INSTRUMENT_CHANNEL_CALIBRATION_MODEL_SCHEMA_VERSION = "2.0"
 
 
 @dataclass(frozen=True)
@@ -1161,6 +1480,9 @@ class InstrumentChannelCalibration:
     n_pairs: int
     n_inliers: int
     residual_mad_sigma: float | None
+    coefficient_uncertainty: (
+        InstrumentChannelCalibrationCoefficientUncertainty
+    )
     fit_method: str = "iterative_mad_clipped_affine"
 
     def __post_init__(self) -> None:
@@ -1227,6 +1549,16 @@ class InstrumentChannelCalibration:
                     "when supplied."
                 )
 
+        if not isinstance(
+            self.coefficient_uncertainty,
+            InstrumentChannelCalibrationCoefficientUncertainty,
+        ):
+            raise TypeError(
+                "coefficient_uncertainty must be an "
+                "InstrumentChannelCalibrationCoefficientUncertainty "
+                "instance."
+            )
+
     def to_dict(self) -> dict[str, Any]:
         """Return a strict JSON-safe representation."""
 
@@ -1245,6 +1577,9 @@ class InstrumentChannelCalibration:
                 else float(self.residual_mad_sigma)
             ),
             "fit_method": self.fit_method,
+            "coefficient_uncertainty": (
+                self.coefficient_uncertainty.to_dict()
+            ),
             "application_equation": (
                 "reference_flux = offset + scale * channel_flux"
             ),
@@ -2859,6 +3194,22 @@ def fit_instrument_channel_calibration(
         n_inliers=n_inliers,
         residual_mad_sigma=_calibration_mad_sigma(
             final_residual
+        ),
+        coefficient_uncertainty=(
+            InstrumentChannelCalibrationCoefficientUncertainty(
+                schema_version=(
+                    INSTRUMENT_CHANNEL_CALIBRATION_UNCERTAINTY_SCHEMA_VERSION
+                ),
+                status=(
+                    InstrumentChannelCalibrationUncertaintyStatus.UNAVAILABLE
+                ),
+                uncertainty_source="pgmuvi_affine_fit",
+                coefficient_covariance=None,
+                reason=(
+                    "Coefficient-uncertainty estimation is not implemented "
+                    "for the current affine fitter."
+                ),
+            )
         ),
     )
 

--- a/tests/test_docs_instrument_channel_calibration.py
+++ b/tests/test_docs_instrument_channel_calibration.py
@@ -38,6 +38,14 @@ class TestInstrumentChannelCalibrationDocumentation(unittest.TestCase):
             "INSTRUMENT_CHANNEL_CALIBRATION_MODEL_SCHEMA_VERSION",
             instrument_channel_calibration.__all__,
         )
+        self.assertIn(
+            "InstrumentChannelCalibrationCoefficientUncertainty",
+            instrument_channel_calibration.__all__,
+        )
+        self.assertIn(
+            "INSTRUMENT_CHANNEL_CALIBRATION_UNCERTAINTY_SCHEMA_VERSION",
+            instrument_channel_calibration.__all__,
+        )
 
         api_text = API.read_text(encoding="utf-8")
         page_text = PAGE.read_text(encoding="utf-8")
@@ -83,9 +91,23 @@ class TestInstrumentChannelCalibrationDocumentation(unittest.TestCase):
         self.assertIn("O(n_reference * n_channel)", text)
         self.assertIn("time and memory cost", text)
         self.assertIn("affine", text.lower())
+        normalized = " ".join(text.split())
+        self.assertIn(
+            "InstrumentChannelCalibrationCoefficientUncertainty",
+            text,
+        )
+        self.assertIn("fixed coefficient order", normalized)
+        self.assertIn("offset, scale", normalized)
+        self.assertIn("complete symmetric 2-by-2 covariance", normalized)
+        self.assertIn("explicit uncertainty source", normalized)
+        self.assertIn("unavailable", normalized)
+        self.assertIn(
+            "does not estimate covariance",
+            normalized,
+        )
         self.assertIn(
             "does not propagate uncertainty in the fitted offset or scale",
-            " ".join(text.split()),
+            normalized,
         )
 
     def test_future_work_marker_remains_open(self):
@@ -97,6 +119,10 @@ class TestInstrumentChannelCalibrationDocumentation(unittest.TestCase):
         self.assertIn("does not close", text)
         self.assertIn(
             "representative calibration validation",
+            text,
+        )
+        self.assertIn(
+            "uncertainty estimation and propagation",
             text,
         )
 

--- a/tests/test_instrument_channel_calibration_fit_apply.py
+++ b/tests/test_instrument_channel_calibration_fit_apply.py
@@ -7,10 +7,27 @@ import numpy as np
 
 from pgmuvi.instrument_channel_calibration import (
     INSTRUMENT_CHANNEL_CALIBRATION_MODEL_SCHEMA_VERSION,
+    INSTRUMENT_CHANNEL_CALIBRATION_UNCERTAINTY_SCHEMA_VERSION,
     InstrumentChannelCalibration,
+    InstrumentChannelCalibrationCoefficientUncertainty,
+    InstrumentChannelCalibrationUncertaintyStatus,
     apply_instrument_channel_calibration,
     fit_instrument_channel_calibration,
 )
+
+
+def _unavailable_coefficient_uncertainty():
+    return InstrumentChannelCalibrationCoefficientUncertainty(
+        schema_version=(
+            INSTRUMENT_CHANNEL_CALIBRATION_UNCERTAINTY_SCHEMA_VERSION
+        ),
+        status=(
+            InstrumentChannelCalibrationUncertaintyStatus.UNAVAILABLE
+        ),
+        uncertainty_source="test_fixture",
+        coefficient_covariance=None,
+        reason="Coefficient uncertainty is unavailable in this fixture.",
+    )
 
 
 class TestInstrumentChannelCalibrationFit(unittest.TestCase):
@@ -198,6 +215,9 @@ class TestInstrumentChannelCalibrationFit(unittest.TestCase):
             "n_pairs": 20,
             "n_inliers": 18,
             "residual_mad_sigma": 0.01,
+            "coefficient_uncertainty": (
+                _unavailable_coefficient_uncertainty()
+            ),
         }
 
         calibration = InstrumentChannelCalibration(
@@ -235,6 +255,9 @@ class TestInstrumentChannelCalibrationApply(unittest.TestCase):
             n_pairs=20,
             n_inliers=18,
             residual_mad_sigma=0.01,
+            coefficient_uncertainty=(
+                _unavailable_coefficient_uncertainty()
+            ),
         )
 
     def test_flux_is_mapped_to_reference_scale(self):

--- a/tests/test_instrument_channel_calibration_orchestration_contract.py
+++ b/tests/test_instrument_channel_calibration_orchestration_contract.py
@@ -3,9 +3,12 @@ import unittest
 
 from pgmuvi.instrument_channel_calibration import (
     INSTRUMENT_CHANNEL_CALIBRATION_MODEL_SCHEMA_VERSION,
+    INSTRUMENT_CHANNEL_CALIBRATION_UNCERTAINTY_SCHEMA_VERSION,
     INSTRUMENT_CHANNEL_CALIBRATION_PLAN_SCHEMA_VERSION,
     INSTRUMENT_CHANNEL_PAIRING_SCHEMA_VERSION,
     InstrumentChannelCalibration,
+    InstrumentChannelCalibrationCoefficientUncertainty,
+    InstrumentChannelCalibrationUncertaintyStatus,
     InstrumentChannelCalibrationChannelPlan,
     InstrumentChannelCalibrationDisposition,
     InstrumentChannelCalibrationGroupPlan,
@@ -15,6 +18,20 @@ from pgmuvi.instrument_channel_calibration import (
     assess_instrument_channel_calibration_requirement,
     define_instrument_channel_calibration_plan,
 )
+
+
+def _unavailable_coefficient_uncertainty():
+    return InstrumentChannelCalibrationCoefficientUncertainty(
+        schema_version=(
+            INSTRUMENT_CHANNEL_CALIBRATION_UNCERTAINTY_SCHEMA_VERSION
+        ),
+        status=(
+            InstrumentChannelCalibrationUncertaintyStatus.UNAVAILABLE
+        ),
+        uncertainty_source="test_fixture",
+        coefficient_covariance=None,
+        reason="Coefficient uncertainty is unavailable in this fixture.",
+    )
 
 
 class TestInstrumentChannelCalibrationOrchestrationContract(
@@ -299,6 +316,9 @@ class TestInstrumentChannelCalibrationOrchestrationContract(
             n_pairs=3,
             n_inliers=3,
             residual_mad_sigma=0.01,
+            coefficient_uncertainty=(
+                _unavailable_coefficient_uncertainty()
+            ),
         )
         channel_plan = self._planned(
             "B",
@@ -343,6 +363,9 @@ class TestInstrumentChannelCalibrationOrchestrationContract(
             n_pairs=3,
             n_inliers=3,
             residual_mad_sigma=0.0,
+            coefficient_uncertainty=(
+                _unavailable_coefficient_uncertainty()
+            ),
         )
         with self.assertRaisesRegex(
             ValueError,

--- a/tests/test_instrument_channel_calibration_uncertainty_contract.py
+++ b/tests/test_instrument_channel_calibration_uncertainty_contract.py
@@ -1,0 +1,233 @@
+"""Affine coefficient-uncertainty provenance contract tests."""
+
+import json
+import unittest
+
+import numpy as np
+
+from pgmuvi.instrument_channel_calibration import (
+    INSTRUMENT_CHANNEL_CALIBRATION_MODEL_SCHEMA_VERSION,
+    INSTRUMENT_CHANNEL_CALIBRATION_UNCERTAINTY_SCHEMA_VERSION,
+    InstrumentChannelCalibration,
+    InstrumentChannelCalibrationCoefficientUncertainty,
+    InstrumentChannelCalibrationUncertaintyStatus,
+    fit_instrument_channel_calibration,
+)
+
+
+class TestInstrumentChannelCalibrationCoefficientUncertainty(unittest.TestCase):
+    @staticmethod
+    def _available(**overrides):
+        values = {
+            "schema_version": (
+                INSTRUMENT_CHANNEL_CALIBRATION_UNCERTAINTY_SCHEMA_VERSION
+            ),
+            "status": (
+                InstrumentChannelCalibrationUncertaintyStatus.AVAILABLE
+            ),
+            "uncertainty_source": "caller_supplied_bootstrap",
+            "coefficient_covariance": (
+                (np.float64(0.04), np.float64(-0.006)),
+                (np.float64(-0.006), np.float64(0.01)),
+            ),
+            "estimation_method": "paired_bootstrap",
+            "degrees_of_freedom": np.int64(18),
+            "residual_variance": np.float64(0.0025),
+        }
+        values.update(overrides)
+        return InstrumentChannelCalibrationCoefficientUncertainty(**values)
+
+    @staticmethod
+    def _unavailable(**overrides):
+        values = {
+            "schema_version": (
+                INSTRUMENT_CHANNEL_CALIBRATION_UNCERTAINTY_SCHEMA_VERSION
+            ),
+            "status": (
+                InstrumentChannelCalibrationUncertaintyStatus.UNAVAILABLE
+            ),
+            "uncertainty_source": "pgmuvi_affine_fit",
+            "coefficient_covariance": None,
+            "reason": "Coefficient uncertainty was not estimated.",
+        }
+        values.update(overrides)
+        return InstrumentChannelCalibrationCoefficientUncertainty(**values)
+
+    def test_unknown_uncertainty_and_legacy_model_schemas_are_rejected(self):
+        with self.assertRaisesRegex(ValueError, "uncertainty schema"):
+            self._available(schema_version="unknown")
+
+        with self.assertRaisesRegex(ValueError, "model schema"):
+            InstrumentChannelCalibration(
+                schema_version="1.0",
+                reference_channel="reference",
+                channel="target",
+                wavelength=1.0,
+                offset=0.25,
+                scale=1.5,
+                n_pairs=20,
+                n_inliers=18,
+                residual_mad_sigma=0.01,
+                coefficient_uncertainty=self._available(),
+            )
+
+    def test_available_covariance_is_immutable_and_json_safe(self):
+        uncertainty = self._available()
+
+        self.assertEqual(
+            uncertainty.coefficient_covariance,
+            ((0.04, -0.006), (-0.006, 0.01)),
+        )
+        self.assertAlmostEqual(uncertainty.offset_standard_error, 0.2)
+        self.assertAlmostEqual(uncertainty.scale_standard_error, 0.1)
+
+        payload = uncertainty.to_dict()
+        json.dumps(payload, allow_nan=False)
+        self.assertEqual(payload["coefficient_order"], ["offset", "scale"])
+        self.assertEqual(
+            payload["coefficient_covariance"],
+            [[0.04, -0.006], [-0.006, 0.01]],
+        )
+        self.assertFalse(payload["predictive_uncertainty_propagated"])
+
+    def test_available_uncertainty_requires_covariance_and_method(self):
+        with self.assertRaisesRegex(ValueError, "requires a complete"):
+            self._available(coefficient_covariance=None)
+        with self.assertRaisesRegex(ValueError, "estimation_method"):
+            self._available(estimation_method=None)
+        with self.assertRaisesRegex(ValueError, "must not carry"):
+            self._available(reason="Unexpected reason.")
+
+    def test_covariance_must_be_symmetric_positive_semidefinite(self):
+        with self.assertRaisesRegex(ValueError, "symmetric"):
+            self._available(
+                coefficient_covariance=((1.0, 0.2), (0.1, 1.0))
+            )
+        with self.assertRaisesRegex(ValueError, "positive semidefinite"):
+            self._available(
+                coefficient_covariance=((1.0, 2.0), (2.0, 1.0))
+            )
+        with self.assertRaisesRegex(ValueError, "positive semidefinite"):
+            self._available(
+                coefficient_covariance=(
+                    (1.0e-8, 1.1e-8),
+                    (1.1e-8, 1.0e-8),
+                )
+            )
+
+    def test_covariance_rejects_boolean_values(self):
+        boolean_covariances = (
+            [[1.0, False], [False, 1.0]],
+            (
+                (1.0, np.bool_(False)),
+                (np.bool_(False), 1.0),
+            ),
+            np.asarray(
+                [[1.0, False], [False, 1.0]],
+                dtype=object,
+            ),
+        )
+
+        for covariance in boolean_covariances:
+            with self.subTest(covariance=covariance):
+                with self.assertRaisesRegex(TypeError, "not booleans"):
+                    self._available(
+                        coefficient_covariance=covariance
+                    )
+
+    def test_unavailable_uncertainty_is_explicit_and_non_numeric(self):
+        uncertainty = self._unavailable()
+        payload = uncertainty.to_dict()
+        json.dumps(payload, allow_nan=False)
+
+        self.assertEqual(payload["status"], "unavailable")
+        self.assertIsNone(payload["coefficient_covariance"])
+        self.assertIsNone(payload["offset_standard_error"])
+        self.assertEqual(
+            payload["reason"],
+            "Coefficient uncertainty was not estimated.",
+        )
+
+        with self.assertRaisesRegex(ValueError, "requires a reason"):
+            self._unavailable(reason=None)
+        with self.assertRaisesRegex(ValueError, "cannot contain"):
+            self._unavailable(
+                coefficient_covariance=((1.0, 0.0), (0.0, 1.0))
+            )
+
+    def test_optional_estimation_metadata_is_strict(self):
+        with self.assertRaisesRegex(TypeError, "integer"):
+            self._available(degrees_of_freedom=True)
+        with self.assertRaisesRegex(ValueError, "at least 1"):
+            self._available(degrees_of_freedom=0)
+        with self.assertRaisesRegex(TypeError, "not boolean"):
+            self._available(residual_variance=np.bool_(False))
+        with self.assertRaisesRegex(ValueError, "non-negative"):
+            self._available(residual_variance=-0.1)
+
+    def test_model_schema_requires_nested_uncertainty_record(self):
+        uncertainty = self._available()
+        calibration = InstrumentChannelCalibration(
+            schema_version=(
+                INSTRUMENT_CHANNEL_CALIBRATION_MODEL_SCHEMA_VERSION
+            ),
+            reference_channel="reference",
+            channel="target",
+            wavelength=1.0,
+            offset=0.25,
+            scale=1.5,
+            n_pairs=20,
+            n_inliers=18,
+            residual_mad_sigma=0.01,
+            coefficient_uncertainty=uncertainty,
+        )
+
+        payload = calibration.to_dict()
+        json.dumps(payload, allow_nan=False)
+        self.assertEqual(
+            payload["coefficient_uncertainty"]["status"],
+            "available",
+        )
+
+        with self.assertRaisesRegex(
+            TypeError,
+            "InstrumentChannelCalibrationCoefficientUncertainty",
+        ):
+            InstrumentChannelCalibration(
+                schema_version=(
+                    INSTRUMENT_CHANNEL_CALIBRATION_MODEL_SCHEMA_VERSION
+                ),
+                reference_channel="reference",
+                channel="target",
+                wavelength=1.0,
+                offset=0.25,
+                scale=1.5,
+                n_pairs=20,
+                n_inliers=18,
+                residual_mad_sigma=0.01,
+                coefficient_uncertainty=object(),
+            )
+
+    def test_current_fitter_records_uncertainty_as_unavailable(self):
+        channel_flux = np.linspace(0.0, 1.0, 20)
+        reference_flux = 0.25 + 1.5 * channel_flux
+
+        calibration = fit_instrument_channel_calibration(
+            reference_flux,
+            channel_flux,
+            reference_channel="reference",
+            channel="target",
+            wavelength=1.0,
+        )
+
+        uncertainty = calibration.coefficient_uncertainty
+        self.assertEqual(
+            uncertainty.status,
+            InstrumentChannelCalibrationUncertaintyStatus.UNAVAILABLE,
+        )
+        self.assertEqual(uncertainty.uncertainty_source, "pgmuvi_affine_fit")
+        self.assertIn("not implemented", uncertainty.reason)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Define the provenance contract for uncertainty in the affine offset and scale coefficients used to map one observational channel onto a reference observational channel at the same physical wavelength.

## Contract

- add an immutable, strict-JSON-safe coefficient-uncertainty record;
- preserve the complete symmetric positive-semidefinite 2-by-2 covariance matrix in fixed `offset, scale` order when uncertainty is available;
- derive offset and scale standard errors from the covariance diagonal;
- require explicit uncertainty source and estimation-method provenance;
- require a reason, and prohibit placeholder numerical metadata, when uncertainty is unavailable;
- bump the calibration-model schema to version 2.0 and require the nested uncertainty record.

## Current implementation boundary

The existing affine fitter records coefficient uncertainty as unavailable. It does not estimate covariance or silently approximate it.

Calibration application continues to propagate measurement uncertainty through the fitted scale only. Predictive propagation of fitted offset-and-scale uncertainty remains future work.

No automatic calibration choice or normal light-curve fitting integration is introduced.

## Validation

- Ruff passed.
- Strict documentation build succeeded.
- All 2,629 tests passed.

## Stacking

This pull request is stacked on `pr143-implement-instrument-channel-calibration-orchestration`.
