### PR TITLE
Implement calibration coefficient uncertainty estimation

### DIFF
--- a/docs/source/future_work.rst
+++ b/docs/source/future_work.rst
@@ -119,10 +119,11 @@ Wavelength-model extensions
     defines an inert JSON-safe dataset-level orchestration plan contract, and
     executes caller-authored plans across shared-wavelength observational channels
     into copied calibrated arrays with completed pairing and fit
-    provenance. This does not close the marker: scientifically
-    validated instrument-specific tolerance guidance, fitted-coefficient
-    uncertainty estimation and propagation, workflow integration, and
-    representative
+    provenance, including local covariance estimation for unweighted and
+    reference-error weighted final affine solves. This does not close the
+    marker: scientifically validated instrument-specific tolerance guidance,
+    fitted-coefficient uncertainty estimation for scale-dependent channel-axis
+    errors, predictive propagation, workflow integration, and representative
     calibration validation remain future work.
 
 **TBD[multi-periodic-wavelength-models]**

--- a/docs/source/pgmuvi.instrument_channel_calibration.rst
+++ b/docs/source/pgmuvi.instrument_channel_calibration.rst
@@ -73,13 +73,32 @@ standard errors are derived from the covariance diagonal rather than stored as
 independent values.  The record also preserves an explicit uncertainty source,
 estimation method, and optional degrees of freedom and residual variance.
 
-When coefficient uncertainty has not been estimated, the nested record uses the
-explicit ``unavailable`` status and a required reason.  It cannot contain
-placeholder covariance or estimation metadata.  This applies equally to
-caller-supplied calibration provenance and calibrations produced by PGMUVI.
-The current affine fitter records coefficient uncertainty as unavailable; it
-does not estimate covariance, and application still propagates only measurement
-uncertainty through the fitted scale.
+The affine fitter estimates covariance for its final fixed-weight least-squares
+subproblem, conditional on the final MAD-clipped inlier set, when either no
+measurement errors or only reference-channel errors are supplied.  With no
+supplied errors it uses the ordinary-least-squares normal-matrix inverse scaled
+by the residual variance
+``sum(residual**2) / (n_inliers - 2)``.  Reference-channel errors use a
+known-variance weighted normal-matrix inverse without residual-variance
+rescaling.
+
+Coefficient covariance is unavailable when channel-axis errors are supplied.
+Those errors produce effective residual variances that depend on the fitted
+scale, while the current iterative weighting procedure does not expose a
+full-objective Hessian or estimating-equation covariance for that dependence.
+PGMUVI therefore records an explicit unavailable reason rather than presenting
+a frozen-weight normal-matrix inverse as uncertainty for the complete
+estimator.
+
+Covariance also remains unavailable, with a deterministic reason, when the
+final weighted design has zero residual degrees of freedom, invalid numerical
+inputs, a failed singular-value decomposition, or numerical rank deficiency.
+Available covariance is local and conditional: it does not include uncertainty
+from pair construction, MAD-clipping selection, calibration-family choice, or
+caller choices about observational-channel pairing.  Its fixed coefficient
+order is ``offset, scale``.  Application still propagates only measurement
+uncertainty through the fitted scale; it does not propagate the estimated
+coefficient covariance into calibrated predictions.
 
 Executing an explicit plan
 --------------------------
@@ -140,7 +159,8 @@ still lacks:
 
 * scientifically validated instrument-specific rules for choosing
   pairing methods and tolerances;
-* estimation and propagation of fitted-coefficient uncertainty;
+* coefficient-uncertainty estimation for scale-dependent channel-axis errors;
+* propagation of fitted-coefficient uncertainty into calibrated predictions;
 * integration into the normal light-curve fitting workflow; and
 * validation across representative instruments, filters, and LPV sources.
 

--- a/pgmuvi/instrument_channel_calibration.py
+++ b/pgmuvi/instrument_channel_calibration.py
@@ -2886,6 +2886,167 @@ def _weighted_affine_solution(
     return float(offset), float(scale)
 
 
+def _estimate_affine_coefficient_uncertainty(
+    channel_flux: np.ndarray,
+    residual: np.ndarray,
+    weights: np.ndarray,
+    *,
+    measurement_errors_supplied: bool,
+    channel_errors_supplied: bool,
+) -> InstrumentChannelCalibrationCoefficientUncertainty:
+    """Estimate covariance for the final fixed-weight affine solve.
+
+    The covariance is conditional on the final clipped inlier set.
+    Unweighted solves estimate residual variance, while reference-channel
+    measurement variances are treated as known. Channel-axis measurement
+    errors make the effective variances depend on the fitted scale, so this
+    helper returns an explicit unavailable record rather than freezing those
+    weights.
+    """
+
+    uncertainty_source = "pgmuvi_affine_fit_final_inliers"
+
+    def unavailable(
+        reason: str,
+    ) -> InstrumentChannelCalibrationCoefficientUncertainty:
+        return InstrumentChannelCalibrationCoefficientUncertainty(
+            schema_version=(
+                INSTRUMENT_CHANNEL_CALIBRATION_UNCERTAINTY_SCHEMA_VERSION
+            ),
+            status=(
+                InstrumentChannelCalibrationUncertaintyStatus.UNAVAILABLE
+            ),
+            uncertainty_source=uncertainty_source,
+            coefficient_covariance=None,
+            reason=reason,
+        )
+
+    degrees_of_freedom = int(channel_flux.size - 2)
+    if degrees_of_freedom < 1:
+        return unavailable(
+            "Final affine inlier set has zero residual degrees of freedom; "
+            "coefficient covariance is unavailable."
+        )
+
+    if (
+        residual.shape != channel_flux.shape
+        or weights.shape != channel_flux.shape
+    ):
+        return unavailable(
+            "Final affine covariance inputs have inconsistent shapes."
+        )
+    if np.any(~np.isfinite(weights) | (weights <= 0.0)):
+        return unavailable(
+            "Final affine weights are not finite and strictly positive; "
+            "coefficient covariance is unavailable."
+        )
+    if np.any(~np.isfinite(channel_flux)) or np.any(~np.isfinite(residual)):
+        return unavailable(
+            "Final affine covariance inputs contain non-finite values."
+        )
+
+    if channel_errors_supplied:
+        return unavailable(
+            "Coefficient covariance is unavailable when channel-axis "
+            "measurement errors contribute scale-dependent effective "
+            "variances; the current affine fitter does not expose a "
+            "covariance estimator for the full iterative weighting procedure."
+        )
+
+    design = np.column_stack(
+        (
+            np.ones(channel_flux.size, dtype=float),
+            channel_flux,
+        )
+    )
+    weighted_design = design * np.sqrt(weights)[:, None]
+
+    try:
+        _, singular_values, right_singular_vectors = np.linalg.svd(
+            weighted_design,
+            full_matrices=False,
+        )
+    except np.linalg.LinAlgError:
+        return unavailable(
+            "Final weighted affine design decomposition failed; "
+            "coefficient covariance is unavailable."
+        )
+
+    if singular_values.shape != (2,) or np.any(
+        ~np.isfinite(singular_values)
+    ):
+        return unavailable(
+            "Final weighted affine design has invalid singular values; "
+            "coefficient covariance is unavailable."
+        )
+
+    largest_singular_value = float(singular_values[0])
+    smallest_singular_value = float(singular_values[-1])
+    if largest_singular_value <= 0.0:
+        return unavailable(
+            "Final weighted affine design is rank-deficient; coefficient "
+            "covariance is unavailable."
+        )
+
+    minimum_relative_singular_value = math.sqrt(np.finfo(float).eps)
+    if (
+        smallest_singular_value / largest_singular_value
+        <= minimum_relative_singular_value
+    ):
+        return unavailable(
+            "Final weighted affine design is numerically rank-deficient; "
+            "coefficient covariance is unavailable."
+        )
+
+    inverse_squared_singular_values = 1.0 / singular_values**2
+    covariance = (
+        right_singular_vectors.T * inverse_squared_singular_values
+    ) @ right_singular_vectors
+
+    residual_variance = None
+    if not measurement_errors_supplied:
+        residual_variance = float(
+            np.dot(residual, residual) / degrees_of_freedom
+        )
+        covariance = covariance * residual_variance
+        estimation_method = (
+            "ordinary_least_squares_residual_variance_scaled_"
+            "normal_matrix_inverse"
+        )
+    else:
+        estimation_method = (
+            "known_variance_weighted_normal_matrix_inverse"
+        )
+
+    covariance = 0.5 * (covariance + covariance.T)
+    if np.any(~np.isfinite(covariance)):
+        return unavailable(
+            "Final affine coefficient covariance contains non-finite values."
+        )
+    if residual_variance is not None and (
+        not np.isfinite(residual_variance) or residual_variance < 0.0
+    ):
+        return unavailable(
+            "Estimated affine residual variance is invalid; coefficient "
+            "covariance is unavailable."
+        )
+
+    return InstrumentChannelCalibrationCoefficientUncertainty(
+        schema_version=(
+            INSTRUMENT_CHANNEL_CALIBRATION_UNCERTAINTY_SCHEMA_VERSION
+        ),
+        status=InstrumentChannelCalibrationUncertaintyStatus.AVAILABLE,
+        uncertainty_source=uncertainty_source,
+        coefficient_covariance=(
+            (float(covariance[0, 0]), float(covariance[0, 1])),
+            (float(covariance[1, 0]), float(covariance[1, 1])),
+        ),
+        estimation_method=estimation_method,
+        degrees_of_freedom=degrees_of_freedom,
+        residual_variance=residual_variance,
+    )
+
+
 def _calibration_mad_sigma(values: np.ndarray) -> float:
     if values.size == 0:
         return 0.0
@@ -2948,6 +3109,15 @@ def fit_instrument_channel_calibration(
     InstrumentChannelCalibration
         An immutable affine mapping satisfying
         ``reference_flux = offset + scale * channel_flux``.
+
+    Notes
+    -----
+    Coefficient covariance is estimated for the final fixed-weight solve,
+    conditional on the final MAD-clipped inlier set. Reference-channel
+    measurement variances are treated as known. When channel-axis errors are
+    supplied, their effective variances depend on the fitted scale, so
+    coefficient covariance is recorded as unavailable rather than using a
+    frozen-weight approximation.
     """
 
     if isinstance(min_pairs, bool) or not isinstance(min_pairs, int):
@@ -3180,6 +3350,15 @@ def fit_instrument_channel_calibration(
         reference[keep]
         - (offset + scale * target[keep])
     )
+    coefficient_uncertainty = _estimate_affine_coefficient_uncertainty(
+        target[keep],
+        final_residual,
+        final_weights,
+        measurement_errors_supplied=(
+            reference_sigma is not None or channel_sigma is not None
+        ),
+        channel_errors_supplied=channel_sigma is not None,
+    )
 
     return InstrumentChannelCalibration(
         schema_version=(
@@ -3195,22 +3374,7 @@ def fit_instrument_channel_calibration(
         residual_mad_sigma=_calibration_mad_sigma(
             final_residual
         ),
-        coefficient_uncertainty=(
-            InstrumentChannelCalibrationCoefficientUncertainty(
-                schema_version=(
-                    INSTRUMENT_CHANNEL_CALIBRATION_UNCERTAINTY_SCHEMA_VERSION
-                ),
-                status=(
-                    InstrumentChannelCalibrationUncertaintyStatus.UNAVAILABLE
-                ),
-                uncertainty_source="pgmuvi_affine_fit",
-                coefficient_covariance=None,
-                reason=(
-                    "Coefficient-uncertainty estimation is not implemented "
-                    "for the current affine fitter."
-                ),
-            )
-        ),
+        coefficient_uncertainty=coefficient_uncertainty,
     )
 
 

--- a/tests/test_docs_instrument_channel_calibration.py
+++ b/tests/test_docs_instrument_channel_calibration.py
@@ -102,7 +102,20 @@ class TestInstrumentChannelCalibrationDocumentation(unittest.TestCase):
         self.assertIn("explicit uncertainty source", normalized)
         self.assertIn("unavailable", normalized)
         self.assertIn(
-            "does not estimate covariance",
+            "ordinary-least-squares normal-matrix inverse",
+            normalized,
+        )
+        self.assertIn(
+            "Coefficient covariance is unavailable when channel-axis errors "
+            "are supplied",
+            normalized,
+        )
+        self.assertIn(
+            "does not expose a full-objective Hessian",
+            normalized,
+        )
+        self.assertIn(
+            "local and conditional",
             normalized,
         )
         self.assertIn(
@@ -122,6 +135,14 @@ class TestInstrumentChannelCalibrationDocumentation(unittest.TestCase):
             text,
         )
         self.assertIn(
+            "scale-dependent channel-axis errors",
+            text,
+        )
+        self.assertIn(
+            "predictive propagation",
+            text,
+        )
+        self.assertNotIn(
             "uncertainty estimation and propagation",
             text,
         )

--- a/tests/test_instrument_channel_calibration_fit_apply.py
+++ b/tests/test_instrument_channel_calibration_fit_apply.py
@@ -73,6 +73,10 @@ class TestInstrumentChannelCalibrationFit(unittest.TestCase):
         self.assertLess(calibration.n_inliers, calibration.n_pairs)
         self.assertAlmostEqual(calibration.offset, 0.125, delta=0.002)
         self.assertAlmostEqual(calibration.scale, 1.35, delta=0.002)
+        self.assertEqual(
+            calibration.coefficient_uncertainty.degrees_of_freedom,
+            calibration.n_inliers - 2,
+        )
 
     def test_zero_mad_outliers_are_clipped(self):
         channel_flux = np.linspace(0.0, 1.0, 61)
@@ -115,6 +119,33 @@ class TestInstrumentChannelCalibrationFit(unittest.TestCase):
 
         self.assertGreater(calibration.scale, 0.0)
         self.assertEqual(calibration.n_pairs, 60)
+
+    def test_too_few_finite_pairs_are_rejected(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "Insufficient finite paired measurements",
+        ):
+            fit_instrument_channel_calibration(
+                np.array([1.0, 2.0, np.nan]),
+                np.array([0.0, 1.0, 2.0]),
+                reference_channel="reference",
+                channel="target",
+                wavelength=0.656,
+            )
+
+    def test_invalid_measurement_errors_can_leave_too_few_pairs(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "Insufficient finite paired measurements",
+        ):
+            fit_instrument_channel_calibration(
+                np.array([1.0, 2.0, 3.0, 4.0]),
+                np.array([0.0, 1.0, 2.0, 3.0]),
+                reference_channel="reference",
+                channel="target",
+                wavelength=0.656,
+                reference_error=np.array([0.1, 0.0, np.nan, 0.1]),
+            )
 
     def test_nonfinite_pairs_are_removed_before_fitting(self):
         reference_flux = self.reference_flux.copy()
@@ -285,6 +316,42 @@ class TestInstrumentChannelCalibrationApply(unittest.TestCase):
         np.testing.assert_allclose(
             error,
             np.array([0.15, 0.30]),
+        )
+
+    def test_available_coefficient_uncertainty_is_not_propagated(self):
+        channel_flux = np.linspace(0.0, 2.0, 20)
+        reference_flux = (
+            0.25
+            + 1.5 * channel_flux
+            + 0.01 * np.sin(np.arange(channel_flux.size))
+        )
+        calibration = fit_instrument_channel_calibration(
+            reference_flux,
+            channel_flux,
+            reference_channel="reference",
+            channel="target",
+            wavelength=0.656,
+            sigma_clip=100.0,
+        )
+
+        self.assertEqual(
+            calibration.coefficient_uncertainty.status,
+            InstrumentChannelCalibrationUncertaintyStatus.AVAILABLE,
+        )
+        _, error = apply_instrument_channel_calibration(
+            np.array([1.0, 2.0]),
+            calibration,
+            flux_error=np.array([0.1, 0.2]),
+        )
+
+        np.testing.assert_allclose(
+            error,
+            np.abs(calibration.scale) * np.array([0.1, 0.2]),
+        )
+        self.assertFalse(
+            calibration.coefficient_uncertainty.to_dict()[
+                "predictive_uncertainty_propagated"
+            ]
         )
 
     def test_calibration_type_is_checked(self):

--- a/tests/test_instrument_channel_calibration_orchestration_execution.py
+++ b/tests/test_instrument_channel_calibration_orchestration_execution.py
@@ -168,6 +168,14 @@ class TestInstrumentChannelCalibrationOrchestrationExecution(
             completed.pairing.channel_row_indices,
             (40, 50, 60),
         )
+        self.assertEqual(
+            completed.calibration.coefficient_uncertainty.status.value,
+            "unavailable",
+        )
+        self.assertIn(
+            "scale-dependent effective variances",
+            completed.calibration.coefficient_uncertainty.reason,
+        )
         self.assertEqual(result.applied_channels, ("B",))
         self.assertEqual(
             result.applied_source_row_indices,

--- a/tests/test_instrument_channel_calibration_uncertainty_contract.py
+++ b/tests/test_instrument_channel_calibration_uncertainty_contract.py
@@ -208,8 +208,131 @@ class TestInstrumentChannelCalibrationCoefficientUncertainty(unittest.TestCase):
                 coefficient_uncertainty=object(),
             )
 
-    def test_current_fitter_records_uncertainty_as_unavailable(self):
-        channel_flux = np.linspace(0.0, 1.0, 20)
+    def test_unweighted_fit_estimates_scaled_normal_matrix_covariance(self):
+        channel_flux = np.linspace(-1.0, 2.0, 24)
+        perturbation = 0.01 * np.sin(np.arange(channel_flux.size))
+        reference_flux = 0.25 + 1.5 * channel_flux + perturbation
+
+        calibration = fit_instrument_channel_calibration(
+            reference_flux,
+            channel_flux,
+            reference_channel="reference",
+            channel="target",
+            wavelength=1.0,
+            sigma_clip=100.0,
+        )
+
+        uncertainty = calibration.coefficient_uncertainty
+        self.assertEqual(
+            uncertainty.status,
+            InstrumentChannelCalibrationUncertaintyStatus.AVAILABLE,
+        )
+        self.assertEqual(
+            uncertainty.uncertainty_source,
+            "pgmuvi_affine_fit_final_inliers",
+        )
+        self.assertEqual(
+            uncertainty.estimation_method,
+            "ordinary_least_squares_residual_variance_scaled_"
+            "normal_matrix_inverse",
+        )
+        self.assertEqual(uncertainty.degrees_of_freedom, 22)
+
+        design = np.column_stack((np.ones(24), channel_flux))
+        residual = reference_flux - (
+            calibration.offset + calibration.scale * channel_flux
+        )
+        expected_residual_variance = float(
+            np.dot(residual, residual) / 22
+        )
+        expected_covariance = (
+            np.linalg.inv(design.T @ design)
+            * expected_residual_variance
+        )
+
+        self.assertAlmostEqual(
+            uncertainty.residual_variance,
+            expected_residual_variance,
+        )
+        np.testing.assert_allclose(
+            uncertainty.coefficient_covariance,
+            expected_covariance,
+            rtol=1.0e-12,
+            atol=1.0e-15,
+        )
+        self.assertGreater(uncertainty.offset_standard_error, 0.0)
+        self.assertGreater(uncertainty.scale_standard_error, 0.0)
+        json.dumps(calibration.to_dict(), allow_nan=False)
+
+    def test_reference_error_fit_uses_known_variance_covariance(self):
+        channel_flux = np.linspace(0.0, 2.0, 20)
+        reference_flux = 0.25 + 1.5 * channel_flux
+        reference_error = np.linspace(0.02, 0.05, channel_flux.size)
+
+        calibration = fit_instrument_channel_calibration(
+            reference_flux,
+            channel_flux,
+            reference_channel="reference",
+            channel="target",
+            wavelength=1.0,
+            reference_error=reference_error,
+        )
+
+        uncertainty = calibration.coefficient_uncertainty
+        self.assertEqual(
+            uncertainty.status,
+            InstrumentChannelCalibrationUncertaintyStatus.AVAILABLE,
+        )
+        self.assertEqual(
+            uncertainty.estimation_method,
+            "known_variance_weighted_normal_matrix_inverse",
+        )
+        self.assertEqual(uncertainty.degrees_of_freedom, 18)
+        self.assertIsNone(uncertainty.residual_variance)
+
+        design = np.column_stack((np.ones(20), channel_flux))
+        weights = 1.0 / reference_error**2
+        expected_covariance = np.linalg.inv(
+            design.T @ (weights[:, None] * design)
+        )
+        np.testing.assert_allclose(
+            uncertainty.coefficient_covariance,
+            expected_covariance,
+            rtol=1.0e-12,
+            atol=1.0e-15,
+        )
+
+    def test_channel_error_fit_records_uncertainty_as_unavailable(self):
+        channel_flux = np.linspace(0.0, 2.0, 20)
+        reference_flux = 0.25 + 1.5 * channel_flux
+
+        calibration = fit_instrument_channel_calibration(
+            reference_flux,
+            channel_flux,
+            reference_channel="reference",
+            channel="target",
+            wavelength=1.0,
+            reference_error=np.full(20, 0.03),
+            channel_error=np.linspace(0.01, 0.02, 20),
+        )
+
+        uncertainty = calibration.coefficient_uncertainty
+        self.assertEqual(
+            uncertainty.status,
+            InstrumentChannelCalibrationUncertaintyStatus.UNAVAILABLE,
+        )
+        self.assertIsNone(uncertainty.coefficient_covariance)
+        self.assertEqual(
+            uncertainty.reason,
+            "Coefficient covariance is unavailable when channel-axis "
+            "measurement errors contribute scale-dependent effective "
+            "variances; the current affine fitter does not expose a "
+            "covariance estimator for the full iterative weighting procedure.",
+        )
+        json.dumps(calibration.to_dict(), allow_nan=False)
+
+    def test_numerically_rank_deficient_fit_has_explicit_unavailable_reason(self):
+        channel_flux = 1.0 + 1.0e-12 * np.arange(20, dtype=float)
         reference_flux = 0.25 + 1.5 * channel_flux
 
         calibration = fit_instrument_channel_calibration(
@@ -225,8 +348,13 @@ class TestInstrumentChannelCalibrationCoefficientUncertainty(unittest.TestCase):
             uncertainty.status,
             InstrumentChannelCalibrationUncertaintyStatus.UNAVAILABLE,
         )
-        self.assertEqual(uncertainty.uncertainty_source, "pgmuvi_affine_fit")
-        self.assertIn("not implemented", uncertainty.reason)
+        self.assertIsNone(uncertainty.coefficient_covariance)
+        self.assertEqual(
+            uncertainty.reason,
+            "Final weighted affine design is numerically rank-deficient; "
+            "coefficient covariance is unavailable.",
+        )
+        json.dumps(calibration.to_dict(), allow_nan=False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- estimate affine calibration coefficient covariance for the final MAD-clipped unweighted least-squares solve using residual-variance scaling
- estimate covariance for reference-error weighted solves using the known-variance weighted normal-matrix inverse
- record coefficient covariance as explicitly unavailable when channel-axis errors create scale-dependent effective variances
- preserve the existing boundary that fitted-coefficient uncertainty is not propagated into calibrated predictions
- update calibration documentation, future-work scope, orchestration coverage, and uncertainty-contract tests

## Scientific scope

The covariance is local and conditional on the final clipped inlier set and selected affine calibration family. It does not include uncertainty from pair construction, clipping selection, calibration-family choice, or caller-authored observational-channel configuration.

Channel-axis measurement errors remain outside the implemented covariance estimator because their effective variances depend on the fitted scale and the current iterative fitter does not expose a full-objective Hessian or estimating-equation covariance.

## Validation

- `ruff check -v --output-format=full --show-fixes ./pgmuvi`
- `make -C docs clean`
- `make -C docs html-strict`
- `PYTHONPATH=. python3 -m unittest discover -s tests -p "test*.py" -v`
- all 2,635 tests passed
