### PR TITLE
Implement scale-dependent calibration uncertainty integration

### DIFF
--- a/docs/source/future_work.rst
+++ b/docs/source/future_work.rst
@@ -124,13 +124,13 @@ Wavelength-model extensions
     marginal or full-covariance predictive propagation without orchestration
     activation, and implements the dedicated full-objective
     observed-Hessian estimator for scale-dependent channel-axis coefficient
-    uncertainty, and defines deterministic fitter routing, exact final-inlier
-    provenance, consistent point-estimate/covariance semantics, fallback status,
-    and orchestration preservation without activating the estimator in the
-    fitter or orchestration layer.  This does not close the marker:
-    scientifically validated instrument-specific tolerance guidance, fitter and
-    orchestration activation, workflow integration, and representative
-    calibration validation remain future work.
+    uncertainty, defines deterministic fitter routing, exact final-inlier
+    provenance, consistent point-estimate/covariance semantics and fallback
+    status, and activates the scale-dependent full-objective estimator in the
+    affine fitter and dataset orchestration while preserving separate
+    observational-channel records.  This does not close the marker:
+    scientifically validated instrument-specific tolerance guidance, workflow
+    integration, and representative calibration validation remain future work.
 
 **TBD[multi-periodic-wavelength-models]**
     Add a documented and validated multi-periodic workflow beyond the current

--- a/docs/source/pgmuvi.instrument_channel_calibration.rst
+++ b/docs/source/pgmuvi.instrument_channel_calibration.rst
@@ -82,12 +82,11 @@ by the residual variance
 known-variance weighted normal-matrix inverse without residual-variance
 rescaling.
 
-Coefficient covariance is unavailable when channel-axis errors are supplied.
-Those errors produce effective residual variances that depend on the fitted
-scale, while the current iterative weighting procedure does not expose a
-full-objective Hessian or estimating-equation covariance for that dependence.
-PGMUVI therefore records an explicit unavailable reason rather than presenting
-a frozen-weight normal-matrix inverse as uncertainty for the complete
+When channel-axis errors are supplied, the fitter activates the dedicated
+scale-dependent full objective after selecting its final MAD-clipped inlier set.
+The reported offset, scale, and coefficient covariance then come from the same
+converged optimum, and covariance is the inverse observed Hessian of that
+objective.  A frozen-weight normal-matrix inverse is not substituted for this
 estimator.
 
 Scale-dependent channel-axis uncertainty contract
@@ -97,9 +96,8 @@ Scale-dependent channel-axis uncertainty contract
 defines the immutable JSON-safe result of the dedicated
 :func:`~pgmuvi.instrument_channel_calibration.estimate_scale_dependent_instrument_channel_calibration_coefficient_uncertainty`
 low-level callable.  The estimator is implemented with analytic objective
-derivatives and a log-scale parameterization, while the current affine fitter
-continues to report coefficient uncertainty as unavailable whenever
-channel-axis errors are supplied.
+derivatives and a log-scale parameterization and is activated by the affine
+fitter whenever channel-axis errors participate in the final fit.
 
 For final-inlier paired values, the estimator minimizes the Gaussian
 negative log likelihood
@@ -155,15 +153,18 @@ and whether the point estimate and covariance share one objective optimum.
 The nested ``coefficient_uncertainty`` field remains the sole source of
 coefficient covariance in fixed order ``offset, scale``.
 
-Scale-dependent activation remains deliberately disabled in the affine fitter.
-For current fits with observational-channel-axis errors, provenance reports
-``defined_not_activated`` and identifies the reported coefficients as the
-iterative scale-frozen weighted affine fallback.  Coefficient covariance stays
-explicitly unavailable.  Future successful activation must report the offset,
-scale, objective, covariance, and final-inlier conditioning from the same
-full-objective optimum.  If future optimization fails, a retained affine point
-estimate must use the explicit ``attempted_unavailable_fallback`` status rather
-than being paired with covariance from a different optimum.
+Scale-dependent activation is now implemented in the affine fitter.  For
+successful fits with observational-channel-axis errors, provenance reports
+``active`` and identifies the full-objective optimum as the common source of the
+reported offset, scale, and covariance.  The covariance remains conditioned on
+the exact final MAD-clipped inlier set.
+
+``defined_not_activated`` remains a stable contract value for records produced
+before activation or by external callers.  If full-objective optimization is
+attempted but unavailable, the fitter retains its iterative scale-frozen affine
+point estimate, records ``attempted_unavailable_fallback``, and leaves
+coefficient covariance explicitly unavailable rather than pairing fallback
+coefficients with covariance from a different optimum.
 
 Dataset orchestration already preserves complete per-observational-channel
 calibration records, so this provenance remains separate for channels that
@@ -246,9 +247,10 @@ and derived standard deviation.  ``full_covariance`` additionally records
 correlations between predictions that share fitted coefficients.  Scalar input
 uses ``input_shape=()``; array results preserve their original shape.
 
-Unavailable coefficient covariance, including current fits with
-scale-dependent channel-axis errors, produces an explicit ``unavailable``
-result with no numerical predictive uncertainty.  There is no silent fallback
+Unavailable coefficient covariance, including an attempted scale-dependent
+optimization that falls back to the iterative affine estimate, produces an
+explicit ``unavailable`` result with no numerical predictive uncertainty.
+There is no silent fallback
 to measurement-only uncertainty.  Predictive propagation is implemented only
 in the dedicated application callable; current dataset orchestration continues
 to record that propagation was not requested or performed.  The stable future
@@ -264,8 +266,6 @@ still lacks:
 
 * scientifically validated instrument-specific rules for choosing
   pairing methods and tolerances;
-* fitter and orchestration activation of scale-dependent channel-axis
-  coefficient uncertainty;
 * integration into the normal light-curve fitting workflow; and
 * validation across representative instruments, filters, and LPV sources.
 

--- a/pgmuvi/instrument_channel_calibration.py
+++ b/pgmuvi/instrument_channel_calibration.py
@@ -1228,8 +1228,8 @@ def select_instrument_channel_calibration_uncertainty_estimator(
     Reference-axis errors alone retain the existing fixed-weight covariance
     path. Any observational-channel-axis error selects the scale-dependent
     full-objective path, whether or not reference-axis errors are also present.
-    This selector defines integration routing only; it does not activate the
-    scale-dependent estimator in the affine fitter.
+    The affine fitter applies this routing and activates the selected
+    estimator after finite filtering and final-inlier selection.
     """
 
     for name, value in (
@@ -1259,8 +1259,8 @@ class InstrumentChannelCalibrationFitProvenance:
     filtering. The selected estimator is deterministic from error-axis
     participation. A scale-dependent available covariance must share the same
     full-objective optimum and final-inlier set as the reported coefficients.
-    If that estimator fails after future activation, a fallback point estimate
-    must be represented explicitly rather than paired with its covariance.
+    If that estimator fails after activation, a fallback point estimate must
+    be represented explicitly rather than paired with its covariance.
     """
 
     schema_version: str
@@ -4868,12 +4868,13 @@ def fit_instrument_channel_calibration(
 
     Notes
     -----
-    Coefficient covariance is estimated for the final fixed-weight solve,
-    conditional on the final MAD-clipped inlier set. Reference-channel
-    measurement variances are treated as known. When channel-axis errors are
-    supplied, their effective variances depend on the fitted scale, so
-    coefficient covariance is recorded as unavailable rather than using a
-    frozen-weight approximation.
+    Coefficient covariance is conditioned on the final MAD-clipped inlier set.
+    No-error and reference-error-only fits use the final fixed-weight affine
+    solve. Fits with channel-axis errors activate the scale-dependent Gaussian
+    full objective so the reported offset, scale, and inverse observed-Hessian
+    covariance share one optimum. If that optimization is unavailable, the
+    iterative scale-frozen affine estimate is retained with explicit fallback
+    provenance and unavailable coefficient covariance.
     """
 
     if isinstance(min_pairs, bool) or not isinstance(min_pairs, int):
@@ -5109,23 +5110,23 @@ def fit_instrument_channel_calibration(
         reference[keep]
         - (offset + scale * target[keep])
     )
-    coefficient_uncertainty = _estimate_affine_coefficient_uncertainty(
-        target[keep],
-        final_residual,
-        final_weights,
-        measurement_errors_supplied=(
-            reference_sigma is not None or channel_sigma is not None
-        ),
-        channel_errors_supplied=channel_sigma is not None,
-    )
-
     selected_uncertainty_estimator = (
         select_instrument_channel_calibration_uncertainty_estimator(
             reference_error_supplied=reference_sigma is not None,
             channel_error_supplied=channel_sigma is not None,
         )
     )
+
     if channel_sigma is None:
+        coefficient_uncertainty = _estimate_affine_coefficient_uncertainty(
+            target[keep],
+            final_residual,
+            final_weights,
+            measurement_errors_supplied=(
+                reference_sigma is not None
+            ),
+            channel_errors_supplied=False,
+        )
         integration_status = (
             InstrumentChannelCalibrationUncertaintyIntegrationStatus.ACTIVE
         )
@@ -5134,22 +5135,96 @@ def fit_instrument_channel_calibration(
         point_estimate_matches_uncertainty_objective = True
         integration_reason = None
     else:
-        integration_status = (
-            InstrumentChannelCalibrationUncertaintyIntegrationStatus
-            .DEFINED_NOT_ACTIVATED
+        scale_dependent_estimate = (
+            estimate_scale_dependent_instrument_channel_calibration_coefficient_uncertainty(
+                reference[keep],
+                target[keep],
+                reference_error=(
+                    None
+                    if reference_sigma is None
+                    else reference_sigma[keep]
+                ),
+                channel_error=channel_sigma[keep],
+                initial_offset=offset,
+                initial_scale=scale,
+            )
         )
-        point_estimate_source = (
-            "pgmuvi_iterative_mad_clipped_affine_fallback_final_inliers"
-        )
-        point_estimate_objective = (
-            "iterative_scale_frozen_weighted_least_squares"
-        )
-        point_estimate_matches_uncertainty_objective = False
-        integration_reason = (
-            "Scale-dependent full-objective fitter integration is defined "
-            "but not activated; the reported coefficients remain the "
-            "iterative scale-frozen weighted affine point estimate."
-        )
+
+        if (
+            scale_dependent_estimate.status
+            is InstrumentChannelCalibrationUncertaintyStatus.AVAILABLE
+        ):
+            offset = float(scale_dependent_estimate.offset)
+            scale = float(scale_dependent_estimate.scale)
+            final_residual = (
+                reference[keep]
+                - (offset + scale * target[keep])
+            )
+            coefficient_uncertainty = (
+                InstrumentChannelCalibrationCoefficientUncertainty(
+                    schema_version=(
+                        INSTRUMENT_CHANNEL_CALIBRATION_UNCERTAINTY_SCHEMA_VERSION
+                    ),
+                    status=(
+                        InstrumentChannelCalibrationUncertaintyStatus.AVAILABLE
+                    ),
+                    uncertainty_source=(
+                        scale_dependent_estimate.uncertainty_source
+                    ),
+                    coefficient_covariance=(
+                        scale_dependent_estimate.coefficient_covariance
+                    ),
+                    estimation_method=(
+                        "inverse_observed_hessian_"
+                        "scale_dependent_full_objective"
+                    ),
+                )
+            )
+            integration_status = (
+                InstrumentChannelCalibrationUncertaintyIntegrationStatus.ACTIVE
+            )
+            point_estimate_source = (
+                "pgmuvi_scale_dependent_full_objective_final_inliers"
+            )
+            point_estimate_objective = (
+                "gaussian_negative_log_likelihood_"
+                "scale_dependent_effective_variance"
+            )
+            point_estimate_matches_uncertainty_objective = True
+            integration_reason = None
+        else:
+            estimator_reason = scale_dependent_estimate.reason
+            integration_reason = (
+                "Scale-dependent full-objective optimization was attempted "
+                "on the final inlier set but coefficient uncertainty is "
+                f"unavailable: {estimator_reason}"
+            )
+            coefficient_uncertainty = (
+                InstrumentChannelCalibrationCoefficientUncertainty(
+                    schema_version=(
+                        INSTRUMENT_CHANNEL_CALIBRATION_UNCERTAINTY_SCHEMA_VERSION
+                    ),
+                    status=(
+                        InstrumentChannelCalibrationUncertaintyStatus.UNAVAILABLE
+                    ),
+                    uncertainty_source=(
+                        scale_dependent_estimate.uncertainty_source
+                    ),
+                    coefficient_covariance=None,
+                    reason=integration_reason,
+                )
+            )
+            integration_status = (
+                InstrumentChannelCalibrationUncertaintyIntegrationStatus
+                .ATTEMPTED_UNAVAILABLE_FALLBACK
+            )
+            point_estimate_source = (
+                "pgmuvi_iterative_mad_clipped_affine_fallback_final_inliers"
+            )
+            point_estimate_objective = (
+                "iterative_scale_frozen_weighted_least_squares"
+            )
+            point_estimate_matches_uncertainty_objective = False
 
     fit_provenance = InstrumentChannelCalibrationFitProvenance(
         schema_version=(

--- a/tests/test_docs_instrument_channel_calibration.py
+++ b/tests/test_docs_instrument_channel_calibration.py
@@ -142,12 +142,13 @@ class TestInstrumentChannelCalibrationDocumentation(unittest.TestCase):
             normalized,
         )
         self.assertIn(
-            "Coefficient covariance is unavailable when channel-axis errors "
-            "are supplied",
+            "When channel-axis errors are supplied, the fitter activates the "
+            "dedicated scale-dependent full objective",
             normalized,
         )
         self.assertIn(
-            "does not expose a full-objective Hessian",
+            "reported offset, scale, and coefficient covariance then come "
+            "from the same converged optimum",
             normalized,
         )
         self.assertIn(
@@ -197,6 +198,10 @@ class TestInstrumentChannelCalibrationDocumentation(unittest.TestCase):
         )
         self.assertIn("defined_not_activated", text)
         self.assertIn("attempted_unavailable_fallback", text)
+        self.assertIn(
+            "Scale-dependent activation is now implemented",
+            normalized,
+        )
         self.assertIn(
             "sole source of coefficient covariance",
             normalized,
@@ -264,13 +269,13 @@ class TestInstrumentChannelCalibrationDocumentation(unittest.TestCase):
             text,
         )
         self.assertIn(
-            "without activating the estimator in the fitter or orchestration "
-            "layer",
+            "activates the scale-dependent full-objective estimator in the "
+            "affine fitter and dataset orchestration",
             text,
         )
         self.assertIn("deterministic fitter routing", text)
         self.assertIn("exact final-inlier provenance", text)
-        self.assertIn("fitter and orchestration activation", text)
+        self.assertNotIn("fitter and orchestration activation", text)
         self.assertNotIn(
             "predictive-propagation implementation",
             text,

--- a/tests/test_instrument_channel_calibration_orchestration_execution.py
+++ b/tests/test_instrument_channel_calibration_orchestration_execution.py
@@ -146,20 +146,31 @@ class TestInstrumentChannelCalibrationOrchestrationExecution(
             result.schema_version,
             INSTRUMENT_CHANNEL_CALIBRATION_EXECUTION_SCHEMA_VERSION,
         )
+        completed = result.plan.group_plans[0].channel_plans[0]
+        self.assertIsNotNone(completed.pairing)
+        self.assertIsNotNone(completed.calibration)
+        calibration = completed.calibration
+
+        expected_flux = original_flux.copy()
+        expected_flux[3:] = (
+            calibration.offset
+            + calibration.scale * original_flux[3:]
+        )
+        expected_error = original_error.copy()
+        expected_error[3:] = (
+            abs(calibration.scale) * original_error[3:]
+        )
         np.testing.assert_allclose(
             result.calibrated_flux,
-            [3.0, 5.0, 7.0, 3.0, 5.0, 7.0],
+            expected_flux,
         )
         np.testing.assert_allclose(
             result.calibrated_flux_error,
-            [0.3, 0.3, 0.3, 0.2, 0.2, 0.2],
+            expected_error,
         )
         np.testing.assert_array_equal(flux, original_flux)
         np.testing.assert_array_equal(error, original_error)
 
-        completed = result.plan.group_plans[0].channel_plans[0]
-        self.assertIsNotNone(completed.pairing)
-        self.assertIsNotNone(completed.calibration)
         self.assertEqual(
             completed.pairing.reference_row_indices,
             (10, 20, 30),
@@ -169,12 +180,16 @@ class TestInstrumentChannelCalibrationOrchestrationExecution(
             (40, 50, 60),
         )
         self.assertEqual(
-            completed.calibration.coefficient_uncertainty.status.value,
-            "unavailable",
+            calibration.coefficient_uncertainty.status.value,
+            "available",
         )
-        self.assertIn(
-            "scale-dependent effective variances",
-            completed.calibration.coefficient_uncertainty.reason,
+        self.assertEqual(
+            calibration.coefficient_uncertainty.estimation_method,
+            "inverse_observed_hessian_scale_dependent_full_objective",
+        )
+        self.assertEqual(
+            calibration.fit_provenance.integration_status.value,
+            "active",
         )
         self.assertEqual(result.applied_channels, ("B",))
         self.assertEqual(

--- a/tests/test_instrument_channel_calibration_scale_dependent_uncertainty_contract.py
+++ b/tests/test_instrument_channel_calibration_scale_dependent_uncertainty_contract.py
@@ -200,9 +200,13 @@ class TestScaleDependentUncertaintyEstimateContract(unittest.TestCase):
         self.assertTrue(result.optimizer_converged)
         self.assertTrue(result.to_dict()["implemented"])
 
-    def test_current_fitter_boundary_remains_unavailable(self):
+    def test_fitter_activates_scale_dependent_full_objective(self):
         channel_flux = np.linspace(0.0, 2.0, 20)
-        reference_flux = 0.25 + 1.5 * channel_flux
+        reference_flux = (
+            0.25
+            + 1.5 * channel_flux
+            + 0.01 * np.sin(np.arange(channel_flux.size))
+        )
 
         calibration = fit_instrument_channel_calibration(
             reference_flux,
@@ -217,12 +221,20 @@ class TestScaleDependentUncertaintyEstimateContract(unittest.TestCase):
         uncertainty = calibration.coefficient_uncertainty
         self.assertEqual(
             uncertainty.status,
-            InstrumentChannelCalibrationUncertaintyStatus.UNAVAILABLE,
+            InstrumentChannelCalibrationUncertaintyStatus.AVAILABLE,
         )
-        self.assertIsNone(uncertainty.coefficient_covariance)
-        self.assertIn(
-            "current affine fitter does not expose a covariance estimator",
-            uncertainty.reason,
+        self.assertIsNotNone(uncertainty.coefficient_covariance)
+        self.assertEqual(
+            uncertainty.estimation_method,
+            "inverse_observed_hessian_scale_dependent_full_objective",
+        )
+        self.assertEqual(
+            calibration.fit_provenance.integration_status.value,
+            "active",
+        )
+        self.assertTrue(
+            calibration.fit_provenance
+            .point_estimate_matches_uncertainty_objective
         )
 
 

--- a/tests/test_instrument_channel_calibration_uncertainty_contract.py
+++ b/tests/test_instrument_channel_calibration_uncertainty_contract.py
@@ -302,9 +302,13 @@ class TestInstrumentChannelCalibrationCoefficientUncertainty(unittest.TestCase):
             atol=1.0e-15,
         )
 
-    def test_channel_error_fit_records_uncertainty_as_unavailable(self):
+    def test_channel_error_fit_records_full_objective_uncertainty(self):
         channel_flux = np.linspace(0.0, 2.0, 20)
-        reference_flux = 0.25 + 1.5 * channel_flux
+        reference_flux = (
+            0.25
+            + 1.5 * channel_flux
+            + 0.01 * np.sin(np.arange(channel_flux.size))
+        )
 
         calibration = fit_instrument_channel_calibration(
             reference_flux,
@@ -319,15 +323,24 @@ class TestInstrumentChannelCalibrationCoefficientUncertainty(unittest.TestCase):
         uncertainty = calibration.coefficient_uncertainty
         self.assertEqual(
             uncertainty.status,
-            InstrumentChannelCalibrationUncertaintyStatus.UNAVAILABLE,
+            InstrumentChannelCalibrationUncertaintyStatus.AVAILABLE,
         )
-        self.assertIsNone(uncertainty.coefficient_covariance)
         self.assertEqual(
-            uncertainty.reason,
-            "Coefficient covariance is unavailable when channel-axis "
-            "measurement errors contribute scale-dependent effective "
-            "variances; the current affine fitter does not expose a "
-            "covariance estimator for the full iterative weighting procedure.",
+            uncertainty.uncertainty_source,
+            "pgmuvi_scale_dependent_full_objective_final_inliers",
+        )
+        self.assertEqual(
+            uncertainty.estimation_method,
+            "inverse_observed_hessian_scale_dependent_full_objective",
+        )
+        self.assertIsNotNone(uncertainty.coefficient_covariance)
+        self.assertEqual(
+            calibration.fit_provenance.integration_status.value,
+            "active",
+        )
+        self.assertTrue(
+            calibration.fit_provenance
+            .point_estimate_matches_uncertainty_objective
         )
         json.dumps(calibration.to_dict(), allow_nan=False)
 

--- a/tests/test_instrument_channel_calibration_uncertainty_integration_contract.py
+++ b/tests/test_instrument_channel_calibration_uncertainty_integration_contract.py
@@ -2,8 +2,12 @@
 
 import json
 import unittest
+from unittest.mock import patch
 
 import numpy as np
+from scipy.optimize import OptimizeResult
+
+from pgmuvi import instrument_channel_calibration
 
 from pgmuvi.instrument_channel_calibration import (
     INSTRUMENT_CHANNEL_CALIBRATION_FIT_PROVENANCE_SCHEMA_VERSION,
@@ -22,6 +26,7 @@ from pgmuvi.instrument_channel_calibration import (
     apply_instrument_channel_calibration_with_predictive_uncertainty,
     assess_instrument_channel_calibration_requirement,
     define_instrument_channel_calibration_plan,
+    estimate_scale_dependent_instrument_channel_calibration_coefficient_uncertainty,
     execute_instrument_channel_calibration_plan,
     fit_instrument_channel_calibration,
     select_instrument_channel_calibration_uncertainty_estimator,
@@ -247,15 +252,24 @@ class TestCalibrationUncertaintyIntegrationContract(unittest.TestCase):
                     InstrumentChannelCalibrationUncertaintyStatus.AVAILABLE,
                 )
 
-    def test_channel_errors_select_but_do_not_activate_full_objective(self):
+    def test_channel_errors_activate_full_objective(self):
         channel_flux = np.linspace(0.0, 2.0, 20)
-        reference_flux = 0.25 + 1.5 * channel_flux
+        reference_flux = (
+            0.25
+            + 1.5 * channel_flux
+            + 0.01 * np.sin(np.arange(channel_flux.size))
+        )
 
         for reference_error in (
             None,
             np.full(channel_flux.size, 0.03),
         ):
             with self.subTest(reference_error=reference_error is not None):
+                channel_error = np.linspace(
+                    0.01,
+                    0.02,
+                    channel_flux.size,
+                )
                 calibration = fit_instrument_channel_calibration(
                     reference_flux,
                     channel_flux,
@@ -263,11 +277,7 @@ class TestCalibrationUncertaintyIntegrationContract(unittest.TestCase):
                     channel="target",
                     wavelength=1.0,
                     reference_error=reference_error,
-                    channel_error=np.linspace(
-                        0.01,
-                        0.02,
-                        channel_flux.size,
-                    ),
+                    channel_error=channel_error,
                 )
                 provenance = calibration.fit_provenance
                 uncertainty = calibration.coefficient_uncertainty
@@ -280,17 +290,102 @@ class TestCalibrationUncertaintyIntegrationContract(unittest.TestCase):
                 self.assertIs(
                     provenance.integration_status,
                     InstrumentChannelCalibrationUncertaintyIntegrationStatus
-                    .DEFINED_NOT_ACTIVATED,
+                    .ACTIVE,
                 )
-                self.assertFalse(
+                self.assertTrue(
                     provenance.point_estimate_matches_uncertainty_objective
                 )
-                self.assertIn("defined but not activated", provenance.reason)
+                self.assertEqual(
+                    provenance.point_estimate_source,
+                    "pgmuvi_scale_dependent_full_objective_final_inliers",
+                )
+                self.assertEqual(
+                    provenance.point_estimate_objective,
+                    "gaussian_negative_log_likelihood_"
+                    "scale_dependent_effective_variance",
+                )
+                self.assertIsNone(provenance.reason)
                 self.assertIs(
                     uncertainty.status,
-                    InstrumentChannelCalibrationUncertaintyStatus.UNAVAILABLE,
+                    InstrumentChannelCalibrationUncertaintyStatus.AVAILABLE,
                 )
-                self.assertIsNone(uncertainty.coefficient_covariance)
+                self.assertIsNotNone(uncertainty.coefficient_covariance)
+
+                direct = (
+                    estimate_scale_dependent_instrument_channel_calibration_coefficient_uncertainty(
+                        reference_flux,
+                        channel_flux,
+                        reference_error=reference_error,
+                        channel_error=channel_error,
+                        initial_offset=0.25,
+                        initial_scale=1.5,
+                    )
+                )
+                self.assertIs(
+                    direct.status,
+                    InstrumentChannelCalibrationUncertaintyStatus.AVAILABLE,
+                )
+                np.testing.assert_allclose(
+                    (calibration.offset, calibration.scale),
+                    (direct.offset, direct.scale),
+                    rtol=1.0e-8,
+                    atol=1.0e-10,
+                )
+                np.testing.assert_allclose(
+                    uncertainty.coefficient_covariance,
+                    direct.coefficient_covariance,
+                    rtol=1.0e-7,
+                    atol=1.0e-12,
+                )
+
+    def test_optimizer_failure_retains_explicit_affine_fallback(self):
+        channel_flux = np.linspace(0.0, 2.0, 20)
+        reference_flux = 0.25 + 1.5 * channel_flux
+        failure = OptimizeResult(
+            success=False,
+            message="forced integration failure",
+            x=np.asarray([0.25, 0.0]),
+        )
+
+        with patch.object(
+            instrument_channel_calibration.optimize,
+            "minimize",
+            return_value=failure,
+        ):
+            calibration = fit_instrument_channel_calibration(
+                reference_flux,
+                channel_flux,
+                reference_channel="reference",
+                channel="target",
+                wavelength=1.0,
+                reference_error=np.full(channel_flux.size, 0.03),
+                channel_error=np.linspace(
+                    0.01,
+                    0.02,
+                    channel_flux.size,
+                ),
+            )
+
+        provenance = calibration.fit_provenance
+        uncertainty = calibration.coefficient_uncertainty
+        self.assertIs(
+            provenance.integration_status,
+            InstrumentChannelCalibrationUncertaintyIntegrationStatus
+            .ATTEMPTED_UNAVAILABLE_FALLBACK,
+        )
+        self.assertFalse(
+            provenance.point_estimate_matches_uncertainty_objective
+        )
+        self.assertIn("forced integration failure", provenance.reason)
+        self.assertIs(
+            uncertainty.status,
+            InstrumentChannelCalibrationUncertaintyStatus.UNAVAILABLE,
+        )
+        self.assertIsNone(uncertainty.coefficient_covariance)
+        self.assertIn("forced integration failure", uncertainty.reason)
+        self.assertAlmostEqual(calibration.offset, 0.25, places=12)
+        self.assertAlmostEqual(calibration.scale, 1.5, places=12)
+        json.dumps(calibration.to_dict(), allow_nan=False)
 
     def test_model_count_consistency_is_enforced(self):
         fitted = fit_instrument_channel_calibration(
@@ -347,11 +442,14 @@ class TestCalibrationUncertaintyIntegrationContract(unittest.TestCase):
 
     def test_orchestration_preserves_separate_same_wavelength_provenance(self):
         times = np.tile(np.arange(4, dtype=float), 3)
-        channels = np.repeat(np.asarray(["A", "B", "C"], dtype=object), 4)
+        channels = np.repeat(
+            np.asarray(["A", "B", "C"], dtype=object),
+            4,
+        )
         wavelengths = np.ones(12, dtype=float)
         flux = np.concatenate(
             (
-                np.asarray([1.0, 3.0, 5.0, 7.0]),
+                np.asarray([1.0, 3.01, 4.99, 7.0]),
                 np.asarray([0.0, 1.0, 2.0, 3.0]),
                 np.asarray([0.5, 1.5, 2.5, 3.5]),
             )
@@ -395,13 +493,25 @@ class TestCalibrationUncertaintyIntegrationContract(unittest.TestCase):
         )
         completed = execution.plan.group_plans[0].channel_plans
 
-        self.assertEqual(tuple(item.channel for item in completed), ("B", "C"))
-        self.assertTrue(all(item.calibration is not None for item in completed))
+        self.assertEqual(
+            tuple(item.channel for item in completed),
+            ("B", "C"),
+        )
+        self.assertTrue(
+            all(item.calibration is not None for item in completed)
+        )
         self.assertTrue(
             all(
                 item.calibration.fit_provenance.integration_status
                 is InstrumentChannelCalibrationUncertaintyIntegrationStatus
-                .DEFINED_NOT_ACTIVATED
+                .ACTIVE
+                for item in completed
+            )
+        )
+        self.assertTrue(
+            all(
+                item.calibration.coefficient_uncertainty.status
+                is InstrumentChannelCalibrationUncertaintyStatus.AVAILABLE
                 for item in completed
             )
         )
@@ -414,19 +524,30 @@ class TestCalibrationUncertaintyIntegrationContract(unittest.TestCase):
             ["B", "C"],
         )
         self.assertTrue(
-            all(item["calibration"]["fit_provenance"] for item in serialized_channels)
+            all(
+                item["calibration"]["fit_provenance"]
+                for item in serialized_channels
+            )
         )
         json.dumps(payload, allow_nan=False)
 
-    def test_predictive_boundary_remains_explicitly_unavailable(self):
+    def test_predictive_boundary_uses_activated_covariance(self):
         channel_flux = np.linspace(0.0, 2.0, 20)
         calibration = fit_instrument_channel_calibration(
-            0.25 + 1.5 * channel_flux,
+            (
+                0.25
+                + 1.5 * channel_flux
+                + 0.01 * np.sin(np.arange(channel_flux.size))
+            ),
             channel_flux,
             reference_channel="reference",
             channel="target",
             wavelength=1.0,
-            channel_error=np.linspace(0.01, 0.02, channel_flux.size),
+            channel_error=np.linspace(
+                0.01,
+                0.02,
+                channel_flux.size,
+            ),
         )
 
         _, predictive = (
@@ -443,9 +564,10 @@ class TestCalibrationUncertaintyIntegrationContract(unittest.TestCase):
 
         self.assertIs(
             predictive.status,
-            InstrumentChannelCalibrationPredictiveUncertaintyStatus.UNAVAILABLE,
+            InstrumentChannelCalibrationPredictiveUncertaintyStatus.AVAILABLE,
         )
-        self.assertIsNone(predictive.measurement_variance)
+        self.assertIsNotNone(predictive.measurement_variance)
+        self.assertIsNotNone(predictive.predictive_variance)
         self.assertEqual(
             predictive.coefficient_uncertainty_source,
             calibration.coefficient_uncertainty.uncertainty_source,


### PR DESCRIPTION
## Summary

- activate the scale-dependent full-objective calibration uncertainty estimator whenever observational-channel-axis errors participate in an affine calibration fit
- ensure the reported offset, scale, and coefficient covariance come from the same full-objective optimum and exact final MAD-clipped inlier set
- retain the iterative scale-frozen affine estimate as an explicit `attempted_unavailable_fallback` when full-objective optimization or covariance estimation is unavailable
- preserve separate calibration and uncertainty provenance for observational channels sharing one physical wavelength
- make fitted scale-dependent coefficient covariance available to the dedicated predictive-uncertainty application boundary while leaving ordinary dataset orchestration propagation unrequested
- update calibration documentation and future-work status to reflect fitter and orchestration activation

## Contract behavior

Successful observational-channel-error fits now record:

- estimator: `scale_dependent_full_objective`
- integration status: `active`
- point-estimate source: `pgmuvi_scale_dependent_full_objective_final_inliers`
- point-estimate objective: `gaussian_negative_log_likelihood_scale_dependent_effective_variance`
- point-estimate/covariance objective match: `true`
- covariance method: `inverse_observed_hessian_scale_dependent_full_objective`

If the full-objective estimator is unavailable, the fitter:

- retains the iterative MAD-clipped scale-frozen affine point estimate
- records `attempted_unavailable_fallback`
- records the optimizer or covariance diagnostic
- leaves coefficient covariance unavailable
- never pairs fallback coefficients with covariance from another objective or optimum

The existing no-error and reference-error-only fixed-weight covariance paths remain unchanged.

## Validation

- targeted scale-dependent estimator, uncertainty-contract, integration-contract, orchestration, fit/apply, predictive-boundary, and documentation tests passed
- full suite: **2,671 tests passed**
- canonical Ruff check passed
- strict Sphinx documentation build passed
- staged and committed diff checks passed
- local and remote branch heads match

## Scope deliberately retained

This does not:

- choose observational-channel pairing methods or tolerances automatically
- merge observational channels that share one physical wavelength
- propagate fitted coefficient uncertainty through ordinary dataset orchestration
- integrate calibration into the normal `Lightcurve.fit()` workflow
- close `TBD[instrument-channel-calibration]`
