### PR TITLE
Define scale-dependent channel-axis calibration uncertainty contract

### DIFF
--- a/docs/source/future_work.rst
+++ b/docs/source/future_work.rst
@@ -122,10 +122,12 @@ Wavelength-model extensions
     provenance, including local covariance estimation for unweighted and
     reference-error weighted final affine solves, and implements dedicated
     marginal or full-covariance predictive propagation without orchestration
-    activation. This does not close the marker: scientifically validated
-    instrument-specific tolerance guidance, fitted-coefficient uncertainty
-    estimation for scale-dependent channel-axis errors, workflow integration,
-    and representative calibration validation remain future work.
+    activation, and defines the full-objective observed-Hessian contract for
+    future scale-dependent channel-axis coefficient uncertainty estimation.
+    This does not close the marker: scientifically validated instrument-specific
+    tolerance guidance, implementation of the scale-dependent estimator,
+    workflow integration, and representative calibration validation remain
+    future work.
 
 **TBD[multi-periodic-wavelength-models]**
     Add a documented and validated multi-periodic workflow beyond the current

--- a/docs/source/pgmuvi.instrument_channel_calibration.rst
+++ b/docs/source/pgmuvi.instrument_channel_calibration.rst
@@ -90,6 +90,37 @@ PGMUVI therefore records an explicit unavailable reason rather than presenting
 a frozen-weight normal-matrix inverse as uncertainty for the complete
 estimator.
 
+Scale-dependent channel-axis uncertainty contract
+--------------------------------------------------
+
+:class:`~pgmuvi.instrument_channel_calibration.InstrumentChannelCalibrationScaleDependentUncertaintyEstimate`
+defines the immutable JSON-safe result contract for a future dedicated
+:func:`~pgmuvi.instrument_channel_calibration.estimate_scale_dependent_instrument_channel_calibration_coefficient_uncertainty`
+callable.  The callable raises ``NotImplementedError`` in this contract-only
+tranche, and the current affine fitter continues to report coefficient
+uncertainty as unavailable whenever channel-axis errors are supplied.
+
+For final-inlier paired values, the future estimator minimizes the Gaussian
+negative log likelihood
+
+.. math::
+
+   \frac{1}{2}\sum_i\left[
+   \log(v_i) + \frac{r_i^2}{v_i}
+   \right],
+
+where :math:`r_i=y_i-(b+a x_i)` and
+:math:`v_i=\sigma_{y,i}^2+a^2\sigma_{x,i}^2`.  Coefficient order remains
+``offset, scale`` and the scale domain is strictly positive.  Available
+coefficient covariance is defined as the inverse observed Hessian of this full
+objective at a converged optimum, not a frozen-weight normal-matrix inverse.
+
+The result records the optimum, objective value, optimizer and convergence
+state, gradient method and norm, Hessian method and eigenvalues, final-inlier
+conditioning, and deterministic unavailable reason.  It does not include
+uncertainty from pair construction, MAD-clipping selection, calibration-family
+choice, or caller choices about observational-channel pairing.
+
 Covariance also remains unavailable, with a deterministic reason, when the
 final weighted design has zero residual degrees of freedom, invalid numerical
 inputs, a failed singular-value decomposition, or numerical rank deficiency.

--- a/pgmuvi/instrument_channel_calibration.py
+++ b/pgmuvi/instrument_channel_calibration.py
@@ -41,6 +41,9 @@ INSTRUMENT_CHANNEL_CALIBRATION_EXECUTION_SCHEMA_VERSION = (
 INSTRUMENT_CHANNEL_CALIBRATION_UNCERTAINTY_SCHEMA_VERSION = (
     "pgmuvi-instrument-channel-calibration-uncertainty-v1"
 )
+INSTRUMENT_CHANNEL_CALIBRATION_SCALE_DEPENDENT_UNCERTAINTY_SCHEMA_VERSION = (
+    "pgmuvi-instrument-channel-calibration-scale-dependent-uncertainty-v1"
+)
 INSTRUMENT_CHANNEL_CALIBRATION_PREDICTIVE_UNCERTAINTY_SCHEMA_VERSION = (
     "pgmuvi-instrument-channel-calibration-predictive-uncertainty-v1"
 )
@@ -51,6 +54,7 @@ __all__ = [
     "INSTRUMENT_CHANNEL_CALIBRATION_MODEL_SCHEMA_VERSION",
     "INSTRUMENT_CHANNEL_CALIBRATION_PLAN_SCHEMA_VERSION",
     "INSTRUMENT_CHANNEL_CALIBRATION_PREDICTIVE_UNCERTAINTY_SCHEMA_VERSION",
+    "INSTRUMENT_CHANNEL_CALIBRATION_SCALE_DEPENDENT_UNCERTAINTY_SCHEMA_VERSION",
     "INSTRUMENT_CHANNEL_CALIBRATION_SCHEMA_VERSION",
     "INSTRUMENT_CHANNEL_CALIBRATION_TBD_MARKER",
     "INSTRUMENT_CHANNEL_CALIBRATION_UNCERTAINTY_SCHEMA_VERSION",
@@ -67,6 +71,7 @@ __all__ = [
     "InstrumentChannelCalibrationPredictiveUncertainty",
     "InstrumentChannelCalibrationPredictiveUncertaintyDisposition",
     "InstrumentChannelCalibrationPredictiveUncertaintyStatus",
+    "InstrumentChannelCalibrationScaleDependentUncertaintyEstimate",
     "InstrumentChannelCalibrationStatus",
     "InstrumentChannelCalibrationUncertaintyStatus",
     "InstrumentChannelPairing",
@@ -77,6 +82,7 @@ __all__ = [
     "assess_instrument_channel_calibration_requirement",
     "construct_instrument_channel_pairing",
     "define_instrument_channel_calibration_plan",
+    "estimate_scale_dependent_instrument_channel_calibration_coefficient_uncertainty",
     "execute_instrument_channel_calibration_plan",
     "fit_instrument_channel_calibration",
 ]
@@ -1489,6 +1495,408 @@ class InstrumentChannelCalibrationCoefficientUncertainty:
             "residual_variance": self.residual_variance,
             "reason": self.reason,
             "predictive_uncertainty_propagated": False,
+        }
+
+
+@dataclass(frozen=True)
+class InstrumentChannelCalibrationScaleDependentUncertaintyEstimate:
+    """Contract for a future full-objective channel-axis error estimator.
+
+    The estimator is conditioned on a caller-selected final inlier set and
+    minimizes the Gaussian negative log likelihood
+
+    ``0.5 * sum(log(v_i) + residual_i**2 / v_i)``,
+
+    where ``v_i = reference_error_i**2 + scale**2 * channel_error_i**2``.
+    Coefficient order is fixed as ``offset, scale``. Available covariance is
+    the inverse observed Hessian of that full objective at a converged optimum
+    in the strictly positive-scale domain.
+    """
+
+    schema_version: str
+    status: InstrumentChannelCalibrationUncertaintyStatus | str
+    uncertainty_source: str
+    n_inliers: int
+    coefficient_covariance: (
+        tuple[tuple[float, float], tuple[float, float]] | None
+    ) = None
+    offset: float | None = None
+    scale: float | None = None
+    objective_value: float | None = None
+    optimizer: str | None = None
+    optimizer_converged: bool | None = None
+    gradient_method: str | None = None
+    gradient_norm: float | None = None
+    hessian_method: str | None = None
+    hessian_eigenvalues: tuple[float, float] | None = None
+    reason: str | None = None
+    conditioned_on_final_inlier_set: bool = True
+    positive_scale_domain_enforced: bool = True
+
+    def __post_init__(self) -> None:
+        if self.schema_version != (
+            INSTRUMENT_CHANNEL_CALIBRATION_SCALE_DEPENDENT_UNCERTAINTY_SCHEMA_VERSION
+        ):
+            raise ValueError(
+                "Unsupported scale-dependent calibration uncertainty schema "
+                f"version: {self.schema_version!r}."
+            )
+
+        status = self.status
+        if not isinstance(
+            status,
+            InstrumentChannelCalibrationUncertaintyStatus,
+        ):
+            try:
+                status = InstrumentChannelCalibrationUncertaintyStatus(
+                    str(status)
+                )
+            except ValueError as exc:
+                raise ValueError(
+                    "Unsupported scale-dependent calibration uncertainty "
+                    f"status: {self.status!r}."
+                ) from exc
+
+        uncertainty_source = (
+            InstrumentChannelCalibrationCoefficientUncertainty
+            ._normalize_required_text(
+                self.uncertainty_source,
+                name="uncertainty_source",
+            )
+        )
+        optimizer = (
+            InstrumentChannelCalibrationCoefficientUncertainty
+            ._normalize_optional_text(
+                self.optimizer,
+                name="optimizer",
+            )
+        )
+        gradient_method = (
+            InstrumentChannelCalibrationCoefficientUncertainty
+            ._normalize_optional_text(
+                self.gradient_method,
+                name="gradient_method",
+            )
+        )
+        hessian_method = (
+            InstrumentChannelCalibrationCoefficientUncertainty
+            ._normalize_optional_text(
+                self.hessian_method,
+                name="hessian_method",
+            )
+        )
+        reason = (
+            InstrumentChannelCalibrationCoefficientUncertainty
+            ._normalize_optional_text(
+                self.reason,
+                name="reason",
+            )
+        )
+
+        if isinstance(self.n_inliers, (bool, np.bool_)) or not isinstance(
+            self.n_inliers,
+            (int, np.integer),
+        ):
+            raise TypeError("n_inliers must be an integer.")
+        n_inliers = int(self.n_inliers)
+        if n_inliers < 3:
+            raise ValueError("n_inliers must be at least 3.")
+
+        for name in (
+            "conditioned_on_final_inlier_set",
+            "positive_scale_domain_enforced",
+        ):
+            value = getattr(self, name)
+            if not isinstance(value, (bool, np.bool_)):
+                raise TypeError(f"{name} must be boolean.")
+            if not bool(value):
+                raise ValueError(f"{name} must be true for this contract.")
+
+        optimizer_converged = self.optimizer_converged
+        if optimizer_converged is not None and not isinstance(
+            optimizer_converged,
+            (bool, np.bool_),
+        ):
+            raise TypeError("optimizer_converged must be boolean when supplied.")
+        if optimizer_converged is not None:
+            optimizer_converged = bool(optimizer_converged)
+
+        covariance = (
+            InstrumentChannelCalibrationCoefficientUncertainty
+            ._normalize_covariance(self.coefficient_covariance)
+        )
+
+        def finite_optional(
+            value: Any,
+            *,
+            name: str,
+            non_negative: bool = False,
+            strictly_positive: bool = False,
+        ) -> float | None:
+            if value is None:
+                return None
+            if isinstance(value, (bool, np.bool_)):
+                raise TypeError(f"{name} must be numeric, not boolean.")
+            normalized = float(value)
+            if not math.isfinite(normalized):
+                raise ValueError(f"{name} must be finite when supplied.")
+            if non_negative and normalized < 0.0:
+                raise ValueError(
+                    f"{name} must be non-negative when supplied."
+                )
+            if strictly_positive and normalized <= 0.0:
+                raise ValueError(
+                    f"{name} must be strictly positive when supplied."
+                )
+            return normalized
+
+        offset = finite_optional(self.offset, name="offset")
+        scale = finite_optional(
+            self.scale,
+            name="scale",
+            strictly_positive=True,
+        )
+        objective_value = finite_optional(
+            self.objective_value,
+            name="objective_value",
+        )
+        gradient_norm = finite_optional(
+            self.gradient_norm,
+            name="gradient_norm",
+            non_negative=True,
+        )
+
+        hessian_eigenvalues = self._normalize_hessian_eigenvalues(
+            self.hessian_eigenvalues
+        )
+
+        if (
+            status
+            is InstrumentChannelCalibrationUncertaintyStatus.AVAILABLE
+        ):
+            required = {
+                "coefficient_covariance": covariance,
+                "offset": offset,
+                "scale": scale,
+                "objective_value": objective_value,
+                "optimizer": optimizer,
+                "optimizer_converged": optimizer_converged,
+                "gradient_method": gradient_method,
+                "gradient_norm": gradient_norm,
+                "hessian_method": hessian_method,
+                "hessian_eigenvalues": hessian_eigenvalues,
+            }
+            missing = [
+                name for name, value in required.items() if value is None
+            ]
+            if missing:
+                raise ValueError(
+                    "Available scale-dependent uncertainty requires complete "
+                    "estimation provenance; missing "
+                    + ", ".join(missing)
+                    + "."
+                )
+            if optimizer_converged is not True:
+                raise ValueError(
+                    "Available scale-dependent uncertainty requires a "
+                    "converged optimizer."
+                )
+            if reason is not None:
+                raise ValueError(
+                    "Available scale-dependent uncertainty must not carry "
+                    "an unavailable reason."
+                )
+        else:
+            if reason is None:
+                raise ValueError(
+                    "Unavailable scale-dependent uncertainty requires a "
+                    "reason."
+                )
+            if covariance is not None:
+                raise ValueError(
+                    "Unavailable scale-dependent uncertainty cannot carry "
+                    "coefficient covariance."
+                )
+            if any(
+                value is not None
+                for value in (
+                    offset,
+                    scale,
+                    objective_value,
+                    gradient_norm,
+                    hessian_eigenvalues,
+                )
+            ):
+                raise ValueError(
+                    "Unavailable scale-dependent uncertainty cannot carry "
+                    "numerical estimation results."
+                )
+            if optimizer_converged is True:
+                raise ValueError(
+                    "Unavailable scale-dependent uncertainty cannot report "
+                    "a converged optimizer."
+                )
+
+        object.__setattr__(self, "status", status)
+        object.__setattr__(
+            self,
+            "uncertainty_source",
+            uncertainty_source,
+        )
+        object.__setattr__(self, "n_inliers", n_inliers)
+        object.__setattr__(
+            self,
+            "coefficient_covariance",
+            covariance,
+        )
+        object.__setattr__(self, "offset", offset)
+        object.__setattr__(self, "scale", scale)
+        object.__setattr__(
+            self,
+            "objective_value",
+            objective_value,
+        )
+        object.__setattr__(self, "optimizer", optimizer)
+        object.__setattr__(
+            self,
+            "optimizer_converged",
+            optimizer_converged,
+        )
+        object.__setattr__(
+            self,
+            "gradient_method",
+            gradient_method,
+        )
+        object.__setattr__(
+            self,
+            "gradient_norm",
+            gradient_norm,
+        )
+        object.__setattr__(
+            self,
+            "hessian_method",
+            hessian_method,
+        )
+        object.__setattr__(
+            self,
+            "hessian_eigenvalues",
+            hessian_eigenvalues,
+        )
+        object.__setattr__(self, "reason", reason)
+        object.__setattr__(
+            self,
+            "conditioned_on_final_inlier_set",
+            True,
+        )
+        object.__setattr__(
+            self,
+            "positive_scale_domain_enforced",
+            True,
+        )
+
+    @staticmethod
+    def _normalize_hessian_eigenvalues(
+        value: Any,
+    ) -> tuple[float, float] | None:
+        if value is None:
+            return None
+
+        if isinstance(value, np.ndarray):
+            raw = value.tolist()
+        else:
+            raw = value
+
+        if not isinstance(raw, (list, tuple)) or len(raw) != 2:
+            raise ValueError(
+                "hessian_eigenvalues must contain exactly two values."
+            )
+
+        normalized = []
+        for item in raw:
+            if isinstance(item, (bool, np.bool_)):
+                raise TypeError(
+                    "hessian_eigenvalues must be numeric, not boolean."
+                )
+            numeric = float(item)
+            if not math.isfinite(numeric) or numeric <= 0.0:
+                raise ValueError(
+                    "hessian_eigenvalues must be finite and strictly "
+                    "positive."
+                )
+            normalized.append(numeric)
+
+        return (normalized[0], normalized[1])
+
+    @property
+    def offset_standard_error(self) -> float | None:
+        """Return the derived offset standard error when available."""
+
+        if self.coefficient_covariance is None:
+            return None
+        return math.sqrt(self.coefficient_covariance[0][0])
+
+    @property
+    def scale_standard_error(self) -> float | None:
+        """Return the derived scale standard error when available."""
+
+        if self.coefficient_covariance is None:
+            return None
+        return math.sqrt(self.coefficient_covariance[1][1])
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the strict JSON-safe estimator contract."""
+
+        return {
+            "schema_version": self.schema_version,
+            "status": self.status.value,
+            "uncertainty_source": self.uncertainty_source,
+            "coefficient_order": ["offset", "scale"],
+            "objective": (
+                "gaussian_negative_log_likelihood_"
+                "scale_dependent_effective_variance"
+            ),
+            "objective_equation": (
+                "0.5 * sum(log(v_i) + residual_i**2 / v_i)"
+            ),
+            "effective_variance_equation": (
+                "reference_error_i**2 + "
+                "scale**2 * channel_error_i**2"
+            ),
+            "covariance_estimator": (
+                "inverse_observed_hessian_at_converged_optimum"
+            ),
+            "conditioned_on_final_inlier_set": (
+                self.conditioned_on_final_inlier_set
+            ),
+            "positive_scale_domain_enforced": (
+                self.positive_scale_domain_enforced
+            ),
+            "n_inliers": self.n_inliers,
+            "offset": self.offset,
+            "scale": self.scale,
+            "coefficient_covariance": (
+                None
+                if self.coefficient_covariance is None
+                else [
+                    list(row)
+                    for row in self.coefficient_covariance
+                ]
+            ),
+            "offset_standard_error": self.offset_standard_error,
+            "scale_standard_error": self.scale_standard_error,
+            "objective_value": self.objective_value,
+            "optimizer": self.optimizer,
+            "optimizer_converged": self.optimizer_converged,
+            "gradient_method": self.gradient_method,
+            "gradient_norm": self.gradient_norm,
+            "hessian_method": self.hessian_method,
+            "hessian_eigenvalues": (
+                None
+                if self.hessian_eigenvalues is None
+                else list(self.hessian_eigenvalues)
+            ),
+            "reason": self.reason,
+            "implemented": False,
         }
 
 
@@ -3550,6 +3958,43 @@ def _normalize_calibration_channel(
         raise ValueError(f"{name} must be non-empty.")
 
     return channel_name
+
+
+def estimate_scale_dependent_instrument_channel_calibration_coefficient_uncertainty(
+    reference_flux: Any,
+    channel_flux: Any,
+    *,
+    reference_error: Any | None,
+    channel_error: Any,
+    initial_offset: float,
+    initial_scale: float,
+) -> InstrumentChannelCalibrationScaleDependentUncertaintyEstimate:
+    """Estimate channel-axis-error covariance in a future implementation.
+
+    Inputs represent the caller-selected final inlier set. The future
+    implementation will minimize the complete Gaussian negative log
+    likelihood whose residual variance is
+
+    ``reference_error**2 + scale**2 * channel_error**2``
+
+    over ``offset`` and strictly positive ``scale``. Available coefficient
+    covariance will be the inverse observed Hessian of that full objective at
+    a converged optimum. A frozen-weight normal-matrix inverse is explicitly
+    outside this contract.
+    """
+
+    del (
+        reference_flux,
+        channel_flux,
+        reference_error,
+        channel_error,
+        initial_offset,
+        initial_scale,
+    )
+    raise NotImplementedError(
+        "Scale-dependent channel-axis calibration coefficient uncertainty "
+        "estimation is not implemented."
+    )
 
 
 def fit_instrument_channel_calibration(

--- a/tests/test_docs_instrument_channel_calibration.py
+++ b/tests/test_docs_instrument_channel_calibration.py
@@ -47,6 +47,18 @@ class TestInstrumentChannelCalibrationDocumentation(unittest.TestCase):
             instrument_channel_calibration.__all__,
         )
         self.assertIn(
+            "INSTRUMENT_CHANNEL_CALIBRATION_SCALE_DEPENDENT_UNCERTAINTY_SCHEMA_VERSION",
+            instrument_channel_calibration.__all__,
+        )
+        self.assertIn(
+            "InstrumentChannelCalibrationScaleDependentUncertaintyEstimate",
+            instrument_channel_calibration.__all__,
+        )
+        self.assertIn(
+            "estimate_scale_dependent_instrument_channel_calibration_coefficient_uncertainty",
+            instrument_channel_calibration.__all__,
+        )
+        self.assertIn(
             "InstrumentChannelCalibrationPredictiveUncertainty",
             instrument_channel_calibration.__all__,
         )
@@ -131,6 +143,35 @@ class TestInstrumentChannelCalibrationDocumentation(unittest.TestCase):
             normalized,
         )
         self.assertIn(
+            "Scale-dependent channel-axis uncertainty contract",
+            text,
+        )
+        self.assertIn(
+            "InstrumentChannelCalibrationScaleDependentUncertaintyEstimate",
+            text,
+        )
+        self.assertIn(
+            "estimate_scale_dependent_instrument_channel_calibration_"
+            "coefficient_uncertainty",
+            text,
+        )
+        self.assertIn(
+            "raises ``NotImplementedError`` in this contract-only tranche",
+            normalized,
+        )
+        self.assertIn(
+            "inverse observed Hessian of this full objective",
+            normalized,
+        )
+        self.assertIn(
+            "not a frozen-weight normal-matrix inverse",
+            normalized,
+        )
+        self.assertIn(
+            "v_i=\\sigma_{y,i}^2+a^2\\sigma_{x,i}^2",
+            normalized,
+        )
+        self.assertIn(
             "does not propagate uncertainty in the fitted offset or scale",
             normalized,
         )
@@ -147,7 +188,14 @@ class TestInstrumentChannelCalibrationDocumentation(unittest.TestCase):
             "record",
             normalized,
         )
-        self.assertNotIn("raises ``NotImplementedError``", normalized)
+        predictive_section = text.split(
+            "Predictive-uncertainty propagation",
+            maxsplit=1,
+        )[1].split(
+            "``TBD[instrument-channel-calibration]`` remains open",
+            maxsplit=1,
+        )[0]
+        self.assertNotIn("NotImplementedError", predictive_section)
         self.assertIn("J_i=[1, x_i]", normalized)
         self.assertIn("offset-scale covariance cross-term", normalized)
         self.assertIn("full_covariance", text)
@@ -174,7 +222,11 @@ class TestInstrumentChannelCalibrationDocumentation(unittest.TestCase):
             text,
         )
         self.assertIn(
-            "scale-dependent channel-axis errors",
+            "full-objective observed-Hessian contract",
+            text,
+        )
+        self.assertIn(
+            "implementation of the scale-dependent estimator",
             text,
         )
         self.assertNotIn(

--- a/tests/test_instrument_channel_calibration_scale_dependent_uncertainty_contract.py
+++ b/tests/test_instrument_channel_calibration_scale_dependent_uncertainty_contract.py
@@ -1,0 +1,215 @@
+"""Scale-dependent channel-axis uncertainty contract tests."""
+
+import json
+import unittest
+
+import numpy as np
+
+from pgmuvi.instrument_channel_calibration import (
+    INSTRUMENT_CHANNEL_CALIBRATION_SCALE_DEPENDENT_UNCERTAINTY_SCHEMA_VERSION,
+    InstrumentChannelCalibrationScaleDependentUncertaintyEstimate,
+    InstrumentChannelCalibrationUncertaintyStatus,
+    estimate_scale_dependent_instrument_channel_calibration_coefficient_uncertainty,
+    fit_instrument_channel_calibration,
+)
+
+
+class TestScaleDependentUncertaintyEstimateContract(unittest.TestCase):
+    @staticmethod
+    def _available(**overrides):
+        values = {
+            "schema_version": (
+                INSTRUMENT_CHANNEL_CALIBRATION_SCALE_DEPENDENT_UNCERTAINTY_SCHEMA_VERSION
+            ),
+            "status": InstrumentChannelCalibrationUncertaintyStatus.AVAILABLE,
+            "uncertainty_source": "future_full_objective_estimator",
+            "n_inliers": np.int64(24),
+            "coefficient_covariance": (
+                (np.float64(0.04), np.float64(-0.006)),
+                (np.float64(-0.006), np.float64(0.01)),
+            ),
+            "offset": np.float64(0.25),
+            "scale": np.float64(1.5),
+            "objective_value": np.float64(-12.5),
+            "optimizer": "bounded_quasi_newton",
+            "optimizer_converged": np.bool_(True),
+            "gradient_method": "analytic",
+            "gradient_norm": np.float64(1.0e-9),
+            "hessian_method": "analytic_observed_hessian",
+            "hessian_eigenvalues": (
+                np.float64(20.0),
+                np.float64(80.0),
+            ),
+        }
+        values.update(overrides)
+        return InstrumentChannelCalibrationScaleDependentUncertaintyEstimate(
+            **values
+        )
+
+    @staticmethod
+    def _unavailable(**overrides):
+        values = {
+            "schema_version": (
+                INSTRUMENT_CHANNEL_CALIBRATION_SCALE_DEPENDENT_UNCERTAINTY_SCHEMA_VERSION
+            ),
+            "status": (
+                InstrumentChannelCalibrationUncertaintyStatus.UNAVAILABLE
+            ),
+            "uncertainty_source": "future_full_objective_estimator",
+            "n_inliers": 24,
+            "optimizer": "bounded_quasi_newton",
+            "optimizer_converged": False,
+            "gradient_method": "analytic",
+            "hessian_method": "analytic_observed_hessian",
+            "reason": "Observed Hessian is not positive definite.",
+        }
+        values.update(overrides)
+        return InstrumentChannelCalibrationScaleDependentUncertaintyEstimate(
+            **values
+        )
+
+    def test_available_contract_is_immutable_and_json_safe(self):
+        result = self._available()
+        payload = result.to_dict()
+        json.dumps(payload, allow_nan=False)
+
+        self.assertEqual(payload["coefficient_order"], ["offset", "scale"])
+        self.assertEqual(
+            payload["objective"],
+            "gaussian_negative_log_likelihood_"
+            "scale_dependent_effective_variance",
+        )
+        self.assertEqual(
+            payload["effective_variance_equation"],
+            "reference_error_i**2 + scale**2 * channel_error_i**2",
+        )
+        self.assertEqual(
+            payload["covariance_estimator"],
+            "inverse_observed_hessian_at_converged_optimum",
+        )
+        self.assertTrue(payload["conditioned_on_final_inlier_set"])
+        self.assertTrue(payload["positive_scale_domain_enforced"])
+        self.assertFalse(payload["implemented"])
+        self.assertAlmostEqual(result.offset_standard_error, 0.2)
+        self.assertAlmostEqual(result.scale_standard_error, 0.1)
+
+        with self.assertRaisesRegex(
+            AttributeError,
+            "cannot assign to field",
+        ):
+            result.scale = 2.0
+
+    def test_available_contract_requires_complete_converged_provenance(self):
+        required_fields = (
+            "coefficient_covariance",
+            "offset",
+            "scale",
+            "objective_value",
+            "optimizer",
+            "optimizer_converged",
+            "gradient_method",
+            "gradient_norm",
+            "hessian_method",
+            "hessian_eigenvalues",
+        )
+
+        for name in required_fields:
+            with self.subTest(name=name):
+                replacement = False if name == "optimizer_converged" else None
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "requires complete|requires a converged optimizer",
+                ):
+                    self._available(**{name: replacement})
+
+        with self.assertRaisesRegex(ValueError, "strictly positive"):
+            self._available(scale=0.0)
+        with self.assertRaisesRegex(ValueError, "must not carry"):
+            self._available(reason="Unexpected failure.")
+
+    def test_hessian_and_boolean_fields_are_strict(self):
+        with self.assertRaisesRegex(ValueError, "exactly two"):
+            self._available(hessian_eigenvalues=(1.0,))
+        with self.assertRaisesRegex(ValueError, "strictly positive"):
+            self._available(hessian_eigenvalues=(1.0, 0.0))
+        with self.assertRaisesRegex(TypeError, "not boolean"):
+            self._available(hessian_eigenvalues=(1.0, False))
+        with self.assertRaisesRegex(TypeError, "must be boolean"):
+            self._available(optimizer_converged=1)
+        with self.assertRaisesRegex(ValueError, "must be true"):
+            self._available(conditioned_on_final_inlier_set=False)
+        with self.assertRaisesRegex(ValueError, "must be true"):
+            self._available(positive_scale_domain_enforced=False)
+
+    def test_unavailable_contract_is_explicit_and_non_numeric(self):
+        result = self._unavailable()
+        payload = result.to_dict()
+        json.dumps(payload, allow_nan=False)
+
+        self.assertEqual(payload["status"], "unavailable")
+        self.assertIsNone(payload["coefficient_covariance"])
+        self.assertIsNone(payload["offset"])
+        self.assertIsNone(payload["scale"])
+        self.assertEqual(
+            payload["reason"],
+            "Observed Hessian is not positive definite.",
+        )
+
+        with self.assertRaisesRegex(ValueError, "requires a reason"):
+            self._unavailable(reason=None)
+        with self.assertRaisesRegex(ValueError, "cannot carry coefficient"):
+            self._unavailable(
+                coefficient_covariance=((1.0, 0.0), (0.0, 1.0))
+            )
+        with self.assertRaisesRegex(ValueError, "numerical estimation"):
+            self._unavailable(objective_value=1.0)
+        with self.assertRaisesRegex(ValueError, "cannot report"):
+            self._unavailable(optimizer_converged=True)
+
+    def test_schema_and_inlier_count_are_strict(self):
+        with self.assertRaisesRegex(ValueError, "schema version"):
+            self._available(schema_version="unknown")
+        with self.assertRaisesRegex(TypeError, "n_inliers must be an integer"):
+            self._available(n_inliers=True)
+        with self.assertRaisesRegex(ValueError, "at least 3"):
+            self._available(n_inliers=2)
+
+    def test_dedicated_estimator_callable_is_contract_only(self):
+        with self.assertRaisesRegex(NotImplementedError, "not implemented"):
+            estimate_scale_dependent_instrument_channel_calibration_coefficient_uncertainty(
+                np.array([1.0, 2.0, 3.0]),
+                np.array([0.5, 1.0, 1.5]),
+                reference_error=np.full(3, 0.03),
+                channel_error=np.full(3, 0.02),
+                initial_offset=0.25,
+                initial_scale=1.5,
+            )
+
+    def test_current_fitter_boundary_remains_unavailable(self):
+        channel_flux = np.linspace(0.0, 2.0, 20)
+        reference_flux = 0.25 + 1.5 * channel_flux
+
+        calibration = fit_instrument_channel_calibration(
+            reference_flux,
+            channel_flux,
+            reference_channel="reference",
+            channel="target",
+            wavelength=1.0,
+            reference_error=np.full(20, 0.03),
+            channel_error=np.linspace(0.01, 0.02, 20),
+        )
+
+        uncertainty = calibration.coefficient_uncertainty
+        self.assertEqual(
+            uncertainty.status,
+            InstrumentChannelCalibrationUncertaintyStatus.UNAVAILABLE,
+        )
+        self.assertIsNone(uncertainty.coefficient_covariance)
+        self.assertIn(
+            "current affine fitter does not expose a covariance estimator",
+            uncertainty.reason,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- define an immutable, strict JSON-safe result contract for future coefficient-uncertainty estimation when observational-channel-axis errors produce scale-dependent effective variances
- define the complete Gaussian negative-log-likelihood objective and fixed coefficient order `offset, scale`
- define available covariance as the inverse observed Hessian of the full objective at a converged optimum in the strictly positive-scale domain
- record optimizer, convergence, gradient, Hessian, objective, final-inlier conditioning, and deterministic unavailable-reason provenance
- add a dedicated public estimator callable that intentionally raises `NotImplementedError` in this contract-only tranche
- preserve the current affine fitter boundary, predictive propagation behavior, dataset orchestration, and `Lightcurve.fit()`

## Validation

- 2,656 tests passed
- canonical Ruff check passed for `./pgmuvi`
- strict documentation build passed
- complete staged diff and independent semantic audit passed

## Remaining future work

- implement the scale-dependent full-objective estimator
- establish scientifically validated instrument-specific pairing and tolerance guidance
- integrate calibration into the normal workflow
- validate calibration across representative instruments, observational channels, and LPV sources