### PR TITLE
Define scale-dependent calibration uncertainty integration contract

### DIFF
--- a/docs/source/future_work.rst
+++ b/docs/source/future_work.rst
@@ -124,10 +124,13 @@ Wavelength-model extensions
     marginal or full-covariance predictive propagation without orchestration
     activation, and implements the dedicated full-objective
     observed-Hessian estimator for scale-dependent channel-axis coefficient
-    uncertainty without activating it in the fitter or orchestration layer.
-    This does not close the marker: scientifically validated instrument-specific
-    tolerance guidance, workflow integration, and representative calibration
-    validation remain future work.
+    uncertainty, and defines deterministic fitter routing, exact final-inlier
+    provenance, consistent point-estimate/covariance semantics, fallback status,
+    and orchestration preservation without activating the estimator in the
+    fitter or orchestration layer.  This does not close the marker:
+    scientifically validated instrument-specific tolerance guidance, fitter and
+    orchestration activation, workflow integration, and representative
+    calibration validation remain future work.
 
 **TBD[multi-periodic-wavelength-models]**
     Add a documented and validated multi-periodic workflow beyond the current

--- a/docs/source/pgmuvi.instrument_channel_calibration.rst
+++ b/docs/source/pgmuvi.instrument_channel_calibration.rst
@@ -132,6 +132,45 @@ order is ``offset, scale``.  Application still propagates only measurement
 uncertainty through the fitted scale; it does not propagate the estimated
 coefficient covariance into calibrated predictions.
 
+Scale-dependent fitter and orchestration integration contract
+---------------------------------------------------------------
+
+:func:`~pgmuvi.instrument_channel_calibration.select_instrument_channel_calibration_uncertainty_estimator`
+defines deterministic routing after the fitter has validated optional error
+arrays.  No errors and reference-axis errors alone select the existing
+``fixed_weight_normal_matrix`` path.  Any observational-channel-axis errors
+select ``scale_dependent_full_objective``, whether or not reference-axis errors
+are also present.  Neither error axis is silently reinterpreted, frozen, or
+ignored by this selection contract.
+
+Each fitter-produced
+:class:`~pgmuvi.instrument_channel_calibration.InstrumentChannelCalibration`
+now carries an immutable
+:class:`~pgmuvi.instrument_channel_calibration.InstrumentChannelCalibrationFitProvenance`
+record.  Pair positions refer to the original caller-supplied paired arrays and
+identify both the finite-value subset and exact final MAD-clipped inlier set.
+The record also identifies participating error axes, selected uncertainty
+estimator, integration status, reported point-estimate source and objective,
+and whether the point estimate and covariance share one objective optimum.
+The nested ``coefficient_uncertainty`` field remains the sole source of
+coefficient covariance in fixed order ``offset, scale``.
+
+Scale-dependent activation remains deliberately disabled in the affine fitter.
+For current fits with observational-channel-axis errors, provenance reports
+``defined_not_activated`` and identifies the reported coefficients as the
+iterative scale-frozen weighted affine fallback.  Coefficient covariance stays
+explicitly unavailable.  Future successful activation must report the offset,
+scale, objective, covariance, and final-inlier conditioning from the same
+full-objective optimum.  If future optimization fails, a retained affine point
+estimate must use the explicit ``attempted_unavailable_fallback`` status rather
+than being paired with covariance from a different optimum.
+
+Dataset orchestration already preserves complete per-observational-channel
+calibration records, so this provenance remains separate for channels that
+share one physical wavelength.  Orchestration does not aggregate coefficient
+covariance by physical wavelength and does not yet request predictive
+propagation.
+
 Executing an explicit plan
 --------------------------
 
@@ -225,7 +264,8 @@ still lacks:
 
 * scientifically validated instrument-specific rules for choosing
   pairing methods and tolerances;
-* coefficient-uncertainty estimation for scale-dependent channel-axis errors;
+* fitter and orchestration activation of scale-dependent channel-axis
+  coefficient uncertainty;
 * integration into the normal light-curve fitting workflow; and
 * validation across representative instruments, filters, and LPV sources.
 

--- a/pgmuvi/instrument_channel_calibration.py
+++ b/pgmuvi/instrument_channel_calibration.py
@@ -42,6 +42,9 @@ INSTRUMENT_CHANNEL_CALIBRATION_EXECUTION_SCHEMA_VERSION = (
 INSTRUMENT_CHANNEL_CALIBRATION_UNCERTAINTY_SCHEMA_VERSION = (
     "pgmuvi-instrument-channel-calibration-uncertainty-v1"
 )
+INSTRUMENT_CHANNEL_CALIBRATION_FIT_PROVENANCE_SCHEMA_VERSION = (
+    "pgmuvi-instrument-channel-calibration-fit-provenance-v1"
+)
 INSTRUMENT_CHANNEL_CALIBRATION_SCALE_DEPENDENT_UNCERTAINTY_SCHEMA_VERSION = (
     "pgmuvi-instrument-channel-calibration-scale-dependent-uncertainty-v1"
 )
@@ -52,6 +55,7 @@ INSTRUMENT_CHANNEL_CALIBRATION_PREDICTIVE_UNCERTAINTY_SCHEMA_VERSION = (
 
 __all__ = [
     "INSTRUMENT_CHANNEL_CALIBRATION_EXECUTION_SCHEMA_VERSION",
+    "INSTRUMENT_CHANNEL_CALIBRATION_FIT_PROVENANCE_SCHEMA_VERSION",
     "INSTRUMENT_CHANNEL_CALIBRATION_MODEL_SCHEMA_VERSION",
     "INSTRUMENT_CHANNEL_CALIBRATION_PLAN_SCHEMA_VERSION",
     "INSTRUMENT_CHANNEL_CALIBRATION_PREDICTIVE_UNCERTAINTY_SCHEMA_VERSION",
@@ -66,6 +70,7 @@ __all__ = [
     "InstrumentChannelCalibrationCoefficientUncertainty",
     "InstrumentChannelCalibrationDisposition",
     "InstrumentChannelCalibrationExecution",
+    "InstrumentChannelCalibrationFitProvenance",
     "InstrumentChannelCalibrationGroupPlan",
     "InstrumentChannelCalibrationPlan",
     "InstrumentChannelCalibrationPredictiveCovarianceMode",
@@ -74,6 +79,8 @@ __all__ = [
     "InstrumentChannelCalibrationPredictiveUncertaintyStatus",
     "InstrumentChannelCalibrationScaleDependentUncertaintyEstimate",
     "InstrumentChannelCalibrationStatus",
+    "InstrumentChannelCalibrationUncertaintyEstimator",
+    "InstrumentChannelCalibrationUncertaintyIntegrationStatus",
     "InstrumentChannelCalibrationUncertaintyStatus",
     "InstrumentChannelPairing",
     "InstrumentChannelPairingMethod",
@@ -86,6 +93,7 @@ __all__ = [
     "estimate_scale_dependent_instrument_channel_calibration_coefficient_uncertainty",
     "execute_instrument_channel_calibration_plan",
     "fit_instrument_channel_calibration",
+    "select_instrument_channel_calibration_uncertainty_estimator",
 ]
 
 
@@ -123,6 +131,23 @@ class InstrumentChannelCalibrationUncertaintyStatus(_StringEnum):
 
     AVAILABLE = "available"
     UNAVAILABLE = "unavailable"
+
+
+class InstrumentChannelCalibrationUncertaintyEstimator(_StringEnum):
+    """Selected affine coefficient-uncertainty estimator family."""
+
+    FIXED_WEIGHT_NORMAL_MATRIX = "fixed_weight_normal_matrix"
+    SCALE_DEPENDENT_FULL_OBJECTIVE = "scale_dependent_full_objective"
+
+
+class InstrumentChannelCalibrationUncertaintyIntegrationStatus(_StringEnum):
+    """Integration state for the selected uncertainty estimator."""
+
+    ACTIVE = "active"
+    DEFINED_NOT_ACTIVATED = "defined_not_activated"
+    ATTEMPTED_UNAVAILABLE_FALLBACK = (
+        "attempted_unavailable_fallback"
+    )
 
 
 class InstrumentChannelCalibrationPredictiveUncertaintyStatus(
@@ -1191,6 +1216,352 @@ def construct_instrument_channel_pairing(
         allow_channel_reuse=False,
         interpolation_used=False,
     )
+
+
+def select_instrument_channel_calibration_uncertainty_estimator(
+    *,
+    reference_error_supplied: bool,
+    channel_error_supplied: bool,
+) -> InstrumentChannelCalibrationUncertaintyEstimator:
+    """Select the deterministic coefficient-uncertainty estimator family.
+
+    Reference-axis errors alone retain the existing fixed-weight covariance
+    path. Any observational-channel-axis error selects the scale-dependent
+    full-objective path, whether or not reference-axis errors are also present.
+    This selector defines integration routing only; it does not activate the
+    scale-dependent estimator in the affine fitter.
+    """
+
+    for name, value in (
+        ("reference_error_supplied", reference_error_supplied),
+        ("channel_error_supplied", channel_error_supplied),
+    ):
+        if not isinstance(value, (bool, np.bool_)):
+            raise TypeError(f"{name} must be boolean.")
+
+    if bool(channel_error_supplied):
+        return (
+            InstrumentChannelCalibrationUncertaintyEstimator
+            .SCALE_DEPENDENT_FULL_OBJECTIVE
+        )
+
+    return (
+        InstrumentChannelCalibrationUncertaintyEstimator
+        .FIXED_WEIGHT_NORMAL_MATRIX
+    )
+
+
+@dataclass(frozen=True)
+class InstrumentChannelCalibrationFitProvenance:
+    """Point-estimate and uncertainty-integration provenance.
+
+    Pair positions refer to the caller-supplied paired arrays before finite
+    filtering. The selected estimator is deterministic from error-axis
+    participation. A scale-dependent available covariance must share the same
+    full-objective optimum and final-inlier set as the reported coefficients.
+    If that estimator fails after future activation, a fallback point estimate
+    must be represented explicitly rather than paired with its covariance.
+    """
+
+    schema_version: str
+    selected_uncertainty_estimator: (
+        InstrumentChannelCalibrationUncertaintyEstimator | str
+    )
+    integration_status: (
+        InstrumentChannelCalibrationUncertaintyIntegrationStatus | str
+    )
+    reference_error_supplied: bool
+    channel_error_supplied: bool
+    n_input_pairs: int
+    finite_pair_indices: tuple[int, ...]
+    final_inlier_indices: tuple[int, ...]
+    point_estimate_source: str
+    point_estimate_objective: str
+    point_estimate_matches_uncertainty_objective: bool
+    reason: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.schema_version != (
+            INSTRUMENT_CHANNEL_CALIBRATION_FIT_PROVENANCE_SCHEMA_VERSION
+        ):
+            raise ValueError(
+                "Unsupported instrument-channel calibration fit provenance "
+                f"schema version: {self.schema_version!r}."
+            )
+
+        estimator = self.selected_uncertainty_estimator
+        if not isinstance(
+            estimator,
+            InstrumentChannelCalibrationUncertaintyEstimator,
+        ):
+            try:
+                estimator = (
+                    InstrumentChannelCalibrationUncertaintyEstimator(
+                        str(estimator)
+                    )
+                )
+            except ValueError as exc:
+                raise ValueError(
+                    "Unsupported instrument-channel calibration uncertainty "
+                    f"estimator: {self.selected_uncertainty_estimator!r}."
+                ) from exc
+
+        integration_status = self.integration_status
+        if not isinstance(
+            integration_status,
+            InstrumentChannelCalibrationUncertaintyIntegrationStatus,
+        ):
+            try:
+                integration_status = (
+                    InstrumentChannelCalibrationUncertaintyIntegrationStatus(
+                        str(integration_status)
+                    )
+                )
+            except ValueError as exc:
+                raise ValueError(
+                    "Unsupported instrument-channel calibration uncertainty "
+                    f"integration status: {self.integration_status!r}."
+                ) from exc
+
+        normalized_booleans = {}
+        for name in (
+            "reference_error_supplied",
+            "channel_error_supplied",
+            "point_estimate_matches_uncertainty_objective",
+        ):
+            value = getattr(self, name)
+            if not isinstance(value, (bool, np.bool_)):
+                raise TypeError(f"{name} must be boolean.")
+            normalized_booleans[name] = bool(value)
+
+        if isinstance(self.n_input_pairs, (bool, np.bool_)) or not isinstance(
+            self.n_input_pairs,
+            (int, np.integer),
+        ):
+            raise TypeError("n_input_pairs must be an integer.")
+        n_input_pairs = int(self.n_input_pairs)
+        if n_input_pairs < 3:
+            raise ValueError("n_input_pairs must be at least 3.")
+
+        finite_pair_indices = InstrumentChannelPairing._normalize_indices(
+            self.finite_pair_indices,
+            name="finite_pair_indices",
+        )
+        final_inlier_indices = InstrumentChannelPairing._normalize_indices(
+            self.final_inlier_indices,
+            name="final_inlier_indices",
+        )
+
+        for name, indices in (
+            ("finite_pair_indices", finite_pair_indices),
+            ("final_inlier_indices", final_inlier_indices),
+        ):
+            if len(indices) < 3:
+                raise ValueError(f"{name} must contain at least 3 positions.")
+            if tuple(sorted(set(indices))) != indices:
+                raise ValueError(
+                    f"{name} must contain unique positions in increasing "
+                    "order."
+                )
+            if indices[-1] >= n_input_pairs:
+                raise ValueError(
+                    f"{name} positions must be smaller than n_input_pairs."
+                )
+
+        if not set(final_inlier_indices).issubset(finite_pair_indices):
+            raise ValueError(
+                "final_inlier_indices must be a subset of "
+                "finite_pair_indices."
+            )
+
+        point_estimate_source = (
+            InstrumentChannelCalibrationCoefficientUncertainty
+            ._normalize_required_text(
+                self.point_estimate_source,
+                name="point_estimate_source",
+            )
+        )
+        point_estimate_objective = (
+            InstrumentChannelCalibrationCoefficientUncertainty
+            ._normalize_required_text(
+                self.point_estimate_objective,
+                name="point_estimate_objective",
+            )
+        )
+        reason = (
+            InstrumentChannelCalibrationCoefficientUncertainty
+            ._normalize_optional_text(
+                self.reason,
+                name="reason",
+            )
+        )
+
+        selected = select_instrument_channel_calibration_uncertainty_estimator(
+            reference_error_supplied=normalized_booleans[
+                "reference_error_supplied"
+            ],
+            channel_error_supplied=normalized_booleans[
+                "channel_error_supplied"
+            ],
+        )
+        if estimator is not selected:
+            raise ValueError(
+                "selected_uncertainty_estimator is inconsistent with the "
+                "supplied error axes."
+            )
+
+        matches_objective = normalized_booleans[
+            "point_estimate_matches_uncertainty_objective"
+        ]
+        if integration_status is (
+            InstrumentChannelCalibrationUncertaintyIntegrationStatus.ACTIVE
+        ):
+            if reason is not None:
+                raise ValueError(
+                    "Active uncertainty integration must not carry a reason."
+                )
+            if not matches_objective:
+                raise ValueError(
+                    "Active uncertainty integration requires the point "
+                    "estimate to match the uncertainty objective."
+                )
+        else:
+            if reason is None:
+                raise ValueError(
+                    "Inactive or fallback uncertainty integration requires "
+                    "an explicit reason."
+                )
+            if matches_objective:
+                raise ValueError(
+                    "Inactive or fallback uncertainty integration cannot "
+                    "claim a shared point-estimate objective."
+                )
+
+        fixed_estimator = (
+            InstrumentChannelCalibrationUncertaintyEstimator
+            .FIXED_WEIGHT_NORMAL_MATRIX
+        )
+        if estimator is fixed_estimator:
+            if integration_status is not (
+                InstrumentChannelCalibrationUncertaintyIntegrationStatus
+                .ACTIVE
+            ):
+                raise ValueError(
+                    "The implemented fixed-weight uncertainty path must be "
+                    "active."
+                )
+            expected_source = "pgmuvi_affine_fit_final_inliers"
+            expected_objective = "fixed_weight_least_squares"
+        elif integration_status is (
+            InstrumentChannelCalibrationUncertaintyIntegrationStatus.ACTIVE
+        ):
+            expected_source = (
+                "pgmuvi_scale_dependent_full_objective_final_inliers"
+            )
+            expected_objective = (
+                "gaussian_negative_log_likelihood_"
+                "scale_dependent_effective_variance"
+            )
+        else:
+            expected_source = (
+                "pgmuvi_iterative_mad_clipped_affine_fallback_"
+                "final_inliers"
+            )
+            expected_objective = (
+                "iterative_scale_frozen_weighted_least_squares"
+            )
+
+        if point_estimate_source != expected_source:
+            raise ValueError(
+                "point_estimate_source is inconsistent with the selected "
+                "uncertainty integration path."
+            )
+        if point_estimate_objective != expected_objective:
+            raise ValueError(
+                "point_estimate_objective is inconsistent with the selected "
+                "uncertainty integration path."
+            )
+
+        object.__setattr__(
+            self,
+            "selected_uncertainty_estimator",
+            estimator,
+        )
+        object.__setattr__(
+            self,
+            "integration_status",
+            integration_status,
+        )
+        for name, value in normalized_booleans.items():
+            object.__setattr__(self, name, value)
+        object.__setattr__(self, "n_input_pairs", n_input_pairs)
+        object.__setattr__(
+            self,
+            "finite_pair_indices",
+            finite_pair_indices,
+        )
+        object.__setattr__(
+            self,
+            "final_inlier_indices",
+            final_inlier_indices,
+        )
+        object.__setattr__(
+            self,
+            "point_estimate_source",
+            point_estimate_source,
+        )
+        object.__setattr__(
+            self,
+            "point_estimate_objective",
+            point_estimate_objective,
+        )
+        object.__setattr__(self, "reason", reason)
+
+    @property
+    def n_finite_pairs(self) -> int:
+        """Return the number of pairs retained by finite-value filtering."""
+
+        return len(self.finite_pair_indices)
+
+    @property
+    def n_final_inliers(self) -> int:
+        """Return the caller-selected final-inlier count."""
+
+        return len(self.final_inlier_indices)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return strict JSON-safe fit and integration provenance."""
+
+        return {
+            "schema_version": self.schema_version,
+            "selected_uncertainty_estimator": (
+                self.selected_uncertainty_estimator.value
+            ),
+            "integration_status": self.integration_status.value,
+            "reference_error_supplied": self.reference_error_supplied,
+            "channel_error_supplied": self.channel_error_supplied,
+            "error_axes": [
+                name
+                for name, supplied in (
+                    ("reference", self.reference_error_supplied),
+                    ("observational_channel", self.channel_error_supplied),
+                )
+                if supplied
+            ],
+            "coefficient_order": ["offset", "scale"],
+            "n_input_pairs": self.n_input_pairs,
+            "n_finite_pairs": self.n_finite_pairs,
+            "n_final_inliers": self.n_final_inliers,
+            "finite_pair_indices": list(self.finite_pair_indices),
+            "final_inlier_indices": list(self.final_inlier_indices),
+            "point_estimate_source": self.point_estimate_source,
+            "point_estimate_objective": self.point_estimate_objective,
+            "point_estimate_matches_uncertainty_objective": (
+                self.point_estimate_matches_uncertainty_objective
+            ),
+            "uncertainty_conditioned_on_final_inlier_set": True,
+            "reason": self.reason,
+        }
 
 
 @dataclass(frozen=True)
@@ -2375,6 +2746,7 @@ class InstrumentChannelCalibration:
         InstrumentChannelCalibrationCoefficientUncertainty
     )
     fit_method: str = "iterative_mad_clipped_affine"
+    fit_provenance: InstrumentChannelCalibrationFitProvenance | None = None
 
     def __post_init__(self) -> None:
         if self.schema_version != (
@@ -2450,6 +2822,27 @@ class InstrumentChannelCalibration:
                 "instance."
             )
 
+        fit_provenance = self.fit_provenance
+        if fit_provenance is not None:
+            if not isinstance(
+                fit_provenance,
+                InstrumentChannelCalibrationFitProvenance,
+            ):
+                raise TypeError(
+                    "fit_provenance must be an "
+                    "InstrumentChannelCalibrationFitProvenance instance "
+                    "when supplied."
+                )
+            if fit_provenance.n_finite_pairs != self.n_pairs:
+                raise ValueError(
+                    "fit_provenance finite-pair count must equal n_pairs."
+                )
+            if fit_provenance.n_final_inliers != self.n_inliers:
+                raise ValueError(
+                    "fit_provenance final-inlier count must equal "
+                    "n_inliers."
+                )
+
     def to_dict(self) -> dict[str, Any]:
         """Return a strict JSON-safe representation."""
 
@@ -2468,6 +2861,11 @@ class InstrumentChannelCalibration:
                 else float(self.residual_mad_sigma)
             ),
             "fit_method": self.fit_method,
+            "fit_provenance": (
+                None
+                if self.fit_provenance is None
+                else self.fit_provenance.to_dict()
+            ),
             "coefficient_uncertainty": (
                 self.coefficient_uncertainty.to_dict()
             ),
@@ -4506,6 +4904,8 @@ def fit_instrument_channel_calibration(
             "reference_flux and channel_flux must have the same shape."
         )
 
+    n_input_pairs = int(reference.size)
+
     reference_sigma = _validate_optional_calibration_error(
         reference_error,
         name="reference_error",
@@ -4524,6 +4924,7 @@ def fit_instrument_channel_calibration(
             continue
         finite &= np.isfinite(error) & (error > 0.0)
 
+    finite_pair_indices_array = np.flatnonzero(finite)
     reference = reference[finite]
     target = target[finite]
 
@@ -4718,6 +5119,61 @@ def fit_instrument_channel_calibration(
         channel_errors_supplied=channel_sigma is not None,
     )
 
+    selected_uncertainty_estimator = (
+        select_instrument_channel_calibration_uncertainty_estimator(
+            reference_error_supplied=reference_sigma is not None,
+            channel_error_supplied=channel_sigma is not None,
+        )
+    )
+    if channel_sigma is None:
+        integration_status = (
+            InstrumentChannelCalibrationUncertaintyIntegrationStatus.ACTIVE
+        )
+        point_estimate_source = "pgmuvi_affine_fit_final_inliers"
+        point_estimate_objective = "fixed_weight_least_squares"
+        point_estimate_matches_uncertainty_objective = True
+        integration_reason = None
+    else:
+        integration_status = (
+            InstrumentChannelCalibrationUncertaintyIntegrationStatus
+            .DEFINED_NOT_ACTIVATED
+        )
+        point_estimate_source = (
+            "pgmuvi_iterative_mad_clipped_affine_fallback_final_inliers"
+        )
+        point_estimate_objective = (
+            "iterative_scale_frozen_weighted_least_squares"
+        )
+        point_estimate_matches_uncertainty_objective = False
+        integration_reason = (
+            "Scale-dependent full-objective fitter integration is defined "
+            "but not activated; the reported coefficients remain the "
+            "iterative scale-frozen weighted affine point estimate."
+        )
+
+    fit_provenance = InstrumentChannelCalibrationFitProvenance(
+        schema_version=(
+            INSTRUMENT_CHANNEL_CALIBRATION_FIT_PROVENANCE_SCHEMA_VERSION
+        ),
+        selected_uncertainty_estimator=selected_uncertainty_estimator,
+        integration_status=integration_status,
+        reference_error_supplied=reference_sigma is not None,
+        channel_error_supplied=channel_sigma is not None,
+        n_input_pairs=n_input_pairs,
+        finite_pair_indices=tuple(
+            int(index) for index in finite_pair_indices_array
+        ),
+        final_inlier_indices=tuple(
+            int(index) for index in finite_pair_indices_array[keep]
+        ),
+        point_estimate_source=point_estimate_source,
+        point_estimate_objective=point_estimate_objective,
+        point_estimate_matches_uncertainty_objective=(
+            point_estimate_matches_uncertainty_objective
+        ),
+        reason=integration_reason,
+    )
+
     return InstrumentChannelCalibration(
         schema_version=(
             INSTRUMENT_CHANNEL_CALIBRATION_MODEL_SCHEMA_VERSION
@@ -4733,6 +5189,7 @@ def fit_instrument_channel_calibration(
             final_residual
         ),
         coefficient_uncertainty=coefficient_uncertainty,
+        fit_provenance=fit_provenance,
     )
 
 

--- a/tests/test_docs_instrument_channel_calibration.py
+++ b/tests/test_docs_instrument_channel_calibration.py
@@ -43,6 +43,18 @@ class TestInstrumentChannelCalibrationDocumentation(unittest.TestCase):
             instrument_channel_calibration.__all__,
         )
         self.assertIn(
+            "InstrumentChannelCalibrationFitProvenance",
+            instrument_channel_calibration.__all__,
+        )
+        self.assertIn(
+            "INSTRUMENT_CHANNEL_CALIBRATION_FIT_PROVENANCE_SCHEMA_VERSION",
+            instrument_channel_calibration.__all__,
+        )
+        self.assertIn(
+            "select_instrument_channel_calibration_uncertainty_estimator",
+            instrument_channel_calibration.__all__,
+        )
+        self.assertIn(
             "INSTRUMENT_CHANNEL_CALIBRATION_UNCERTAINTY_SCHEMA_VERSION",
             instrument_channel_calibration.__all__,
         )
@@ -172,6 +184,28 @@ class TestInstrumentChannelCalibrationDocumentation(unittest.TestCase):
             normalized,
         )
         self.assertIn(
+            "Scale-dependent fitter and orchestration integration contract",
+            text,
+        )
+        self.assertIn(
+            "select_instrument_channel_calibration_uncertainty_estimator",
+            text,
+        )
+        self.assertIn(
+            "InstrumentChannelCalibrationFitProvenance",
+            text,
+        )
+        self.assertIn("defined_not_activated", text)
+        self.assertIn("attempted_unavailable_fallback", text)
+        self.assertIn(
+            "sole source of coefficient covariance",
+            normalized,
+        )
+        self.assertIn(
+            "channels that share one physical wavelength",
+            normalized,
+        )
+        self.assertIn(
             "v_i=\\sigma_{y,i}^2+a^2\\sigma_{x,i}^2",
             normalized,
         )
@@ -230,9 +264,13 @@ class TestInstrumentChannelCalibrationDocumentation(unittest.TestCase):
             text,
         )
         self.assertIn(
-            "without activating it in the fitter or orchestration layer",
+            "without activating the estimator in the fitter or orchestration "
+            "layer",
             text,
         )
+        self.assertIn("deterministic fitter routing", text)
+        self.assertIn("exact final-inlier provenance", text)
+        self.assertIn("fitter and orchestration activation", text)
         self.assertNotIn(
             "predictive-propagation implementation",
             text,

--- a/tests/test_instrument_channel_calibration_uncertainty_integration_contract.py
+++ b/tests/test_instrument_channel_calibration_uncertainty_integration_contract.py
@@ -1,0 +1,456 @@
+"""Scale-dependent fitter and orchestration integration contract tests."""
+
+import json
+import unittest
+
+import numpy as np
+
+from pgmuvi.instrument_channel_calibration import (
+    INSTRUMENT_CHANNEL_CALIBRATION_FIT_PROVENANCE_SCHEMA_VERSION,
+    INSTRUMENT_CHANNEL_CALIBRATION_MODEL_SCHEMA_VERSION,
+    InstrumentChannelCalibration,
+    InstrumentChannelCalibrationChannelPlan,
+    InstrumentChannelCalibrationDisposition,
+    InstrumentChannelCalibrationFitProvenance,
+    InstrumentChannelCalibrationGroupPlan,
+    InstrumentChannelCalibrationPredictiveCovarianceMode,
+    InstrumentChannelCalibrationPredictiveUncertaintyStatus,
+    InstrumentChannelCalibrationUncertaintyEstimator,
+    InstrumentChannelCalibrationUncertaintyIntegrationStatus,
+    InstrumentChannelCalibrationUncertaintyStatus,
+    InstrumentChannelPairingMethod,
+    apply_instrument_channel_calibration_with_predictive_uncertainty,
+    assess_instrument_channel_calibration_requirement,
+    define_instrument_channel_calibration_plan,
+    execute_instrument_channel_calibration_plan,
+    fit_instrument_channel_calibration,
+    select_instrument_channel_calibration_uncertainty_estimator,
+)
+
+
+class TestCalibrationUncertaintyIntegrationContract(unittest.TestCase):
+    @staticmethod
+    def _provenance(**overrides):
+        values = {
+            "schema_version": (
+                INSTRUMENT_CHANNEL_CALIBRATION_FIT_PROVENANCE_SCHEMA_VERSION
+            ),
+            "selected_uncertainty_estimator": (
+                InstrumentChannelCalibrationUncertaintyEstimator
+                .FIXED_WEIGHT_NORMAL_MATRIX
+            ),
+            "integration_status": (
+                InstrumentChannelCalibrationUncertaintyIntegrationStatus
+                .ACTIVE
+            ),
+            "reference_error_supplied": False,
+            "channel_error_supplied": False,
+            "n_input_pairs": 6,
+            "finite_pair_indices": (0, 1, 2, 3, 4, 5),
+            "final_inlier_indices": (0, 1, 2, 4, 5),
+            "point_estimate_source": "pgmuvi_affine_fit_final_inliers",
+            "point_estimate_objective": "fixed_weight_least_squares",
+            "point_estimate_matches_uncertainty_objective": True,
+        }
+        values.update(overrides)
+        return InstrumentChannelCalibrationFitProvenance(**values)
+
+    def test_estimator_selection_is_deterministic_for_all_error_axes(self):
+        fixed = (
+            InstrumentChannelCalibrationUncertaintyEstimator
+            .FIXED_WEIGHT_NORMAL_MATRIX
+        )
+        scale_dependent = (
+            InstrumentChannelCalibrationUncertaintyEstimator
+            .SCALE_DEPENDENT_FULL_OBJECTIVE
+        )
+
+        cases = (
+            (False, False, fixed),
+            (True, False, fixed),
+            (False, True, scale_dependent),
+            (True, True, scale_dependent),
+        )
+        for reference_supplied, channel_supplied, expected in cases:
+            with self.subTest(
+                reference_supplied=reference_supplied,
+                channel_supplied=channel_supplied,
+            ):
+                self.assertIs(
+                    select_instrument_channel_calibration_uncertainty_estimator(
+                        reference_error_supplied=reference_supplied,
+                        channel_error_supplied=channel_supplied,
+                    ),
+                    expected,
+                )
+
+        with self.assertRaisesRegex(TypeError, "must be boolean"):
+            select_instrument_channel_calibration_uncertainty_estimator(
+                reference_error_supplied=1,
+                channel_error_supplied=False,
+            )
+
+    def test_fit_provenance_is_immutable_json_safe_and_indexed(self):
+        provenance = self._provenance()
+        payload = provenance.to_dict()
+        json.dumps(payload, allow_nan=False)
+
+        self.assertEqual(payload["coefficient_order"], ["offset", "scale"])
+        self.assertEqual(payload["error_axes"], [])
+        self.assertEqual(payload["n_input_pairs"], 6)
+        self.assertEqual(payload["n_finite_pairs"], 6)
+        self.assertEqual(payload["n_final_inliers"], 5)
+        self.assertEqual(payload["final_inlier_indices"], [0, 1, 2, 4, 5])
+        self.assertTrue(
+            payload["uncertainty_conditioned_on_final_inlier_set"]
+        )
+
+        with self.assertRaisesRegex(AttributeError, "cannot assign"):
+            provenance.n_input_pairs = 8
+        with self.assertRaisesRegex(ValueError, "subset"):
+            self._provenance(
+                finite_pair_indices=(0, 1, 2, 4, 5),
+                final_inlier_indices=(0, 1, 3),
+            )
+        with self.assertRaisesRegex(ValueError, "increasing order"):
+            self._provenance(finite_pair_indices=(0, 2, 1, 3, 4, 5))
+
+    def test_scale_dependent_success_and_fallback_forms_are_explicit(self):
+        common = {
+            "selected_uncertainty_estimator": (
+                InstrumentChannelCalibrationUncertaintyEstimator
+                .SCALE_DEPENDENT_FULL_OBJECTIVE
+            ),
+            "reference_error_supplied": True,
+            "channel_error_supplied": True,
+        }
+        active = self._provenance(
+            **common,
+            integration_status=(
+                InstrumentChannelCalibrationUncertaintyIntegrationStatus
+                .ACTIVE
+            ),
+            point_estimate_source=(
+                "pgmuvi_scale_dependent_full_objective_final_inliers"
+            ),
+            point_estimate_objective=(
+                "gaussian_negative_log_likelihood_"
+                "scale_dependent_effective_variance"
+            ),
+            point_estimate_matches_uncertainty_objective=True,
+        )
+        self.assertEqual(active.integration_status.value, "active")
+
+        fallback = self._provenance(
+            **common,
+            integration_status=(
+                InstrumentChannelCalibrationUncertaintyIntegrationStatus
+                .ATTEMPTED_UNAVAILABLE_FALLBACK
+            ),
+            point_estimate_source=(
+                "pgmuvi_iterative_mad_clipped_affine_fallback_"
+                "final_inliers"
+            ),
+            point_estimate_objective=(
+                "iterative_scale_frozen_weighted_least_squares"
+            ),
+            point_estimate_matches_uncertainty_objective=False,
+            reason="Full-objective optimization did not converge.",
+        )
+        self.assertIn("did not converge", fallback.reason)
+
+        with self.assertRaisesRegex(ValueError, "requires an explicit reason"):
+            self._provenance(
+                **common,
+                integration_status=(
+                    InstrumentChannelCalibrationUncertaintyIntegrationStatus
+                    .ATTEMPTED_UNAVAILABLE_FALLBACK
+                ),
+                point_estimate_source=(
+                    "pgmuvi_iterative_mad_clipped_affine_fallback_"
+                    "final_inliers"
+                ),
+                point_estimate_objective=(
+                    "iterative_scale_frozen_weighted_least_squares"
+                ),
+                point_estimate_matches_uncertainty_objective=False,
+            )
+
+    def test_fitter_owns_finite_filtering_and_final_inlier_identity(self):
+        channel_flux = np.arange(7, dtype=float)
+        reference_flux = 0.5 + 2.0 * channel_flux
+        reference_flux[2] = np.nan
+        reference_flux[5] = 100.0
+
+        calibration = fit_instrument_channel_calibration(
+            reference_flux,
+            channel_flux,
+            reference_channel="reference",
+            channel="target",
+            wavelength=1.0,
+        )
+        provenance = calibration.fit_provenance
+
+        self.assertIsNotNone(provenance)
+        self.assertEqual(provenance.n_input_pairs, 7)
+        self.assertEqual(provenance.finite_pair_indices, (0, 1, 3, 4, 5, 6))
+        self.assertEqual(provenance.final_inlier_indices, (0, 1, 3, 4, 6))
+        self.assertEqual(provenance.n_finite_pairs, calibration.n_pairs)
+        self.assertEqual(provenance.n_final_inliers, calibration.n_inliers)
+        self.assertIs(
+            provenance.integration_status,
+            InstrumentChannelCalibrationUncertaintyIntegrationStatus.ACTIVE,
+        )
+        self.assertTrue(
+            provenance.point_estimate_matches_uncertainty_objective
+        )
+
+    def test_fixed_weight_fitter_paths_are_active(self):
+        channel_flux = np.linspace(0.0, 2.0, 20)
+        reference_flux = 0.25 + 1.5 * channel_flux
+
+        for reference_error in (
+            None,
+            np.linspace(0.02, 0.04, channel_flux.size),
+        ):
+            with self.subTest(reference_error=reference_error is not None):
+                calibration = fit_instrument_channel_calibration(
+                    reference_flux,
+                    channel_flux,
+                    reference_channel="reference",
+                    channel="target",
+                    wavelength=1.0,
+                    reference_error=reference_error,
+                )
+                provenance = calibration.fit_provenance
+
+                self.assertIs(
+                    provenance.selected_uncertainty_estimator,
+                    InstrumentChannelCalibrationUncertaintyEstimator
+                    .FIXED_WEIGHT_NORMAL_MATRIX,
+                )
+                self.assertIs(
+                    provenance.integration_status,
+                    InstrumentChannelCalibrationUncertaintyIntegrationStatus
+                    .ACTIVE,
+                )
+                self.assertEqual(
+                    provenance.to_dict()["error_axes"],
+                    [] if reference_error is None else ["reference"],
+                )
+                self.assertTrue(
+                    provenance.point_estimate_matches_uncertainty_objective
+                )
+                self.assertIsNone(provenance.reason)
+                self.assertIs(
+                    calibration.coefficient_uncertainty.status,
+                    InstrumentChannelCalibrationUncertaintyStatus.AVAILABLE,
+                )
+
+    def test_channel_errors_select_but_do_not_activate_full_objective(self):
+        channel_flux = np.linspace(0.0, 2.0, 20)
+        reference_flux = 0.25 + 1.5 * channel_flux
+
+        for reference_error in (
+            None,
+            np.full(channel_flux.size, 0.03),
+        ):
+            with self.subTest(reference_error=reference_error is not None):
+                calibration = fit_instrument_channel_calibration(
+                    reference_flux,
+                    channel_flux,
+                    reference_channel="reference",
+                    channel="target",
+                    wavelength=1.0,
+                    reference_error=reference_error,
+                    channel_error=np.linspace(
+                        0.01,
+                        0.02,
+                        channel_flux.size,
+                    ),
+                )
+                provenance = calibration.fit_provenance
+                uncertainty = calibration.coefficient_uncertainty
+
+                self.assertIs(
+                    provenance.selected_uncertainty_estimator,
+                    InstrumentChannelCalibrationUncertaintyEstimator
+                    .SCALE_DEPENDENT_FULL_OBJECTIVE,
+                )
+                self.assertIs(
+                    provenance.integration_status,
+                    InstrumentChannelCalibrationUncertaintyIntegrationStatus
+                    .DEFINED_NOT_ACTIVATED,
+                )
+                self.assertFalse(
+                    provenance.point_estimate_matches_uncertainty_objective
+                )
+                self.assertIn("defined but not activated", provenance.reason)
+                self.assertIs(
+                    uncertainty.status,
+                    InstrumentChannelCalibrationUncertaintyStatus.UNAVAILABLE,
+                )
+                self.assertIsNone(uncertainty.coefficient_covariance)
+
+    def test_model_count_consistency_is_enforced(self):
+        fitted = fit_instrument_channel_calibration(
+            np.asarray([1.0, 3.0, 5.0, 7.0]),
+            np.asarray([0.0, 1.0, 2.0, 3.0]),
+            reference_channel="reference",
+            channel="target",
+            wavelength=1.0,
+        )
+
+        with self.assertRaisesRegex(ValueError, "finite-pair count"):
+            InstrumentChannelCalibration(
+                schema_version=(
+                    INSTRUMENT_CHANNEL_CALIBRATION_MODEL_SCHEMA_VERSION
+                ),
+                reference_channel=fitted.reference_channel,
+                channel=fitted.channel,
+                wavelength=fitted.wavelength,
+                offset=fitted.offset,
+                scale=fitted.scale,
+                n_pairs=fitted.n_pairs + 1,
+                n_inliers=fitted.n_inliers,
+                residual_mad_sigma=fitted.residual_mad_sigma,
+                coefficient_uncertainty=fitted.coefficient_uncertainty,
+                fit_provenance=fitted.fit_provenance,
+            )
+
+    def test_manual_calibration_without_fit_provenance_remains_valid(self):
+        fitted = fit_instrument_channel_calibration(
+            np.asarray([1.0, 3.0, 5.0, 7.0]),
+            np.asarray([0.0, 1.0, 2.0, 3.0]),
+            reference_channel="reference",
+            channel="target",
+            wavelength=1.0,
+        )
+        manual = InstrumentChannelCalibration(
+            schema_version=(
+                INSTRUMENT_CHANNEL_CALIBRATION_MODEL_SCHEMA_VERSION
+            ),
+            reference_channel=fitted.reference_channel,
+            channel=fitted.channel,
+            wavelength=fitted.wavelength,
+            offset=fitted.offset,
+            scale=fitted.scale,
+            n_pairs=fitted.n_pairs,
+            n_inliers=fitted.n_inliers,
+            residual_mad_sigma=fitted.residual_mad_sigma,
+            coefficient_uncertainty=fitted.coefficient_uncertainty,
+        )
+
+        self.assertIsNone(manual.fit_provenance)
+        self.assertIsNone(manual.to_dict()["fit_provenance"])
+        json.dumps(manual.to_dict(), allow_nan=False)
+
+    def test_orchestration_preserves_separate_same_wavelength_provenance(self):
+        times = np.tile(np.arange(4, dtype=float), 3)
+        channels = np.repeat(np.asarray(["A", "B", "C"], dtype=object), 4)
+        wavelengths = np.ones(12, dtype=float)
+        flux = np.concatenate(
+            (
+                np.asarray([1.0, 3.0, 5.0, 7.0]),
+                np.asarray([0.0, 1.0, 2.0, 3.0]),
+                np.asarray([0.5, 1.5, 2.5, 3.5]),
+            )
+        )
+        error = np.full(12, 0.1)
+        assessment = assess_instrument_channel_calibration_requirement(
+            wavelengths,
+            channels,
+        )
+        plan = define_instrument_channel_calibration_plan(
+            assessment,
+            (
+                InstrumentChannelCalibrationGroupPlan(
+                    physical_wavelength=1.0,
+                    reference_channel="A",
+                    channel_plans=tuple(
+                        InstrumentChannelCalibrationChannelPlan(
+                            channel=channel,
+                            disposition=(
+                                InstrumentChannelCalibrationDisposition.PLANNED
+                            ),
+                            pairing_method=(
+                                InstrumentChannelPairingMethod.EXACT_TIMESTAMP
+                            ),
+                            time_unit="day",
+                            calibration_family="affine",
+                        )
+                        for channel in ("B", "C")
+                    ),
+                ),
+            ),
+        )
+
+        execution = execute_instrument_channel_calibration_plan(
+            plan,
+            times,
+            flux,
+            wavelengths,
+            channels,
+            flux_error=error,
+        )
+        completed = execution.plan.group_plans[0].channel_plans
+
+        self.assertEqual(tuple(item.channel for item in completed), ("B", "C"))
+        self.assertTrue(all(item.calibration is not None for item in completed))
+        self.assertTrue(
+            all(
+                item.calibration.fit_provenance.integration_status
+                is InstrumentChannelCalibrationUncertaintyIntegrationStatus
+                .DEFINED_NOT_ACTIVATED
+                for item in completed
+            )
+        )
+        payload = execution.to_dict()
+        serialized_channels = payload["plan"]["group_plans"][0][
+            "channel_plans"
+        ]
+        self.assertEqual(
+            [item["channel"] for item in serialized_channels],
+            ["B", "C"],
+        )
+        self.assertTrue(
+            all(item["calibration"]["fit_provenance"] for item in serialized_channels)
+        )
+        json.dumps(payload, allow_nan=False)
+
+    def test_predictive_boundary_remains_explicitly_unavailable(self):
+        channel_flux = np.linspace(0.0, 2.0, 20)
+        calibration = fit_instrument_channel_calibration(
+            0.25 + 1.5 * channel_flux,
+            channel_flux,
+            reference_channel="reference",
+            channel="target",
+            wavelength=1.0,
+            channel_error=np.linspace(0.01, 0.02, channel_flux.size),
+        )
+
+        _, predictive = (
+            apply_instrument_channel_calibration_with_predictive_uncertainty(
+                np.asarray([0.5, 1.0]),
+                calibration,
+                flux_error=np.asarray([0.1, 0.1]),
+                covariance_mode=(
+                    InstrumentChannelCalibrationPredictiveCovarianceMode
+                    .MARGINAL_VARIANCE
+                ),
+            )
+        )
+
+        self.assertIs(
+            predictive.status,
+            InstrumentChannelCalibrationPredictiveUncertaintyStatus.UNAVAILABLE,
+        )
+        self.assertIsNone(predictive.measurement_variance)
+        self.assertEqual(
+            predictive.coefficient_uncertainty_source,
+            calibration.coefficient_uncertainty.uncertainty_source,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- define deterministic uncertainty-estimator routing for all reference-axis and observational-channel-axis error combinations
- add immutable, JSON-safe fit provenance recording finite-pair positions, exact final-inlier positions, participating error axes, selected estimator, integration state, point-estimate source, and objective consistency
- preserve the existing fixed-weight uncertainty paths as active while explicitly marking scale-dependent full-objective fitter integration as defined but not activated
- require future successful scale-dependent integration to report coefficients and covariance from the same full-objective optimum and final-inlier set
- define an explicit unavailable-fallback state for future optimization failures instead of pairing fallback coefficients with covariance from a different optimum
- preserve separate per-observational-channel provenance for channels sharing one physical wavelength
- update calibration documentation and the open future-work marker without claiming fitter or orchestration activation

## Validation

- `python3 -m unittest discover -s tests -p 'test_instrument_channel_calibration_uncertainty_integration_contract.py' -v` — 10 tests passed
- complete instrument-channel calibration regressions — 99 tests passed
- calibration documentation regressions — 4 tests passed
- `python3 -m unittest discover -s tests` — 2,670 tests passed
- `ruff check -v --output-format=full --show-fixes ./pgmuvi` — passed
- `make -C docs clean` and `make -C docs html-strict` — passed

## Scope boundary

This PR defines the integration contract only. It does not activate the scale-dependent full-objective estimator inside the affine fitter or orchestration layer, and it does not enable predictive coefficient-covariance propagation in ordinary dataset calibration application.
