### PR TITLE
Define calibration predictive uncertainty orchestration contract

### DIFF
--- a/docs/source/future_work.rst
+++ b/docs/source/future_work.rst
@@ -128,7 +128,10 @@ Wavelength-model extensions
     provenance, consistent point-estimate/covariance semantics and fallback
     status, and activates the scale-dependent full-objective estimator in the
     affine fitter and dataset orchestration while preserving separate
-    observational-channel records.  This does not close the marker:
+    observational-channel records, and defines the explicit request,
+    per-observational-channel block, row-identity, disposition, and
+    dataset-summary contract for ordinary predictive propagation without
+    activating that execution path.  This does not close the marker:
     scientifically validated instrument-specific tolerance guidance, workflow
     integration, and representative calibration validation remain future work.
 

--- a/docs/source/pgmuvi.instrument_channel_calibration.rst
+++ b/docs/source/pgmuvi.instrument_channel_calibration.rst
@@ -257,6 +257,48 @@ to record that propagation was not requested or performed.  The stable future
 orchestration dispositions remain ``not_requested``, ``available``,
 ``skipped``, and ``unavailable``.
 
+Dataset predictive-orchestration contract
+-----------------------------------------
+
+Dataset propagation is an explicit opt-in represented by
+``InstrumentChannelCalibrationPredictiveUncertaintyRequest``.  Absence of a
+request means fitted-coefficient propagation was not requested; coefficient
+covariance availability alone never activates it.  A request selects
+``marginal_variance`` or ``full_covariance``.  The execution callable accepts
+the request boundary, but PR152 deliberately leaves it defined but not
+activated and raises ``NotImplementedError`` when a request is supplied.
+Ordinary execution without a request keeps its existing return type and
+continues to serialize ``fitted_coefficient_uncertainty_propagated`` as false.
+
+The immutable orchestration result contract partitions original dataset source
+rows among reference rows, non-reference observational-channel results, and
+unaffected rows.  Reference-channel rows are explicitly ``not_applicable`` for
+fitted calibration-coefficient uncertainty.  ``available`` channel results
+carry the existing
+``InstrumentChannelCalibrationPredictiveUncertainty`` record; ``unavailable``
+results carry the existing explicit non-numeric unavailable record, with no
+measurement-only fallback.  ``skipped`` and ``not_requested`` results carry no
+numerical predictive values.  Missing results are represented structurally,
+not with NaN-filled dataset arrays.
+
+Marginal variances and derived predictive standard deviations remain
+per-observational-channel blocks aligned to explicit original
+``source_row_indices``.  Full covariance is also channel-local: its row and
+column order follows that channel's source-row order, and no global dense
+dataset covariance is emitted.  Rows calibrated with one shared pair of
+``offset, scale`` coefficients may therefore be correlated within their block.
+Distinct observational channels retain separate blocks, coefficients,
+covariance, and dispositions even when they share one physical wavelength;
+physical wavelength is never a covariance identity.  Cross-channel covariance
+is not emitted and is not silently asserted to be zero.
+
+The existing ``calibrated_flux_error`` array remains the ordinary transformed
+measurement-error array.  Combined predictive standard deviation is exposed
+only through available predictive blocks, so callers cannot confuse it with
+the compatibility field.  A manually constructed calibration may participate
+when it carries valid available coefficient covariance; fit provenance is not
+required merely because the coefficients were supplied manually.
+
 ``TBD[instrument-channel-calibration]`` remains open
 ----------------------------------------------------
 

--- a/pgmuvi/instrument_channel_calibration.py
+++ b/pgmuvi/instrument_channel_calibration.py
@@ -51,6 +51,9 @@ INSTRUMENT_CHANNEL_CALIBRATION_SCALE_DEPENDENT_UNCERTAINTY_SCHEMA_VERSION = (
 INSTRUMENT_CHANNEL_CALIBRATION_PREDICTIVE_UNCERTAINTY_SCHEMA_VERSION = (
     "pgmuvi-instrument-channel-calibration-predictive-uncertainty-v1"
 )
+INSTRUMENT_CHANNEL_CALIBRATION_PREDICTIVE_ORCHESTRATION_SCHEMA_VERSION = (
+    "pgmuvi-instrument-channel-calibration-predictive-orchestration-v1"
+)
 
 
 __all__ = [
@@ -58,6 +61,7 @@ __all__ = [
     "INSTRUMENT_CHANNEL_CALIBRATION_FIT_PROVENANCE_SCHEMA_VERSION",
     "INSTRUMENT_CHANNEL_CALIBRATION_MODEL_SCHEMA_VERSION",
     "INSTRUMENT_CHANNEL_CALIBRATION_PLAN_SCHEMA_VERSION",
+    "INSTRUMENT_CHANNEL_CALIBRATION_PREDICTIVE_ORCHESTRATION_SCHEMA_VERSION",
     "INSTRUMENT_CHANNEL_CALIBRATION_PREDICTIVE_UNCERTAINTY_SCHEMA_VERSION",
     "INSTRUMENT_CHANNEL_CALIBRATION_SCALE_DEPENDENT_UNCERTAINTY_SCHEMA_VERSION",
     "INSTRUMENT_CHANNEL_CALIBRATION_SCHEMA_VERSION",
@@ -75,7 +79,11 @@ __all__ = [
     "InstrumentChannelCalibrationPlan",
     "InstrumentChannelCalibrationPredictiveCovarianceMode",
     "InstrumentChannelCalibrationPredictiveUncertainty",
+    "InstrumentChannelCalibrationPredictiveUncertaintyChannelResult",
     "InstrumentChannelCalibrationPredictiveUncertaintyDisposition",
+    "InstrumentChannelCalibrationPredictiveUncertaintyGroupResult",
+    "InstrumentChannelCalibrationPredictiveUncertaintyOrchestration",
+    "InstrumentChannelCalibrationPredictiveUncertaintyRequest",
     "InstrumentChannelCalibrationPredictiveUncertaintyStatus",
     "InstrumentChannelCalibrationScaleDependentUncertaintyEstimate",
     "InstrumentChannelCalibrationStatus",
@@ -2718,6 +2726,670 @@ class InstrumentChannelCalibrationPredictiveUncertainty:
         }
 
 
+@dataclass(frozen=True)
+class InstrumentChannelCalibrationPredictiveUncertaintyRequest:
+    """Explicit opt-in request for dataset predictive propagation.
+
+    Absence of this object means propagation was not requested.  Supplying a
+    request selects either marginal variance or per-observational-channel full
+    covariance.  Full covariance is never represented as one global dense
+    dataset matrix.
+    """
+
+    covariance_mode: InstrumentChannelCalibrationPredictiveCovarianceMode | str
+    schema_version: str = (
+        INSTRUMENT_CHANNEL_CALIBRATION_PREDICTIVE_ORCHESTRATION_SCHEMA_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if self.schema_version != (
+            INSTRUMENT_CHANNEL_CALIBRATION_PREDICTIVE_ORCHESTRATION_SCHEMA_VERSION
+        ):
+            raise ValueError(
+                "Unsupported instrument-channel calibration predictive "
+                f"orchestration schema version: {self.schema_version!r}."
+            )
+        if isinstance(self.covariance_mode, (bool, np.bool_)):
+            raise TypeError(
+                "covariance_mode must be a predictive covariance mode, "
+                "not boolean."
+            )
+        mode = self.covariance_mode
+        if not isinstance(
+            mode,
+            InstrumentChannelCalibrationPredictiveCovarianceMode,
+        ):
+            try:
+                mode = InstrumentChannelCalibrationPredictiveCovarianceMode(
+                    str(mode)
+                )
+            except ValueError as exc:
+                raise ValueError(
+                    "Unsupported predictive covariance mode: "
+                    f"{self.covariance_mode!r}."
+                ) from exc
+        object.__setattr__(self, "covariance_mode", mode)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a strict JSON-safe request representation."""
+
+        return {
+            "schema_version": self.schema_version,
+            "requested": True,
+            "covariance_mode": self.covariance_mode.value,
+            "full_covariance_scope": (
+                "per_observational_channel"
+                if self.covariance_mode
+                is InstrumentChannelCalibrationPredictiveCovarianceMode
+                .FULL_COVARIANCE
+                else None
+            ),
+            "global_dense_covariance_requested": False,
+        }
+
+
+@dataclass(frozen=True)
+class InstrumentChannelCalibrationPredictiveUncertaintyChannelResult:
+    """Predictive-propagation disposition for one non-reference channel."""
+
+    physical_wavelength: float
+    reference_channel: str
+    channel: str
+    disposition: (
+        InstrumentChannelCalibrationPredictiveUncertaintyDisposition | str
+    )
+    source_row_indices: tuple[int, ...]
+    predictive_uncertainty: (
+        InstrumentChannelCalibrationPredictiveUncertainty | None
+    ) = None
+    reason: str | None = None
+
+    def __post_init__(self) -> None:
+        wavelength = float(self.physical_wavelength)
+        if not math.isfinite(wavelength):
+            raise ValueError("physical_wavelength must be finite.")
+        reference_channel = _normalize_calibration_channel(
+            self.reference_channel,
+            name="reference_channel",
+        )
+        channel = _normalize_calibration_channel(
+            self.channel,
+            name="channel",
+        )
+        if channel == reference_channel:
+            raise ValueError(
+                "channel and reference_channel must identify different "
+                "observational channels."
+            )
+        if isinstance(self.disposition, (bool, np.bool_)):
+            raise TypeError(
+                "disposition must be a predictive uncertainty disposition, "
+                "not boolean."
+            )
+        disposition = self.disposition
+        if not isinstance(
+            disposition,
+            InstrumentChannelCalibrationPredictiveUncertaintyDisposition,
+        ):
+            try:
+                disposition = (
+                    InstrumentChannelCalibrationPredictiveUncertaintyDisposition(
+                        str(disposition)
+                    )
+                )
+            except ValueError as exc:
+                raise ValueError(
+                    "Unsupported predictive uncertainty disposition: "
+                    f"{self.disposition!r}."
+                ) from exc
+        indices = InstrumentChannelPairing._normalize_indices(
+            self.source_row_indices,
+            name="source_row_indices",
+        )
+        if len(set(indices)) != len(indices):
+            raise ValueError(
+                "source_row_indices must not identify the same source row "
+                "more than once."
+            )
+        if not indices:
+            raise ValueError(
+                "A channel predictive result requires at least one source row."
+            )
+        reason = self.reason
+        if reason is not None:
+            if not isinstance(reason, str):
+                raise TypeError("reason must be a string when supplied.")
+            reason = reason.strip()
+            if not reason:
+                raise ValueError("reason must be non-empty when supplied.")
+        predictive = self.predictive_uncertainty
+
+        if disposition is (
+            InstrumentChannelCalibrationPredictiveUncertaintyDisposition.AVAILABLE
+        ):
+            if not isinstance(
+                predictive,
+                InstrumentChannelCalibrationPredictiveUncertainty,
+            ):
+                raise ValueError(
+                    "An available channel result requires predictive_uncertainty."
+                )
+            if predictive.status is not (
+                InstrumentChannelCalibrationPredictiveUncertaintyStatus.AVAILABLE
+            ):
+                raise ValueError(
+                    "An available channel result requires available predictive "
+                    "uncertainty."
+                )
+            if predictive.input_shape != (len(indices),):
+                raise ValueError(
+                    "predictive_uncertainty input_shape must match the channel "
+                    "source-row count."
+                )
+            if reason is not None:
+                raise ValueError(
+                    "An available channel result must not carry a reason."
+                )
+        elif disposition is (
+            InstrumentChannelCalibrationPredictiveUncertaintyDisposition.UNAVAILABLE
+        ):
+            if not isinstance(
+                predictive,
+                InstrumentChannelCalibrationPredictiveUncertainty,
+            ):
+                raise ValueError(
+                    "An unavailable channel result requires an explicit "
+                    "predictive_uncertainty record."
+                )
+            if predictive.status is not (
+                InstrumentChannelCalibrationPredictiveUncertaintyStatus.UNAVAILABLE
+            ):
+                raise ValueError(
+                    "An unavailable channel result requires unavailable "
+                    "predictive uncertainty."
+                )
+            if predictive.input_shape != (len(indices),):
+                raise ValueError(
+                    "predictive_uncertainty input_shape must match the channel "
+                    "source-row count."
+                )
+            if reason is None or predictive.reason != reason:
+                raise ValueError(
+                    "Unavailable channel reason must match the nested predictive "
+                    "uncertainty reason."
+                )
+        else:
+            if predictive is not None:
+                raise ValueError(
+                    "not_requested and skipped channel results must not carry "
+                    "predictive_uncertainty."
+                )
+            if disposition is (
+                InstrumentChannelCalibrationPredictiveUncertaintyDisposition.SKIPPED
+            ):
+                if reason is None:
+                    raise ValueError(
+                        "A skipped channel result requires a reason."
+                    )
+            elif reason is not None:
+                raise ValueError(
+                    "A not_requested channel result must not carry a reason."
+                )
+
+        object.__setattr__(self, "physical_wavelength", wavelength)
+        object.__setattr__(self, "reference_channel", reference_channel)
+        object.__setattr__(self, "channel", channel)
+        object.__setattr__(self, "disposition", disposition)
+        object.__setattr__(self, "source_row_indices", indices)
+        object.__setattr__(self, "reason", reason)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a strict JSON-safe per-channel representation."""
+
+        return {
+            "physical_wavelength": self.physical_wavelength,
+            "reference_channel": self.reference_channel,
+            "channel": self.channel,
+            "disposition": self.disposition.value,
+            "source_row_indices": list(self.source_row_indices),
+            "predictive_uncertainty": (
+                None
+                if self.predictive_uncertainty is None
+                else self.predictive_uncertainty.to_dict()
+            ),
+            "reason": self.reason,
+        }
+
+
+@dataclass(frozen=True)
+class InstrumentChannelCalibrationPredictiveUncertaintyGroupResult:
+    """Predictive results for distinct channels at one physical wavelength."""
+
+    physical_wavelength: float
+    reference_channel: str
+    reference_source_row_indices: tuple[int, ...]
+    channel_results: tuple[
+        InstrumentChannelCalibrationPredictiveUncertaintyChannelResult,
+        ...,
+    ]
+
+    def __post_init__(self) -> None:
+        wavelength = float(self.physical_wavelength)
+        if not math.isfinite(wavelength):
+            raise ValueError("physical_wavelength must be finite.")
+        reference_channel = _normalize_calibration_channel(
+            self.reference_channel,
+            name="reference_channel",
+        )
+        reference_indices = InstrumentChannelPairing._normalize_indices(
+            self.reference_source_row_indices,
+            name="reference_source_row_indices",
+        )
+        if not reference_indices:
+            raise ValueError(
+                "A predictive group requires at least one reference source row."
+            )
+        if len(set(reference_indices)) != len(reference_indices):
+            raise ValueError(
+                "reference_source_row_indices must not contain duplicates."
+            )
+        channel_results = tuple(self.channel_results)
+        if not channel_results:
+            raise ValueError(
+                "A predictive group requires at least one non-reference "
+                "channel result."
+            )
+        if any(
+            not isinstance(
+                result,
+                InstrumentChannelCalibrationPredictiveUncertaintyChannelResult,
+            )
+            for result in channel_results
+        ):
+            raise TypeError(
+                "channel_results must contain only predictive channel results."
+            )
+        channels = tuple(result.channel for result in channel_results)
+        if len(set(channels)) != len(channels):
+            raise ValueError(
+                "Each observational channel may appear only once in a "
+                "predictive group."
+            )
+        for result in channel_results:
+            if result.physical_wavelength != wavelength:
+                raise ValueError(
+                    "Channel-result physical wavelength must match the group."
+                )
+            if result.reference_channel != reference_channel:
+                raise ValueError(
+                    "Channel-result reference channel must match the group."
+                )
+        all_indices = [*reference_indices]
+        for result in channel_results:
+            all_indices.extend(result.source_row_indices)
+        if len(set(all_indices)) != len(all_indices):
+            raise ValueError(
+                "Reference and non-reference channel results must describe "
+                "disjoint source rows."
+            )
+
+        object.__setattr__(self, "physical_wavelength", wavelength)
+        object.__setattr__(self, "reference_channel", reference_channel)
+        object.__setattr__(
+            self,
+            "reference_source_row_indices",
+            reference_indices,
+        )
+        object.__setattr__(
+            self,
+            "channel_results",
+            tuple(sorted(channel_results, key=lambda item: item.channel)),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a strict JSON-safe group representation."""
+
+        return {
+            "physical_wavelength": self.physical_wavelength,
+            "reference_channel": self.reference_channel,
+            "reference_source_row_indices": list(
+                self.reference_source_row_indices
+            ),
+            "reference_channel_fitted_coefficient_uncertainty_disposition": (
+                "not_applicable"
+            ),
+            "channel_results": [
+                result.to_dict() for result in self.channel_results
+            ],
+            "channel_merging_performed": False,
+            "physical_wavelength_used_as_covariance_identity": False,
+        }
+
+
+@dataclass(frozen=True)
+class InstrumentChannelCalibrationPredictiveUncertaintyOrchestration:
+    """Dataset-level contract for predictive propagation results.
+
+    Dataset rows are partitioned among reference rows, non-reference channel
+    results, and unaffected rows.  Numerical predictive uncertainty remains
+    channel-local; missing values are represented structurally rather than by
+    NaN-filled dataset arrays.
+    """
+
+    schema_version: str
+    covariance_mode: (
+        InstrumentChannelCalibrationPredictiveCovarianceMode | str | None
+    )
+    source_row_indices: tuple[int, ...]
+    group_results: tuple[
+        InstrumentChannelCalibrationPredictiveUncertaintyGroupResult,
+        ...,
+    ]
+    unaffected_source_row_indices: tuple[int, ...]
+    ordinary_calibrated_flux_error_available: bool
+
+    def __post_init__(self) -> None:
+        if self.schema_version != (
+            INSTRUMENT_CHANNEL_CALIBRATION_PREDICTIVE_ORCHESTRATION_SCHEMA_VERSION
+        ):
+            raise ValueError(
+                "Unsupported instrument-channel calibration predictive "
+                f"orchestration schema version: {self.schema_version!r}."
+            )
+        mode = self.covariance_mode
+        if isinstance(mode, (bool, np.bool_)):
+            raise TypeError(
+                "covariance_mode must be a predictive covariance mode or None, "
+                "not boolean."
+            )
+        if mode is not None and not isinstance(
+            mode,
+            InstrumentChannelCalibrationPredictiveCovarianceMode,
+        ):
+            try:
+                mode = InstrumentChannelCalibrationPredictiveCovarianceMode(
+                    str(mode)
+                )
+            except ValueError as exc:
+                raise ValueError(
+                    "Unsupported predictive covariance mode: "
+                    f"{self.covariance_mode!r}."
+                ) from exc
+        raw_source_indices = tuple(self.source_row_indices)
+        source_indices = _normalize_pairing_source_indices(
+            raw_source_indices,
+            size=len(raw_source_indices),
+            name="source_row_indices",
+        )
+        unaffected_indices = InstrumentChannelPairing._normalize_indices(
+            self.unaffected_source_row_indices,
+            name="unaffected_source_row_indices",
+        )
+        if len(set(unaffected_indices)) != len(unaffected_indices):
+            raise ValueError(
+                "unaffected_source_row_indices must not contain duplicates."
+            )
+        if not isinstance(
+            self.ordinary_calibrated_flux_error_available,
+            (bool, np.bool_),
+        ):
+            raise TypeError(
+                "ordinary_calibrated_flux_error_available must be boolean."
+            )
+        group_results = tuple(self.group_results)
+        if any(
+            not isinstance(
+                group,
+                InstrumentChannelCalibrationPredictiveUncertaintyGroupResult,
+            )
+            for group in group_results
+        ):
+            raise TypeError(
+                "group_results must contain only predictive group results."
+            )
+        wavelengths = tuple(
+            group.physical_wavelength for group in group_results
+        )
+        if len(set(wavelengths)) != len(wavelengths):
+            raise ValueError(
+                "Each physical wavelength may appear only once in group_results."
+            )
+        all_group_channels = tuple(
+            channel
+            for group in group_results
+            for channel in (
+                group.reference_channel,
+                *(result.channel for result in group.channel_results),
+            )
+        )
+        if len(set(all_group_channels)) != len(all_group_channels):
+            raise ValueError(
+                "Each observational channel may appear in only one predictive "
+                "orchestration group."
+            )
+        channel_results = tuple(
+            result
+            for group in group_results
+            for result in group.channel_results
+        )
+        if mode is None:
+            invalid = tuple(
+                result.disposition
+                for result in channel_results
+                if result.disposition
+                not in (
+                    InstrumentChannelCalibrationPredictiveUncertaintyDisposition
+                    .NOT_REQUESTED,
+                    InstrumentChannelCalibrationPredictiveUncertaintyDisposition
+                    .SKIPPED,
+                )
+            )
+            if invalid:
+                raise ValueError(
+                    "A not-requested orchestration result may contain only "
+                    "not_requested or skipped channel dispositions."
+                )
+        else:
+            if any(
+                result.disposition is (
+                    InstrumentChannelCalibrationPredictiveUncertaintyDisposition
+                    .NOT_REQUESTED
+                )
+                for result in channel_results
+            ):
+                raise ValueError(
+                    "A requested orchestration result cannot contain a "
+                    "not_requested channel disposition."
+                )
+            for result in channel_results:
+                predictive = result.predictive_uncertainty
+                if predictive is not None and predictive.covariance_mode is not mode:
+                    raise ValueError(
+                        "Per-channel predictive covariance mode must match the "
+                        "dataset request."
+                    )
+        represented_indices = [*unaffected_indices]
+        for group in group_results:
+            represented_indices.extend(group.reference_source_row_indices)
+            for result in group.channel_results:
+                represented_indices.extend(result.source_row_indices)
+        if len(set(represented_indices)) != len(represented_indices):
+            raise ValueError(
+                "Predictive orchestration row partitions must be disjoint."
+            )
+        if set(represented_indices) != set(source_indices):
+            raise ValueError(
+                "Reference, channel, and unaffected source rows must partition "
+                "source_row_indices exactly."
+            )
+        source_position = {
+            source_index: position
+            for position, source_index in enumerate(source_indices)
+        }
+        ordered_partitions = [
+            ("unaffected_source_row_indices", unaffected_indices),
+        ]
+        for group in group_results:
+            ordered_partitions.append(
+                (
+                    "reference_source_row_indices",
+                    group.reference_source_row_indices,
+                )
+            )
+            ordered_partitions.extend(
+                ("channel source_row_indices", result.source_row_indices)
+                for result in group.channel_results
+            )
+        for name, partition in ordered_partitions:
+            positions = tuple(source_position[index] for index in partition)
+            if positions != tuple(sorted(positions)):
+                raise ValueError(
+                    f"{name} must preserve original dataset row order."
+                )
+
+        object.__setattr__(self, "covariance_mode", mode)
+        object.__setattr__(self, "source_row_indices", source_indices)
+        object.__setattr__(
+            self,
+            "group_results",
+            tuple(
+                sorted(
+                    group_results,
+                    key=lambda item: item.physical_wavelength,
+                )
+            ),
+        )
+        object.__setattr__(
+            self,
+            "unaffected_source_row_indices",
+            unaffected_indices,
+        )
+        object.__setattr__(
+            self,
+            "ordinary_calibrated_flux_error_available",
+            bool(self.ordinary_calibrated_flux_error_available),
+        )
+
+    @property
+    def requested(self) -> bool:
+        """Return whether fitted-coefficient propagation was requested."""
+
+        return self.covariance_mode is not None
+
+    @property
+    def channel_results(
+        self,
+    ) -> tuple[
+        InstrumentChannelCalibrationPredictiveUncertaintyChannelResult,
+        ...,
+    ]:
+        """Return all non-reference channel results."""
+
+        return tuple(
+            result
+            for group in self.group_results
+            for result in group.channel_results
+        )
+
+    def _count(
+        self,
+        disposition: InstrumentChannelCalibrationPredictiveUncertaintyDisposition,
+    ) -> int:
+        return sum(
+            result.disposition is disposition
+            for result in self.channel_results
+        )
+
+    @property
+    def n_available_channels(self) -> int:
+        return self._count(
+            InstrumentChannelCalibrationPredictiveUncertaintyDisposition.AVAILABLE
+        )
+
+    @property
+    def n_unavailable_channels(self) -> int:
+        return self._count(
+            InstrumentChannelCalibrationPredictiveUncertaintyDisposition.UNAVAILABLE
+        )
+
+    @property
+    def n_skipped_channels(self) -> int:
+        return self._count(
+            InstrumentChannelCalibrationPredictiveUncertaintyDisposition.SKIPPED
+        )
+
+    @property
+    def n_not_requested_channels(self) -> int:
+        return self._count(
+            InstrumentChannelCalibrationPredictiveUncertaintyDisposition
+            .NOT_REQUESTED
+        )
+
+    @property
+    def all_eligible_channels_available(self) -> bool:
+        eligible = self.n_available_channels + self.n_unavailable_channels
+        return self.requested and eligible > 0 and self.n_unavailable_channels == 0
+
+    @property
+    def fitted_coefficient_uncertainty_propagated(self) -> bool:
+        """Return true when at least one channel has an available result."""
+
+        return self.n_available_channels > 0
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a strict JSON-safe dataset-level representation."""
+
+        return {
+            "schema_version": self.schema_version,
+            "requested": self.requested,
+            "covariance_mode": (
+                None
+                if self.covariance_mode is None
+                else self.covariance_mode.value
+            ),
+            "source_row_indices": list(self.source_row_indices),
+            "group_results": [
+                group.to_dict() for group in self.group_results
+            ],
+            "unaffected_source_row_indices": list(
+                self.unaffected_source_row_indices
+            ),
+            "n_available_channels": self.n_available_channels,
+            "n_unavailable_channels": self.n_unavailable_channels,
+            "n_skipped_channels": self.n_skipped_channels,
+            "n_not_requested_channels": self.n_not_requested_channels,
+            "any_predictive_uncertainty_available": (
+                self.n_available_channels > 0
+            ),
+            "all_eligible_channels_available": (
+                self.all_eligible_channels_available
+            ),
+            "ordinary_calibrated_flux_error_available": (
+                self.ordinary_calibrated_flux_error_available
+            ),
+            "predictive_standard_deviation_blocks_available": (
+                self.n_available_channels > 0
+            ),
+            "predictive_covariance_blocks_available": (
+                self.covariance_mode
+                is InstrumentChannelCalibrationPredictiveCovarianceMode
+                .FULL_COVARIANCE
+                and self.n_available_channels > 0
+            ),
+            "global_predictive_standard_deviation_emitted": False,
+            "global_dense_predictive_covariance_emitted": False,
+            "cross_observational_channel_covariance_emitted": False,
+            "cross_observational_channel_covariance_assumed_zero": False,
+            "fitted_coefficient_uncertainty_propagated": (
+                self.fitted_coefficient_uncertainty_propagated
+            ),
+            "measurement_coefficient_independence_assumed": True,
+            "coefficient_order": ["offset", "scale"],
+            "row_alignment": "original_dataset_source_row_indices",
+            "missing_values_represented_by_nan": False,
+        }
+
+
 INSTRUMENT_CHANNEL_CALIBRATION_MODEL_SCHEMA_VERSION = "2.0"
 
 
@@ -3814,6 +4486,9 @@ def execute_instrument_channel_calibration_plan(
     *,
     flux_error: Any | None = None,
     source_row_indices: Any | None = None,
+    predictive_uncertainty_request: (
+        InstrumentChannelCalibrationPredictiveUncertaintyRequest | None
+    ) = None,
 ) -> InstrumentChannelCalibrationExecution:
     """Execute a caller-authored dataset-level calibration plan.
 
@@ -3829,10 +4504,32 @@ def execute_instrument_channel_calibration_plan(
     reassigned.
 
     The callable performs no automatic reference-channel, pairing-method,
-    tolerance, or calibration-family selection. It does not propagate
-    uncertainty in fitted affine coefficients or integrate the result into
-    :class:`pgmuvi.lightcurve.Lightcurve`.
+    tolerance, or calibration-family selection. Dataset predictive propagation
+    is an explicit opt-in request. Its contract is defined, but execution is not
+    activated here; a supplied request raises :class:`NotImplementedError`.
+    Calibration is not integrated into :class:`pgmuvi.lightcurve.Lightcurve`.
     """
+
+    if predictive_uncertainty_request is not None:
+        if isinstance(predictive_uncertainty_request, (bool, np.bool_)):
+            raise TypeError(
+                "predictive_uncertainty_request must be an "
+                "InstrumentChannelCalibrationPredictiveUncertaintyRequest, "
+                "not boolean."
+            )
+        if not isinstance(
+            predictive_uncertainty_request,
+            InstrumentChannelCalibrationPredictiveUncertaintyRequest,
+        ):
+            raise TypeError(
+                "predictive_uncertainty_request must be an "
+                "InstrumentChannelCalibrationPredictiveUncertaintyRequest "
+                "when supplied."
+            )
+        raise NotImplementedError(
+            "Dataset calibration predictive-uncertainty propagation is "
+            "defined but not yet activated."
+        )
 
     if not isinstance(
         plan,

--- a/tests/test_docs_instrument_channel_calibration.py
+++ b/tests/test_docs_instrument_channel_calibration.py
@@ -82,6 +82,18 @@ class TestInstrumentChannelCalibrationDocumentation(unittest.TestCase):
             "apply_instrument_channel_calibration_with_predictive_uncertainty",
             instrument_channel_calibration.__all__,
         )
+        self.assertIn(
+            "InstrumentChannelCalibrationPredictiveUncertaintyRequest",
+            instrument_channel_calibration.__all__,
+        )
+        self.assertIn(
+            "InstrumentChannelCalibrationPredictiveUncertaintyOrchestration",
+            instrument_channel_calibration.__all__,
+        )
+        self.assertIn(
+            "INSTRUMENT_CHANNEL_CALIBRATION_PREDICTIVE_ORCHESTRATION_SCHEMA_VERSION",
+            instrument_channel_calibration.__all__,
+        )
 
         api_text = API.read_text(encoding="utf-8")
         page_text = PAGE.read_text(encoding="utf-8")
@@ -235,7 +247,7 @@ class TestInstrumentChannelCalibrationDocumentation(unittest.TestCase):
             "Predictive-uncertainty propagation",
             maxsplit=1,
         )[1].split(
-            "``TBD[instrument-channel-calibration]`` remains open",
+            "Dataset predictive-orchestration contract",
             maxsplit=1,
         )[0]
         self.assertNotIn("NotImplementedError", predictive_section)
@@ -252,6 +264,29 @@ class TestInstrumentChannelCalibrationDocumentation(unittest.TestCase):
             "no silent fallback to measurement-only uncertainty",
             normalized.lower(),
         )
+        self.assertIn("Dataset predictive-orchestration contract", text)
+        self.assertIn(
+            "coefficient covariance availability alone never activates it",
+            normalized,
+        )
+        self.assertIn("defined but not activated", normalized)
+        self.assertIn("raises ``NotImplementedError``", normalized)
+        self.assertIn("no global dense dataset covariance", normalized)
+        self.assertIn(
+            "physical wavelength is never a covariance identity",
+            normalized,
+        )
+        self.assertIn(
+            "Cross-channel covariance is not emitted and is not silently "
+            "asserted to be zero",
+            normalized,
+        )
+        self.assertIn(
+            "calibrated_flux_error`` array remains the ordinary transformed "
+            "measurement-error array",
+            normalized,
+        )
+        self.assertIn("fit provenance is not required", normalized)
 
     def test_future_work_marker_remains_open(self):
         text = " ".join(FUTURE.read_text(encoding="utf-8").split())
@@ -285,6 +320,12 @@ class TestInstrumentChannelCalibrationDocumentation(unittest.TestCase):
             "propagation without orchestration activation",
             text,
         )
+        self.assertIn(
+            "defines the explicit request, per-observational-channel block, "
+            "row-identity, disposition, and dataset-summary contract",
+            text,
+        )
+        self.assertIn("without activating that execution path", text)
         self.assertNotIn(
             "uncertainty estimation and propagation",
             text,

--- a/tests/test_instrument_channel_calibration_predictive_orchestration_contract.py
+++ b/tests/test_instrument_channel_calibration_predictive_orchestration_contract.py
@@ -1,0 +1,526 @@
+"""Dataset predictive-uncertainty orchestration contract tests."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+import json
+import unittest
+
+import numpy as np
+
+from pgmuvi.instrument_channel_calibration import (
+    INSTRUMENT_CHANNEL_CALIBRATION_MODEL_SCHEMA_VERSION,
+    INSTRUMENT_CHANNEL_CALIBRATION_PREDICTIVE_ORCHESTRATION_SCHEMA_VERSION,
+    INSTRUMENT_CHANNEL_CALIBRATION_UNCERTAINTY_SCHEMA_VERSION,
+    InstrumentChannelCalibration,
+    InstrumentChannelCalibrationChannelPlan,
+    InstrumentChannelCalibrationCoefficientUncertainty,
+    InstrumentChannelCalibrationDisposition,
+    InstrumentChannelCalibrationGroupPlan,
+    InstrumentChannelCalibrationPredictiveCovarianceMode,
+    InstrumentChannelCalibrationPredictiveUncertaintyChannelResult,
+    InstrumentChannelCalibrationPredictiveUncertaintyDisposition,
+    InstrumentChannelCalibrationPredictiveUncertaintyGroupResult,
+    InstrumentChannelCalibrationPredictiveUncertaintyOrchestration,
+    InstrumentChannelCalibrationPredictiveUncertaintyRequest,
+    InstrumentChannelCalibrationUncertaintyStatus,
+    InstrumentChannelPairingMethod,
+    apply_instrument_channel_calibration_with_predictive_uncertainty,
+    assess_instrument_channel_calibration_requirement,
+    define_instrument_channel_calibration_plan,
+    execute_instrument_channel_calibration_plan,
+)
+
+
+class TestPredictiveOrchestrationContract(unittest.TestCase):
+    @staticmethod
+    def _calibration(
+        *,
+        channel="B",
+        covariance=((0.04, -0.006), (-0.006, 0.01)),
+    ):
+        uncertainty = InstrumentChannelCalibrationCoefficientUncertainty(
+            schema_version=(
+                INSTRUMENT_CHANNEL_CALIBRATION_UNCERTAINTY_SCHEMA_VERSION
+            ),
+            status=InstrumentChannelCalibrationUncertaintyStatus.AVAILABLE,
+            uncertainty_source="caller_supplied_bootstrap",
+            coefficient_covariance=covariance,
+            estimation_method="paired_bootstrap",
+        )
+        return InstrumentChannelCalibration(
+            schema_version=INSTRUMENT_CHANNEL_CALIBRATION_MODEL_SCHEMA_VERSION,
+            reference_channel="A",
+            channel=channel,
+            wavelength=1.0,
+            offset=0.25,
+            scale=1.5,
+            n_pairs=4,
+            n_inliers=4,
+            residual_mad_sigma=0.01,
+            coefficient_uncertainty=uncertainty,
+        )
+
+    @classmethod
+    def _available_result(
+        cls,
+        *,
+        channel="B",
+        source_row_indices=(3, 4),
+        covariance_mode="marginal_variance",
+        covariance=((0.04, -0.006), (-0.006, 0.01)),
+    ):
+        _, predictive = (
+            apply_instrument_channel_calibration_with_predictive_uncertainty(
+                np.asarray([1.0, 2.0]),
+                cls._calibration(channel=channel, covariance=covariance),
+                flux_error=np.asarray([0.1, 0.2]),
+                covariance_mode=covariance_mode,
+            )
+        )
+        return InstrumentChannelCalibrationPredictiveUncertaintyChannelResult(
+            physical_wavelength=1.0,
+            reference_channel="A",
+            channel=channel,
+            disposition=(
+                InstrumentChannelCalibrationPredictiveUncertaintyDisposition
+                .AVAILABLE
+            ),
+            source_row_indices=source_row_indices,
+            predictive_uncertainty=predictive,
+        )
+
+    @staticmethod
+    def _unavailable_result():
+        uncertainty = InstrumentChannelCalibrationCoefficientUncertainty(
+            schema_version=(
+                INSTRUMENT_CHANNEL_CALIBRATION_UNCERTAINTY_SCHEMA_VERSION
+            ),
+            status=InstrumentChannelCalibrationUncertaintyStatus.UNAVAILABLE,
+            uncertainty_source="pgmuvi_affine_fit",
+            coefficient_covariance=None,
+            reason="Coefficient covariance is unavailable.",
+        )
+        calibration = InstrumentChannelCalibration(
+            schema_version=INSTRUMENT_CHANNEL_CALIBRATION_MODEL_SCHEMA_VERSION,
+            reference_channel="A",
+            channel="B",
+            wavelength=1.0,
+            offset=0.25,
+            scale=1.5,
+            n_pairs=4,
+            n_inliers=4,
+            residual_mad_sigma=0.01,
+            coefficient_uncertainty=uncertainty,
+        )
+        _, predictive = (
+            apply_instrument_channel_calibration_with_predictive_uncertainty(
+                np.asarray([1.0, 2.0]),
+                calibration,
+                flux_error=np.asarray([0.1, 0.2]),
+                covariance_mode="marginal_variance",
+            )
+        )
+        return InstrumentChannelCalibrationPredictiveUncertaintyChannelResult(
+            physical_wavelength=1.0,
+            reference_channel="A",
+            channel="B",
+            disposition=(
+                InstrumentChannelCalibrationPredictiveUncertaintyDisposition
+                .UNAVAILABLE
+            ),
+            source_row_indices=(3, 4),
+            predictive_uncertainty=predictive,
+            reason=predictive.reason,
+        )
+
+    def test_request_is_explicit_immutable_and_json_safe(self):
+        request = InstrumentChannelCalibrationPredictiveUncertaintyRequest(
+            covariance_mode="marginal_variance"
+        )
+        payload = request.to_dict()
+        json.dumps(payload, allow_nan=False)
+
+        self.assertEqual(
+            request.covariance_mode,
+            InstrumentChannelCalibrationPredictiveCovarianceMode
+            .MARGINAL_VARIANCE,
+        )
+        self.assertTrue(payload["requested"])
+        self.assertFalse(payload["global_dense_covariance_requested"])
+        with self.assertRaises(FrozenInstanceError):
+            request.covariance_mode = "full_covariance"
+
+    def test_request_rejects_boolean_and_unknown_modes(self):
+        with self.assertRaisesRegex(TypeError, "not boolean"):
+            InstrumentChannelCalibrationPredictiveUncertaintyRequest(
+                covariance_mode=True
+            )
+        with self.assertRaisesRegex(ValueError, "Unsupported"):
+            InstrumentChannelCalibrationPredictiveUncertaintyRequest(
+                covariance_mode="global_dense"
+            )
+
+    def test_available_channel_result_preserves_row_identity(self):
+        result = self._available_result(source_row_indices=(40, 20))
+        payload = result.to_dict()
+        json.dumps(payload, allow_nan=False)
+
+        self.assertEqual(result.source_row_indices, (40, 20))
+        self.assertEqual(payload["source_row_indices"], [40, 20])
+        self.assertEqual(
+            payload["predictive_uncertainty"]["coefficient_order"],
+            ["offset", "scale"],
+        )
+        self.assertIsNotNone(
+            payload["predictive_uncertainty"]["predictive_standard_deviation"]
+        )
+
+    def test_unavailable_channel_has_no_measurement_only_fallback(self):
+        result = self._unavailable_result()
+        payload = result.to_dict()
+        json.dumps(payload, allow_nan=False)
+
+        predictive = payload["predictive_uncertainty"]
+        self.assertEqual(result.disposition.value, "unavailable")
+        self.assertIsNone(predictive["measurement_variance"])
+        self.assertIsNone(predictive["predictive_variance"])
+        self.assertIsNone(predictive["predictive_covariance"])
+
+    def test_not_requested_and_skipped_states_are_non_numeric(self):
+        not_requested = (
+            InstrumentChannelCalibrationPredictiveUncertaintyChannelResult(
+                physical_wavelength=1.0,
+                reference_channel="A",
+                channel="B",
+                disposition="not_requested",
+                source_row_indices=(3, 4),
+            )
+        )
+        skipped = InstrumentChannelCalibrationPredictiveUncertaintyChannelResult(
+            physical_wavelength=1.0,
+            reference_channel="A",
+            channel="C",
+            disposition="skipped",
+            source_row_indices=(5, 6),
+            reason="Caller excluded channel C.",
+        )
+
+        self.assertIsNone(not_requested.predictive_uncertainty)
+        self.assertIsNone(skipped.predictive_uncertainty)
+        with self.assertRaisesRegex(ValueError, "requires a reason"):
+            InstrumentChannelCalibrationPredictiveUncertaintyChannelResult(
+                physical_wavelength=1.0,
+                reference_channel="A",
+                channel="C",
+                disposition="skipped",
+                source_row_indices=(5,),
+            )
+
+    def test_reference_rows_are_explicitly_not_applicable(self):
+        group = InstrumentChannelCalibrationPredictiveUncertaintyGroupResult(
+            physical_wavelength=1.0,
+            reference_channel="A",
+            reference_source_row_indices=(0, 1, 2),
+            channel_results=(
+                InstrumentChannelCalibrationPredictiveUncertaintyChannelResult(
+                    physical_wavelength=1.0,
+                    reference_channel="A",
+                    channel="B",
+                    disposition="not_requested",
+                    source_row_indices=(3, 4),
+                ),
+            ),
+        )
+        payload = group.to_dict()
+
+        self.assertEqual(payload["reference_source_row_indices"], [0, 1, 2])
+        self.assertEqual(
+            payload[
+                "reference_channel_fitted_coefficient_uncertainty_disposition"
+            ],
+            "not_applicable",
+        )
+
+    def test_not_requested_dataset_summary_is_explicit(self):
+        group = InstrumentChannelCalibrationPredictiveUncertaintyGroupResult(
+            physical_wavelength=1.0,
+            reference_channel="A",
+            reference_source_row_indices=(0, 1),
+            channel_results=(
+                InstrumentChannelCalibrationPredictiveUncertaintyChannelResult(
+                    physical_wavelength=1.0,
+                    reference_channel="A",
+                    channel="B",
+                    disposition="not_requested",
+                    source_row_indices=(2, 3),
+                ),
+                InstrumentChannelCalibrationPredictiveUncertaintyChannelResult(
+                    physical_wavelength=1.0,
+                    reference_channel="A",
+                    channel="C",
+                    disposition="skipped",
+                    source_row_indices=(4,),
+                    reason="Caller excluded channel C.",
+                ),
+            ),
+        )
+        result = InstrumentChannelCalibrationPredictiveUncertaintyOrchestration(
+            schema_version=(
+                INSTRUMENT_CHANNEL_CALIBRATION_PREDICTIVE_ORCHESTRATION_SCHEMA_VERSION
+            ),
+            covariance_mode=None,
+            source_row_indices=(0, 1, 2, 3, 4, 9),
+            group_results=(group,),
+            unaffected_source_row_indices=(9,),
+            ordinary_calibrated_flux_error_available=True,
+        )
+        payload = result.to_dict()
+        json.dumps(payload, allow_nan=False)
+
+        self.assertFalse(payload["requested"])
+        self.assertEqual(payload["n_not_requested_channels"], 1)
+        self.assertEqual(payload["n_skipped_channels"], 1)
+        self.assertFalse(payload["fitted_coefficient_uncertainty_propagated"])
+        self.assertFalse(payload["global_dense_predictive_covariance_emitted"])
+        self.assertFalse(payload["missing_values_represented_by_nan"])
+
+    def test_requested_summary_reports_partial_success(self):
+        group = InstrumentChannelCalibrationPredictiveUncertaintyGroupResult(
+            physical_wavelength=1.0,
+            reference_channel="A",
+            reference_source_row_indices=(0, 1, 2),
+            channel_results=(
+                self._available_result(),
+                InstrumentChannelCalibrationPredictiveUncertaintyChannelResult(
+                    physical_wavelength=1.0,
+                    reference_channel="A",
+                    channel="C",
+                    disposition="skipped",
+                    source_row_indices=(5, 6),
+                    reason="Caller excluded channel C.",
+                ),
+            ),
+        )
+        result = InstrumentChannelCalibrationPredictiveUncertaintyOrchestration(
+            schema_version=(
+                INSTRUMENT_CHANNEL_CALIBRATION_PREDICTIVE_ORCHESTRATION_SCHEMA_VERSION
+            ),
+            covariance_mode="marginal_variance",
+            source_row_indices=(0, 1, 2, 3, 4, 5, 6, 9),
+            group_results=(group,),
+            unaffected_source_row_indices=(9,),
+            ordinary_calibrated_flux_error_available=True,
+        )
+        payload = result.to_dict()
+
+        self.assertTrue(payload["requested"])
+        self.assertTrue(payload["any_predictive_uncertainty_available"])
+        self.assertTrue(payload["all_eligible_channels_available"])
+        self.assertTrue(payload["fitted_coefficient_uncertainty_propagated"])
+        self.assertTrue(
+            payload["predictive_standard_deviation_blocks_available"]
+        )
+        self.assertFalse(payload["predictive_covariance_blocks_available"])
+
+    def test_full_covariance_is_channel_local_at_shared_wavelength(self):
+        first = self._available_result(
+            channel="B",
+            source_row_indices=(3, 4),
+            covariance_mode="full_covariance",
+            covariance=((0.04, -0.006), (-0.006, 0.01)),
+        )
+        second = self._available_result(
+            channel="C",
+            source_row_indices=(5, 6),
+            covariance_mode="full_covariance",
+            covariance=((0.09, 0.002), (0.002, 0.02)),
+        )
+        group = InstrumentChannelCalibrationPredictiveUncertaintyGroupResult(
+            physical_wavelength=1.0,
+            reference_channel="A",
+            reference_source_row_indices=(0, 1, 2),
+            channel_results=(first, second),
+        )
+        result = InstrumentChannelCalibrationPredictiveUncertaintyOrchestration(
+            schema_version=(
+                INSTRUMENT_CHANNEL_CALIBRATION_PREDICTIVE_ORCHESTRATION_SCHEMA_VERSION
+            ),
+            covariance_mode="full_covariance",
+            source_row_indices=(0, 1, 2, 3, 4, 5, 6),
+            group_results=(group,),
+            unaffected_source_row_indices=(),
+            ordinary_calibrated_flux_error_available=True,
+        )
+        payload = result.to_dict()
+        serialized = payload["group_results"][0]["channel_results"]
+
+        self.assertEqual([item["channel"] for item in serialized], ["B", "C"])
+        self.assertNotEqual(
+            serialized[0]["predictive_uncertainty"]["predictive_covariance"],
+            serialized[1]["predictive_uncertainty"]["predictive_covariance"],
+        )
+        self.assertTrue(payload["predictive_covariance_blocks_available"])
+        self.assertFalse(payload["global_dense_predictive_covariance_emitted"])
+        self.assertFalse(
+            payload["cross_observational_channel_covariance_emitted"]
+        )
+        self.assertFalse(
+            payload["cross_observational_channel_covariance_assumed_zero"]
+        )
+        self.assertFalse(
+            payload["group_results"][0][
+                "physical_wavelength_used_as_covariance_identity"
+            ]
+        )
+
+    def test_dataset_rows_must_form_exact_disjoint_partition(self):
+        group = InstrumentChannelCalibrationPredictiveUncertaintyGroupResult(
+            physical_wavelength=1.0,
+            reference_channel="A",
+            reference_source_row_indices=(0, 1),
+            channel_results=(
+                InstrumentChannelCalibrationPredictiveUncertaintyChannelResult(
+                    physical_wavelength=1.0,
+                    reference_channel="A",
+                    channel="B",
+                    disposition="not_requested",
+                    source_row_indices=(2, 3),
+                ),
+            ),
+        )
+        common = {
+            "schema_version": (
+                INSTRUMENT_CHANNEL_CALIBRATION_PREDICTIVE_ORCHESTRATION_SCHEMA_VERSION
+            ),
+            "covariance_mode": None,
+            "source_row_indices": (0, 1, 2, 3, 9),
+            "group_results": (group,),
+            "ordinary_calibrated_flux_error_available": True,
+        }
+        with self.assertRaisesRegex(ValueError, "partition"):
+            InstrumentChannelCalibrationPredictiveUncertaintyOrchestration(
+                **common,
+                unaffected_source_row_indices=(),
+            )
+        with self.assertRaisesRegex(ValueError, "disjoint"):
+            InstrumentChannelCalibrationPredictiveUncertaintyOrchestration(
+                **common,
+                unaffected_source_row_indices=(3, 9),
+            )
+        reordered = dict(common)
+        reordered["source_row_indices"] = (0, 1, 3, 2, 9)
+        with self.assertRaisesRegex(ValueError, "preserve original"):
+            InstrumentChannelCalibrationPredictiveUncertaintyOrchestration(
+                **reordered,
+                unaffected_source_row_indices=(9,),
+            )
+
+    def test_manual_calibration_with_covariance_needs_no_fit_provenance(self):
+        calibration = self._calibration()
+        self.assertIsNone(calibration.fit_provenance)
+        _, predictive = (
+            apply_instrument_channel_calibration_with_predictive_uncertainty(
+                np.asarray([1.0, 2.0]),
+                calibration,
+                covariance_mode="marginal_variance",
+            )
+        )
+        channel_result = (
+            InstrumentChannelCalibrationPredictiveUncertaintyChannelResult(
+                physical_wavelength=1.0,
+                reference_channel="A",
+                channel="B",
+                disposition="available",
+                source_row_indices=(3, 4),
+                predictive_uncertainty=predictive,
+            )
+        )
+        self.assertEqual(channel_result.disposition.value, "available")
+
+
+class TestPredictiveOrchestrationExecutionBoundary(unittest.TestCase):
+    @staticmethod
+    def _data_and_plan():
+        times = np.asarray([0.0, 1.0, 2.0, 0.0, 1.0, 2.0])
+        wavelengths = np.ones(6)
+        channels = np.asarray(["A", "A", "A", "B", "B", "B"])
+        flux = np.asarray([3.0, 5.0, 7.0, 1.0, 2.0, 3.0])
+        error = np.asarray([0.3, 0.3, 0.3, 0.1, 0.1, 0.1])
+        assessment = assess_instrument_channel_calibration_requirement(
+            wavelengths,
+            channels,
+        )
+        plan = define_instrument_channel_calibration_plan(
+            assessment,
+            (
+                InstrumentChannelCalibrationGroupPlan(
+                    physical_wavelength=1.0,
+                    reference_channel="A",
+                    channel_plans=(
+                        InstrumentChannelCalibrationChannelPlan(
+                            channel="B",
+                            disposition=(
+                                InstrumentChannelCalibrationDisposition.PLANNED
+                            ),
+                            pairing_method=(
+                                InstrumentChannelPairingMethod.EXACT_TIMESTAMP
+                            ),
+                            time_unit="day",
+                            calibration_family="affine",
+                        ),
+                    ),
+                ),
+            ),
+        )
+        return plan, times, flux, wavelengths, channels, error
+
+    def test_default_execution_remains_backward_compatible(self):
+        plan, times, flux, wavelengths, channels, error = self._data_and_plan()
+        result = execute_instrument_channel_calibration_plan(
+            plan,
+            times,
+            flux,
+            wavelengths,
+            channels,
+            flux_error=error,
+        )
+        payload = result.to_dict()
+
+        self.assertFalse(payload["fitted_coefficient_uncertainty_propagated"])
+        self.assertNotIn("predictive_uncertainty", payload)
+
+    def test_opt_in_request_is_defined_but_not_activated(self):
+        plan, times, flux, wavelengths, channels, error = self._data_and_plan()
+        request = InstrumentChannelCalibrationPredictiveUncertaintyRequest(
+            covariance_mode="marginal_variance"
+        )
+        with self.assertRaisesRegex(NotImplementedError, "not yet activated"):
+            execute_instrument_channel_calibration_plan(
+                plan,
+                times,
+                flux,
+                wavelengths,
+                channels,
+                flux_error=error,
+                predictive_uncertainty_request=request,
+            )
+
+    def test_execution_request_input_is_strict(self):
+        plan, times, flux, wavelengths, channels, error = self._data_and_plan()
+        for value in (True, "marginal_variance"):
+            with self.subTest(value=value):
+                with self.assertRaisesRegex(TypeError, "request"):
+                    execute_instrument_channel_calibration_plan(
+                        plan,
+                        times,
+                        flux,
+                        wavelengths,
+                        channels,
+                        flux_error=error,
+                        predictive_uncertainty_request=value,
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- define an explicit, immutable, JSON-safe request contract for dataset-level calibration predictive-uncertainty propagation
- define per-observational-channel, per-shared-wavelength-group, and dataset-summary result contracts
- add the optional predictive-uncertainty request boundary to calibration-plan execution without activating propagation
- document the orchestration semantics and retain the open instrument-channel calibration future-work marker

## Contract

Dataset propagation remains explicitly opt-in. Coefficient-covariance availability alone never activates it. Supplying a valid request currently raises `NotImplementedError`; omitting the request preserves the existing execution-v1 return type and continues to report `fitted_coefficient_uncertainty_propagated` as false.

The result contract:

- preserves original dataset source-row identity and ordering
- partitions rows exactly among reference rows, non-reference channel results, and unaffected rows
- represents reference rows as `not_applicable`
- uses stable `not_requested`, `available`, `skipped`, and `unavailable` dispositions
- retains unavailable results structurally without measurement-only fallback
- keeps marginal variance, predictive standard deviation, and full covariance in per-observational-channel blocks
- never emits a global dense dataset covariance
- neither emits cross-observational-channel covariance nor silently assumes it is zero
- keeps observational channels distinct when they share one physical wavelength
- preserves `calibrated_flux_error` as the ordinary transformed measurement-error compatibility array
- permits manually supplied calibrations with valid coefficient covariance without requiring fit provenance

## Scope boundary

This pull request defines the dataset orchestration contract only. It does not activate predictive propagation in `execute_instrument_channel_calibration_plan`, select scientific pairing rules, integrate calibration into `Lightcurve`, or close `TBD[instrument-channel-calibration]`.

## Validation

- `python3 -m unittest discover -s tests -p 'test_*.py' -v`
  - 2,499 tests passed
- focused predictive-orchestration contract tests
  - 14 tests passed
- calibration regression suite
  - 114 tests passed
- `ruff check -v --output-format=full --show-fixes ./pgmuvi`
  - passed
- `make -C docs clean`
- `make -C docs html-strict`
  - strict documentation build passed
