### PR TITLE
Implement calibration predictive uncertainty propagation

### DIFF
--- a/docs/source/future_work.rst
+++ b/docs/source/future_work.rst
@@ -120,13 +120,12 @@ Wavelength-model extensions
     executes caller-authored plans across shared-wavelength observational channels
     into copied calibrated arrays with completed pairing and fit
     provenance, including local covariance estimation for unweighted and
-    reference-error weighted final affine solves, and defines predictive-
-    propagation result, covariance-mode, and orchestration-disposition
-    contracts without activating propagation. This does not close the marker:
-    scientifically validated instrument-specific tolerance guidance,
-    fitted-coefficient uncertainty estimation for scale-dependent channel-axis
-    errors, predictive-propagation implementation, workflow integration, and
-    representative calibration validation remain future work.
+    reference-error weighted final affine solves, and implements dedicated
+    marginal or full-covariance predictive propagation without orchestration
+    activation. This does not close the marker: scientifically validated
+    instrument-specific tolerance guidance, fitted-coefficient uncertainty
+    estimation for scale-dependent channel-axis errors, workflow integration,
+    and representative calibration validation remain future work.
 
 **TBD[multi-periodic-wavelength-models]**
     Add a documented and validated multi-periodic workflow beyond the current

--- a/docs/source/pgmuvi.instrument_channel_calibration.rst
+++ b/docs/source/pgmuvi.instrument_channel_calibration.rst
@@ -115,10 +115,11 @@ the shared wavelength. ``skipped`` and ``unavailable`` entries remain unchanged.
 Execution returns an immutable
 :class:`~pgmuvi.instrument_channel_calibration.InstrumentChannelCalibrationExecution`
 containing copied calibrated arrays, the exact source-row indices transformed,
-and a completed plan with pairing and fitted calibration provenance. It
-does not mutate input arrays, merge channels, alter wavelengths, choose
-scientific configuration automatically, propagate fitted-
-coefficient uncertainty, or integrate calibration into ``Lightcurve.fit()``.
+and a completed plan with pairing and fitted calibration provenance.
+It does not mutate input arrays, merge channels, alter wavelengths, or choose
+scientific configuration automatically.  It does not propagate
+fitted-coefficient uncertainty or integrate calibration into
+``Lightcurve.fit()``.
 
 The fitting API accepts **caller-supplied paired** flux measurements for one
 observational channel and an explicitly named reference channel.  It fits the
@@ -150,15 +151,14 @@ Flux uncertainties are multiplied by the absolute fitted scale.  The current
 application function does not propagate uncertainty in the fitted offset or
 scale themselves.
 
-Predictive-uncertainty propagation contract
--------------------------------------------
+Predictive-uncertainty propagation
+----------------------------------
 
-``InstrumentChannelCalibrationPredictiveUncertainty`` defines an immutable,
-JSON-safe result for a future dedicated
-``apply_instrument_channel_calibration_with_predictive_uncertainty`` callable.
-The existing ``apply_instrument_channel_calibration`` return signature remains
-unchanged.  The dedicated callable raises ``NotImplementedError`` in this
-contract-only tranche and performs no predictive propagation.
+``apply_instrument_channel_calibration_with_predictive_uncertainty`` applies
+the same affine mapping as ``apply_instrument_channel_calibration`` and returns
+an ``InstrumentChannelCalibrationPredictiveUncertainty`` record alongside the
+calibrated flux.  The existing application callable and its return signature
+remain unchanged.
 
 For input :math:`x_i`, the coefficient Jacobian is :math:`J_i=[1, x_i]` in
 fixed coefficient order ``offset, scale``.  With coefficient covariance
@@ -166,23 +166,23 @@ fixed coefficient order ``offset, scale``.  With coefficient covariance
 :math:`J_i C J_j^T`.  Marginal coefficient variance is split into offset
 variance, scale variance, and the offset-scale covariance cross-term.
 Independent input measurement errors contribute
-:math:`a^2 \sigma_i^2` only on the diagonal.  Omitting input errors means a
-zero measurement-variance contribution, and the contract assumes measurement
-errors are independent of fitted coefficients.
+:math:`a^2 \sigma_i^2` only on the diagonal.  Omitting input errors produces
+an explicit zero measurement-variance contribution, and the propagation
+assumes measurement errors are independent of fitted coefficients.
 
-``marginal_variance`` records marginal variance and derived standard
-deviation.  ``full_covariance`` also records correlations between predictions
-that share fitted coefficients.  Scalar input uses ``input_shape=()``; array
-results preserve their shape while uncertainty vectors use flattened row-major
-order.
+``marginal_variance`` records flattened row-major marginal variance components
+and derived standard deviation.  ``full_covariance`` additionally records
+correlations between predictions that share fitted coefficients.  Scalar input
+uses ``input_shape=()``; array results preserve their original shape.
 
 Unavailable coefficient covariance, including current fits with
 scale-dependent channel-axis errors, produces an explicit ``unavailable``
 result with no numerical predictive uncertainty.  There is no silent fallback
-to measurement-only uncertainty.  Future orchestration uses the dispositions
-``not_requested``, ``available``, ``skipped``, and ``unavailable``.  Current
-orchestration continues to record that predictive propagation was not
-performed.
+to measurement-only uncertainty.  Predictive propagation is implemented only
+in the dedicated application callable; current dataset orchestration continues
+to record that propagation was not requested or performed.  The stable future
+orchestration dispositions remain ``not_requested``, ``available``,
+``skipped``, and ``unavailable``.
 
 ``TBD[instrument-channel-calibration]`` remains open
 ----------------------------------------------------
@@ -194,7 +194,6 @@ still lacks:
 * scientifically validated instrument-specific rules for choosing
   pairing methods and tolerances;
 * coefficient-uncertainty estimation for scale-dependent channel-axis errors;
-* propagation of fitted-coefficient uncertainty into calibrated predictions;
 * integration into the normal light-curve fitting workflow; and
 * validation across representative instruments, filters, and LPV sources.
 

--- a/pgmuvi/instrument_channel_calibration.py
+++ b/pgmuvi/instrument_channel_calibration.py
@@ -3918,25 +3918,159 @@ def apply_instrument_channel_calibration_with_predictive_uncertainty(
     np.ndarray,
     InstrumentChannelCalibrationPredictiveUncertainty,
 ]:
-    """Apply calibration with predictive propagation in a future tranche.
+    """Apply affine calibration and propagate predictive uncertainty.
 
-    This dedicated callable preserves the return contract of
-    :func:`apply_instrument_channel_calibration`. A future implementation will
-    use ``J_i = [1, x_i]`` and shared coefficient covariance
-    ``J_i C J_j.T``. Independent input measurement errors will contribute
-    ``scale**2 * flux_error_i**2`` only on the diagonal. Omitting
-    ``flux_error`` will mean a zero measurement-variance contribution.
+    The calibrated flux is identical to
+    :func:`apply_instrument_channel_calibration`. Independent input
+    measurement errors contribute ``scale**2 * flux_error_i**2`` only on the
+    predictive-covariance diagonal. Fitted coefficient covariance contributes
+    ``J_i C J_j.T`` with ``J_i = [1, x_i]`` in fixed coefficient order
+    ``offset, scale``.
 
-    ``marginal_variance`` will expose only marginal uncertainty;
-    ``full_covariance`` will retain correlations induced by shared fitted
-    coefficients. Unavailable coefficient covariance will remain explicitly
-    unavailable rather than falling back silently to measurement-only errors.
-
-    Predictive propagation is not implemented in this contract-only tranche.
+    ``marginal_variance`` returns only flattened row-major variance
+    components. ``full_covariance`` additionally returns the complete
+    covariance between calibrated predictions sharing the fitted
+    coefficients. When coefficient covariance is unavailable, the result is
+    explicitly unavailable and contains no numerical variance components;
+    measurement-only fallback is not performed.
     """
 
-    del flux, calibration, flux_error, covariance_mode
-    raise NotImplementedError(
-        "Predictive instrument-channel calibration uncertainty propagation "
-        "is not implemented."
+    if isinstance(
+        covariance_mode,
+        InstrumentChannelCalibrationPredictiveCovarianceMode,
+    ):
+        normalized_mode = covariance_mode
+    else:
+        try:
+            normalized_mode = (
+                InstrumentChannelCalibrationPredictiveCovarianceMode(
+                    str(covariance_mode)
+                )
+            )
+        except ValueError as exc:
+            raise ValueError(
+                "Unsupported predictive covariance mode: "
+                f"{covariance_mode!r}."
+            ) from exc
+
+    applied = apply_instrument_channel_calibration(
+        flux,
+        calibration,
+        flux_error=flux_error,
+    )
+    input_flux = np.asarray(flux, dtype=float)
+
+    if flux_error is None:
+        calibrated_flux = np.asarray(applied, dtype=float)
+        measurement_variance = np.zeros(
+            calibrated_flux.size,
+            dtype=float,
+        )
+    else:
+        calibrated_flux_value, calibrated_error = applied
+        calibrated_flux = np.asarray(calibrated_flux_value, dtype=float)
+        measurement_variance = np.square(
+            np.asarray(calibrated_error, dtype=float).reshape(
+                -1,
+                order="C",
+            )
+        )
+
+    input_shape = tuple(int(item) for item in calibrated_flux.shape)
+    flattened_flux = input_flux.reshape(-1, order="C")
+    coefficient_uncertainty = calibration.coefficient_uncertainty
+
+    if coefficient_uncertainty.status is (
+        InstrumentChannelCalibrationUncertaintyStatus.UNAVAILABLE
+    ):
+        return (
+            calibrated_flux,
+            InstrumentChannelCalibrationPredictiveUncertainty(
+                schema_version=(
+                    INSTRUMENT_CHANNEL_CALIBRATION_PREDICTIVE_UNCERTAINTY_SCHEMA_VERSION
+                ),
+                status=(
+                    InstrumentChannelCalibrationPredictiveUncertaintyStatus.UNAVAILABLE
+                ),
+                covariance_mode=normalized_mode,
+                input_shape=input_shape,
+                input_measurement_uncertainty_supplied=(
+                    flux_error is not None
+                ),
+                coefficient_uncertainty_status=(
+                    coefficient_uncertainty.status
+                ),
+                coefficient_uncertainty_source=(
+                    coefficient_uncertainty.uncertainty_source
+                ),
+                measurement_variance=None,
+                offset_variance=None,
+                scale_variance=None,
+                offset_scale_covariance_term=None,
+                predictive_covariance=None,
+                reason=coefficient_uncertainty.reason,
+            ),
+        )
+
+    coefficient_covariance = np.asarray(
+        coefficient_uncertainty.coefficient_covariance,
+        dtype=float,
+    )
+    offset_variance = np.full(
+        flattened_flux.size,
+        coefficient_covariance[0, 0],
+        dtype=float,
+    )
+    scale_variance = (
+        np.square(flattened_flux) * coefficient_covariance[1, 1]
+    )
+    offset_scale_covariance_term = (
+        2.0 * flattened_flux * coefficient_covariance[0, 1]
+    )
+
+    predictive_covariance = None
+    if normalized_mode is (
+        InstrumentChannelCalibrationPredictiveCovarianceMode.FULL_COVARIANCE
+    ):
+        design = np.column_stack(
+            (
+                np.ones(flattened_flux.size, dtype=float),
+                flattened_flux,
+            )
+        )
+        predictive_covariance_array = (
+            design @ coefficient_covariance @ design.T
+        )
+        predictive_covariance_array = 0.5 * (
+            predictive_covariance_array
+            + predictive_covariance_array.T
+        )
+        diagonal = np.diag_indices_from(predictive_covariance_array)
+        predictive_covariance_array[diagonal] += measurement_variance
+        predictive_covariance = predictive_covariance_array
+
+    return (
+        calibrated_flux,
+        InstrumentChannelCalibrationPredictiveUncertainty(
+            schema_version=(
+                INSTRUMENT_CHANNEL_CALIBRATION_PREDICTIVE_UNCERTAINTY_SCHEMA_VERSION
+            ),
+            status=(
+                InstrumentChannelCalibrationPredictiveUncertaintyStatus.AVAILABLE
+            ),
+            covariance_mode=normalized_mode,
+            input_shape=input_shape,
+            input_measurement_uncertainty_supplied=(flux_error is not None),
+            coefficient_uncertainty_status=coefficient_uncertainty.status,
+            coefficient_uncertainty_source=(
+                coefficient_uncertainty.uncertainty_source
+            ),
+            measurement_variance=measurement_variance,
+            offset_variance=offset_variance,
+            scale_variance=scale_variance,
+            offset_scale_covariance_term=(
+                offset_scale_covariance_term
+            ),
+            predictive_covariance=predictive_covariance,
+        ),
     )

--- a/tests/test_docs_instrument_channel_calibration.py
+++ b/tests/test_docs_instrument_channel_calibration.py
@@ -142,7 +142,12 @@ class TestInstrumentChannelCalibrationDocumentation(unittest.TestCase):
             "apply_instrument_channel_calibration_with_predictive_uncertainty",
             text,
         )
-        self.assertIn("raises ``NotImplementedError``", normalized)
+        self.assertIn(
+            "returns an ``InstrumentChannelCalibrationPredictiveUncertainty`` "
+            "record",
+            normalized,
+        )
+        self.assertNotIn("raises ``NotImplementedError``", normalized)
         self.assertIn("J_i=[1, x_i]", normalized)
         self.assertIn("offset-scale covariance cross-term", normalized)
         self.assertIn("full_covariance", text)
@@ -172,11 +177,15 @@ class TestInstrumentChannelCalibrationDocumentation(unittest.TestCase):
             "scale-dependent channel-axis errors",
             text,
         )
-        self.assertIn(
+        self.assertNotIn(
             "predictive-propagation implementation",
             text,
         )
-        self.assertIn("without activating propagation", text)
+        self.assertIn(
+            "implements dedicated marginal or full-covariance predictive "
+            "propagation without orchestration activation",
+            text,
+        )
         self.assertNotIn(
             "uncertainty estimation and propagation",
             text,

--- a/tests/test_instrument_channel_calibration_predictive_uncertainty_contract.py
+++ b/tests/test_instrument_channel_calibration_predictive_uncertainty_contract.py
@@ -14,6 +14,7 @@ from pgmuvi.instrument_channel_calibration import (
     InstrumentChannelCalibrationPredictiveCovarianceMode,
     InstrumentChannelCalibrationPredictiveUncertainty,
     InstrumentChannelCalibrationPredictiveUncertaintyDisposition,
+    InstrumentChannelCalibrationPredictiveUncertaintyStatus,
     InstrumentChannelCalibrationUncertaintyStatus,
     apply_instrument_channel_calibration,
     apply_instrument_channel_calibration_with_predictive_uncertainty,
@@ -191,16 +192,35 @@ class TestPredictiveUncertaintyContract(unittest.TestCase):
 
 class TestPredictiveApplicationBoundary(unittest.TestCase):
     @staticmethod
-    def _calibration():
-        uncertainty = InstrumentChannelCalibrationCoefficientUncertainty(
-            schema_version=(
-                INSTRUMENT_CHANNEL_CALIBRATION_UNCERTAINTY_SCHEMA_VERSION
-            ),
-            status=InstrumentChannelCalibrationUncertaintyStatus.AVAILABLE,
-            uncertainty_source="caller_supplied_bootstrap",
-            coefficient_covariance=((0.04, -0.006), (-0.006, 0.01)),
-            estimation_method="paired_bootstrap",
-        )
+    def _calibration(*, coefficient_uncertainty_available=True):
+        if coefficient_uncertainty_available:
+            uncertainty = InstrumentChannelCalibrationCoefficientUncertainty(
+                schema_version=(
+                    INSTRUMENT_CHANNEL_CALIBRATION_UNCERTAINTY_SCHEMA_VERSION
+                ),
+                status=(
+                    InstrumentChannelCalibrationUncertaintyStatus.AVAILABLE
+                ),
+                uncertainty_source="caller_supplied_bootstrap",
+                coefficient_covariance=(
+                    (0.04, -0.006),
+                    (-0.006, 0.01),
+                ),
+                estimation_method="paired_bootstrap",
+            )
+        else:
+            uncertainty = InstrumentChannelCalibrationCoefficientUncertainty(
+                schema_version=(
+                    INSTRUMENT_CHANNEL_CALIBRATION_UNCERTAINTY_SCHEMA_VERSION
+                ),
+                status=(
+                    InstrumentChannelCalibrationUncertaintyStatus.UNAVAILABLE
+                ),
+                uncertainty_source="pgmuvi_affine_fit",
+                coefficient_covariance=None,
+                reason="Coefficient uncertainty was not estimated.",
+            )
+
         return InstrumentChannelCalibration(
             schema_version=INSTRUMENT_CHANNEL_CALIBRATION_MODEL_SCHEMA_VERSION,
             reference_channel="reference",
@@ -229,13 +249,132 @@ class TestPredictiveApplicationBoundary(unittest.TestCase):
             ]
         )
 
-    def test_dedicated_predictive_callable_raises(self):
-        with self.assertRaisesRegex(NotImplementedError, "not implemented"):
+    def test_full_covariance_propagates_measurement_and_coefficients(self):
+        calibrated, result = (
             apply_instrument_channel_calibration_with_predictive_uncertainty(
                 np.array([1.0, 2.0]),
                 self._calibration(),
                 flux_error=np.array([0.1, 0.2]),
                 covariance_mode="full_covariance",
+            )
+        )
+
+        np.testing.assert_allclose(calibrated, [1.75, 3.25])
+        self.assertEqual(
+            result.status,
+            InstrumentChannelCalibrationPredictiveUncertaintyStatus.AVAILABLE,
+        )
+        self.assertEqual(result.input_shape, (2,))
+        np.testing.assert_allclose(
+            result.measurement_variance,
+            (0.0225, 0.09),
+        )
+        np.testing.assert_allclose(
+            result.offset_variance,
+            (0.04, 0.04),
+        )
+        np.testing.assert_allclose(
+            result.scale_variance,
+            (0.01, 0.04),
+        )
+        np.testing.assert_allclose(
+            result.offset_scale_covariance_term,
+            (-0.012, -0.024),
+        )
+        np.testing.assert_allclose(
+            result.predictive_variance,
+            (0.0605, 0.146),
+        )
+        np.testing.assert_allclose(
+            result.predictive_covariance,
+            ((0.0605, 0.042), (0.042, 0.146)),
+        )
+        self.assertTrue(
+            result.to_dict()["predictive_uncertainty_propagated"]
+        )
+
+    def test_marginal_scalar_omits_measurement_variance_explicitly(self):
+        calibrated, result = (
+            apply_instrument_channel_calibration_with_predictive_uncertainty(
+                2.0,
+                self._calibration(),
+                covariance_mode="marginal_variance",
+            )
+        )
+
+        self.assertEqual(calibrated.shape, ())
+        self.assertAlmostEqual(float(calibrated), 3.25)
+        self.assertEqual(result.input_shape, ())
+        self.assertFalse(result.input_measurement_uncertainty_supplied)
+        np.testing.assert_allclose(result.measurement_variance, (0.0,))
+        np.testing.assert_allclose(result.predictive_variance, (0.056,))
+        self.assertIsNone(result.predictive_covariance)
+
+    def test_multidimensional_components_use_row_major_order(self):
+        calibrated, result = (
+            apply_instrument_channel_calibration_with_predictive_uncertainty(
+                np.array([[1.0, 2.0], [3.0, 4.0]]),
+                self._calibration(),
+                covariance_mode=(
+                    InstrumentChannelCalibrationPredictiveCovarianceMode.FULL_COVARIANCE
+                ),
+            )
+        )
+
+        np.testing.assert_allclose(
+            calibrated,
+            [[1.75, 3.25], [4.75, 6.25]],
+        )
+        self.assertEqual(result.input_shape, (2, 2))
+        np.testing.assert_allclose(
+            result.scale_variance,
+            (0.01, 0.04, 0.09, 0.16),
+        )
+        np.testing.assert_allclose(
+            result.offset_scale_covariance_term,
+            (-0.012, -0.024, -0.036, -0.048),
+        )
+        self.assertEqual(np.asarray(result.predictive_covariance).shape, (4, 4))
+
+    def test_unavailable_coefficients_do_not_fall_back_to_measurement_only(self):
+        calibrated, result = (
+            apply_instrument_channel_calibration_with_predictive_uncertainty(
+                np.array([1.0, 2.0]),
+                self._calibration(
+                    coefficient_uncertainty_available=False
+                ),
+                flux_error=np.array([0.1, 0.2]),
+                covariance_mode="full_covariance",
+            )
+        )
+
+        np.testing.assert_allclose(calibrated, [1.75, 3.25])
+        self.assertEqual(
+            result.status,
+            InstrumentChannelCalibrationPredictiveUncertaintyStatus.UNAVAILABLE,
+        )
+        self.assertIsNone(result.measurement_variance)
+        self.assertIsNone(result.predictive_variance)
+        self.assertIsNone(result.predictive_covariance)
+        self.assertEqual(
+            result.reason,
+            "Coefficient uncertainty was not estimated.",
+        )
+
+    def test_predictive_application_reuses_input_validation(self):
+        with self.assertRaisesRegex(ValueError, "predictive covariance mode"):
+            apply_instrument_channel_calibration_with_predictive_uncertainty(
+                np.array([1.0]),
+                self._calibration(),
+                covariance_mode="unknown",
+            )
+
+        with self.assertRaisesRegex(ValueError, "same shape"):
+            apply_instrument_channel_calibration_with_predictive_uncertainty(
+                np.array([1.0, 2.0]),
+                self._calibration(),
+                flux_error=np.array([0.1]),
+                covariance_mode="marginal_variance",
             )
 
 


### PR DESCRIPTION
## Summary

- implement the dedicated instrument-channel calibration predictive-uncertainty application callable
- propagate independent input measurement variance and fitted affine coefficient covariance
- support explicit `marginal_variance` and `full_covariance` modes
- preserve scalar and array input shapes with row-major uncertainty-vector ordering
- return an explicit unavailable result when coefficient covariance is unavailable
- retain the existing calibration-application return contract
- leave dataset orchestration unchanged

## Uncertainty contract

For input flux \(x_i\), predictive coefficient covariance uses the Jacobian
\(J_i = [1, x_i]\) in fixed coefficient order `offset, scale`.

The implementation records:

- measurement variance \(a^2 \sigma_i^2\)
- offset variance
- scale variance
- the offset-scale covariance cross-term
- total marginal predictive variance
- optional full covariance \(J_i C J_j^T\), with measurement variance added only to the diagonal

There is no silent fallback to measurement-only uncertainty when fitted-coefficient covariance is unavailable.

## Validation

- targeted predictive-uncertainty, fit/apply, orchestration, and documentation tests passed
- complete test suite passed: 2,649 tests
- canonical full-package Ruff check passed
- strict Sphinx documentation build passed
- independent numerical covariance audit passed
- exact five-file staged and committed path set verified

## Scope boundary

This pull request does not activate predictive propagation in dataset orchestration, choose scientific calibration configuration, merge observational channels, alter physical wavelengths, or integrate calibration into `Lightcurve.fit()`.