### PR TITLE
Implement calibration predictive uncertainty orchestration

### DIFF
--- a/docs/source/future_work.rst
+++ b/docs/source/future_work.rst
@@ -130,8 +130,9 @@ Wavelength-model extensions
     affine fitter and dataset orchestration while preserving separate
     observational-channel records, and defines the explicit request,
     per-observational-channel block, row-identity, disposition, and
-    dataset-summary contract for ordinary predictive propagation without
-    activating that execution path.  This does not close the marker:
+    dataset-summary contract for ordinary predictive propagation, and
+    activates dataset-level predictive propagation through explicit requests.
+    This does not close the marker:
     scientifically validated instrument-specific tolerance guidance, workflow
     integration, and representative calibration validation remain future work.
 

--- a/docs/source/pgmuvi.instrument_channel_calibration.rst
+++ b/docs/source/pgmuvi.instrument_channel_calibration.rst
@@ -250,12 +250,11 @@ uses ``input_shape=()``; array results preserve their original shape.
 Unavailable coefficient covariance, including an attempted scale-dependent
 optimization that falls back to the iterative affine estimate, produces an
 explicit ``unavailable`` result with no numerical predictive uncertainty.
-There is no silent fallback
-to measurement-only uncertainty.  Predictive propagation is implemented only
-in the dedicated application callable; current dataset orchestration continues
-to record that propagation was not requested or performed.  The stable future
-orchestration dispositions remain ``not_requested``, ``available``,
-``skipped``, and ``unavailable``.
+There is no silent fallback to measurement-only uncertainty.  Dataset
+orchestration performs propagation only for an explicit request and otherwise
+retains the ordinary execution-v1 behavior.  The stable orchestration
+dispositions remain ``not_requested``, ``available``, ``skipped``, and
+``unavailable``.
 
 Dataset predictive-orchestration contract
 -----------------------------------------
@@ -264,10 +263,10 @@ Dataset propagation is an explicit opt-in represented by
 ``InstrumentChannelCalibrationPredictiveUncertaintyRequest``.  Absence of a
 request means fitted-coefficient propagation was not requested; coefficient
 covariance availability alone never activates it.  A request selects
-``marginal_variance`` or ``full_covariance``.  The execution callable accepts
-the request boundary, but PR152 deliberately leaves it defined but not
-activated and raises ``NotImplementedError`` when a request is supplied.
-Ordinary execution without a request keeps its existing return type and
+``marginal_variance`` or ``full_covariance`` and the execution callable
+executes predictive propagation after completing the caller-authored
+calibration plan.  Ordinary execution without a request keeps its existing
+return type and serialization, omits the ``predictive_uncertainty`` key, and
 continues to serialize ``fitted_coefficient_uncertainty_propagated`` as false.
 
 The immutable orchestration result contract partitions original dataset source

--- a/pgmuvi/instrument_channel_calibration.py
+++ b/pgmuvi/instrument_channel_calibration.py
@@ -4150,7 +4150,7 @@ class InstrumentChannelCalibrationExecution:
 
     This record does not claim that the caller-selected reference channels,
     pairing methods, tolerances, or affine family are scientifically optimal.
-    Fitted-coefficient uncertainty is not propagated.
+    Predictive uncertainty is present only when explicitly requested.
     """
 
     schema_version: str
@@ -4161,6 +4161,9 @@ class InstrumentChannelCalibrationExecution:
     applied_channels: tuple[str, ...]
     applied_source_row_indices: tuple[int, ...]
     n_applied_observations: int
+    predictive_uncertainty: (
+        InstrumentChannelCalibrationPredictiveUncertaintyOrchestration | None
+    ) = None
 
     def __post_init__(self) -> None:
         if self.schema_version != (
@@ -4296,6 +4299,37 @@ class InstrumentChannelCalibrationExecution:
                 "applied_source_row_indices."
             )
 
+        predictive_uncertainty = self.predictive_uncertainty
+        if predictive_uncertainty is not None:
+            if not isinstance(
+                predictive_uncertainty,
+                InstrumentChannelCalibrationPredictiveUncertaintyOrchestration,
+            ):
+                raise TypeError(
+                    "predictive_uncertainty must be an "
+                    "InstrumentChannelCalibrationPredictiveUncertaintyOrchestration "
+                    "instance when supplied."
+                )
+            if not predictive_uncertainty.requested:
+                raise ValueError(
+                    "Execution predictive_uncertainty must represent an "
+                    "explicitly requested propagation."
+                )
+            if predictive_uncertainty.source_row_indices != source_row_indices:
+                raise ValueError(
+                    "Execution and predictive orchestration source_row_indices "
+                    "must match exactly."
+                )
+            if (
+                predictive_uncertainty
+                .ordinary_calibrated_flux_error_available
+                != (calibrated_flux_error is not None)
+            ):
+                raise ValueError(
+                    "Predictive orchestration ordinary error availability must "
+                    "match calibrated_flux_error."
+                )
+
         object.__setattr__(
             self,
             "source_row_indices",
@@ -4326,11 +4360,16 @@ class InstrumentChannelCalibrationExecution:
             "n_applied_observations",
             n_applied_observations,
         )
+        object.__setattr__(
+            self,
+            "predictive_uncertainty",
+            predictive_uncertainty,
+        )
 
     def to_dict(self) -> dict[str, Any]:
         """Return a strict JSON-safe execution representation."""
 
-        return {
+        payload = {
             "schema_version": self.schema_version,
             "plan": self.plan.to_dict(),
             "source_row_indices": list(self.source_row_indices),
@@ -4356,11 +4395,22 @@ class InstrumentChannelCalibrationExecution:
             "automatic_pairing_method_selection": False,
             "automatic_time_tolerance_selection": False,
             "automatic_calibration_family_selection": False,
-            "fitted_coefficient_uncertainty_propagated": False,
+            "fitted_coefficient_uncertainty_propagated": (
+                False
+                if self.predictive_uncertainty is None
+                else (
+                    self.predictive_uncertainty
+                    .fitted_coefficient_uncertainty_propagated
+                )
+            ),
             "scientific_pairing_validation_performed": False,
             "marker": INSTRUMENT_CHANNEL_CALIBRATION_TBD_MARKER,
         }
-
+        if self.predictive_uncertainty is not None:
+            payload["predictive_uncertainty"] = (
+                self.predictive_uncertainty.to_dict()
+            )
+        return payload
 
 def _as_finite_execution_vector(
     values: Any,
@@ -4503,11 +4553,12 @@ def execute_instrument_channel_calibration_plan(
     mutated, observational channels remain distinct, and wavelengths are not
     reassigned.
 
-    The callable performs no automatic reference-channel, pairing-method,
-    tolerance, or calibration-family selection. Dataset predictive propagation
-    is an explicit opt-in request. Its contract is defined, but execution is not
-    activated here; a supplied request raises :class:`NotImplementedError`.
-    Calibration is not integrated into :class:`pgmuvi.lightcurve.Lightcurve`.
+    Dataset predictive propagation is performed only when the caller supplies
+    an explicit :class:`InstrumentChannelCalibrationPredictiveUncertaintyRequest`.
+    Marginal or full covariance remains in per-observational-channel blocks.
+    Ordinary execution without a request preserves the existing execution-v1
+    serialization. Calibration is not integrated into
+    :class:`pgmuvi.lightcurve.Lightcurve`.
     """
 
     if predictive_uncertainty_request is not None:
@@ -4526,10 +4577,6 @@ def execute_instrument_channel_calibration_plan(
                 "InstrumentChannelCalibrationPredictiveUncertaintyRequest "
                 "when supplied."
             )
-        raise NotImplementedError(
-            "Dataset calibration predictive-uncertainty propagation is "
-            "defined but not yet activated."
-        )
 
     if not isinstance(
         plan,
@@ -4635,6 +4682,9 @@ def execute_instrument_channel_calibration_plan(
     applied_channels = []
     applied_observation_mask = np.zeros(size, dtype=bool)
 
+    predictive_group_results = []
+    predictive_represented_mask = np.zeros(size, dtype=bool)
+
     labels_for_mask = np.asarray(normalized_labels, dtype=object)
     source_indices_array = np.asarray(
         normalized_source_indices,
@@ -4656,15 +4706,13 @@ def execute_instrument_channel_calibration_plan(
                 f"{group_plan.physical_wavelength!r}."
             )
 
+        if predictive_uncertainty_request is not None:
+            predictive_represented_mask[reference_mask] = True
+
         completed_channel_plans = []
+        predictive_channel_results = []
 
         for channel_plan in group_plan.channel_plans:
-            if channel_plan.disposition is not (
-                InstrumentChannelCalibrationDisposition.PLANNED
-            ):
-                completed_channel_plans.append(channel_plan)
-                continue
-
             channel_mask = (
                 (labels_for_mask == channel_plan.channel)
                 & (
@@ -4674,10 +4722,97 @@ def execute_instrument_channel_calibration_plan(
             )
             if not np.any(channel_mask):
                 raise ValueError(
-                    "Execution input contains no rows for planned channel "
+                    "Execution input contains no rows for channel "
                     f"{channel_plan.channel!r} at wavelength "
                     f"{group_plan.physical_wavelength!r}."
                 )
+
+            channel_source_indices = tuple(
+                source_indices_array[channel_mask]
+            )
+
+            if predictive_uncertainty_request is not None:
+                predictive_represented_mask[channel_mask] = True
+
+            if channel_plan.disposition is not (
+                InstrumentChannelCalibrationDisposition.PLANNED
+            ):
+                completed_channel_plans.append(channel_plan)
+
+                if predictive_uncertainty_request is not None:
+                    if channel_plan.disposition is (
+                        InstrumentChannelCalibrationDisposition.SKIPPED
+                    ):
+                        predictive_channel_results.append(
+                            InstrumentChannelCalibrationPredictiveUncertaintyChannelResult(
+                                physical_wavelength=(
+                                    group_plan.physical_wavelength
+                                ),
+                                reference_channel=(
+                                    group_plan.reference_channel
+                                ),
+                                channel=channel_plan.channel,
+                                disposition=(
+                                    InstrumentChannelCalibrationPredictiveUncertaintyDisposition
+                                    .SKIPPED
+                                ),
+                                source_row_indices=channel_source_indices,
+                                reason=channel_plan.reason,
+                            )
+                        )
+                    else:
+                        reason = channel_plan.reason
+                        unavailable = (
+                            InstrumentChannelCalibrationPredictiveUncertainty(
+                                schema_version=(
+                                    INSTRUMENT_CHANNEL_CALIBRATION_PREDICTIVE_UNCERTAINTY_SCHEMA_VERSION
+                                ),
+                                status=(
+                                    InstrumentChannelCalibrationPredictiveUncertaintyStatus
+                                    .UNAVAILABLE
+                                ),
+                                covariance_mode=(
+                                    predictive_uncertainty_request
+                                    .covariance_mode
+                                ),
+                                input_shape=(len(channel_source_indices),),
+                                input_measurement_uncertainty_supplied=(
+                                    normalized_error is not None
+                                ),
+                                coefficient_uncertainty_status=(
+                                    InstrumentChannelCalibrationUncertaintyStatus
+                                    .UNAVAILABLE
+                                ),
+                                coefficient_uncertainty_source=(
+                                    "dataset_orchestration_channel_unavailable"
+                                ),
+                                measurement_variance=None,
+                                offset_variance=None,
+                                scale_variance=None,
+                                offset_scale_covariance_term=None,
+                                predictive_covariance=None,
+                                reason=reason,
+                            )
+                        )
+                        predictive_channel_results.append(
+                            InstrumentChannelCalibrationPredictiveUncertaintyChannelResult(
+                                physical_wavelength=(
+                                    group_plan.physical_wavelength
+                                ),
+                                reference_channel=(
+                                    group_plan.reference_channel
+                                ),
+                                channel=channel_plan.channel,
+                                disposition=(
+                                    InstrumentChannelCalibrationPredictiveUncertaintyDisposition
+                                    .UNAVAILABLE
+                                ),
+                                source_row_indices=channel_source_indices,
+                                predictive_uncertainty=unavailable,
+                                reason=reason,
+                            )
+                        )
+                continue
 
             pairing = channel_plan.pairing
             if pairing is None:
@@ -4772,6 +4907,53 @@ def execute_instrument_channel_calibration_plan(
                 calibrated_flux[channel_mask] = transformed_flux
                 calibrated_error[channel_mask] = transformed_error
 
+            if predictive_uncertainty_request is not None:
+                _, predictive = (
+                    apply_instrument_channel_calibration_with_predictive_uncertainty(
+                        normalized_flux[channel_mask],
+                        calibration,
+                        flux_error=(
+                            None
+                            if normalized_error is None
+                            else normalized_error[channel_mask]
+                        ),
+                        covariance_mode=(
+                            predictive_uncertainty_request.covariance_mode
+                        ),
+                    )
+                )
+                if predictive.status is (
+                    InstrumentChannelCalibrationPredictiveUncertaintyStatus
+                    .AVAILABLE
+                ):
+                    predictive_disposition = (
+                        InstrumentChannelCalibrationPredictiveUncertaintyDisposition
+                        .AVAILABLE
+                    )
+                    predictive_reason = None
+                else:
+                    predictive_disposition = (
+                        InstrumentChannelCalibrationPredictiveUncertaintyDisposition
+                        .UNAVAILABLE
+                    )
+                    predictive_reason = predictive.reason
+
+                predictive_channel_results.append(
+                    InstrumentChannelCalibrationPredictiveUncertaintyChannelResult(
+                        physical_wavelength=(
+                            group_plan.physical_wavelength
+                        ),
+                        reference_channel=(
+                            group_plan.reference_channel
+                        ),
+                        channel=channel_plan.channel,
+                        disposition=predictive_disposition,
+                        source_row_indices=channel_source_indices,
+                        predictive_uncertainty=predictive,
+                        reason=predictive_reason,
+                    )
+                )
+
             completed_channel_plans.append(
                 replace(
                     channel_plan,
@@ -4789,10 +4971,45 @@ def execute_instrument_channel_calibration_plan(
             )
         )
 
+        if predictive_uncertainty_request is not None:
+            predictive_group_results.append(
+                InstrumentChannelCalibrationPredictiveUncertaintyGroupResult(
+                    physical_wavelength=(
+                        group_plan.physical_wavelength
+                    ),
+                    reference_channel=group_plan.reference_channel,
+                    reference_source_row_indices=tuple(
+                        source_indices_array[reference_mask]
+                    ),
+                    channel_results=tuple(predictive_channel_results),
+                )
+            )
+
     completed_plan = define_instrument_channel_calibration_plan(
         plan.assessment,
         tuple(completed_group_plans),
     )
+
+    predictive_uncertainty = None
+    if predictive_uncertainty_request is not None:
+        predictive_uncertainty = (
+            InstrumentChannelCalibrationPredictiveUncertaintyOrchestration(
+                schema_version=(
+                    INSTRUMENT_CHANNEL_CALIBRATION_PREDICTIVE_ORCHESTRATION_SCHEMA_VERSION
+                ),
+                covariance_mode=(
+                    predictive_uncertainty_request.covariance_mode
+                ),
+                source_row_indices=normalized_source_indices,
+                group_results=tuple(predictive_group_results),
+                unaffected_source_row_indices=tuple(
+                    source_indices_array[~predictive_represented_mask]
+                ),
+                ordinary_calibrated_flux_error_available=(
+                    calibrated_error is not None
+                ),
+            )
+        )
 
     return InstrumentChannelCalibrationExecution(
         schema_version=(
@@ -4813,8 +5030,8 @@ def execute_instrument_channel_calibration_plan(
         n_applied_observations=int(
             np.count_nonzero(applied_observation_mask)
         ),
+        predictive_uncertainty=predictive_uncertainty,
     )
-
 
 def _as_calibration_vector(
     values: Any,

--- a/tests/test_docs_instrument_channel_calibration.py
+++ b/tests/test_docs_instrument_channel_calibration.py
@@ -269,8 +269,8 @@ class TestInstrumentChannelCalibrationDocumentation(unittest.TestCase):
             "coefficient covariance availability alone never activates it",
             normalized,
         )
-        self.assertIn("defined but not activated", normalized)
-        self.assertIn("raises ``NotImplementedError``", normalized)
+        self.assertIn("executes predictive propagation", normalized)
+        self.assertNotIn("raises ``NotImplementedError``", normalized)
         self.assertIn("no global dense dataset covariance", normalized)
         self.assertIn(
             "physical wavelength is never a covariance identity",
@@ -325,7 +325,11 @@ class TestInstrumentChannelCalibrationDocumentation(unittest.TestCase):
             "row-identity, disposition, and dataset-summary contract",
             text,
         )
-        self.assertIn("without activating that execution path", text)
+        self.assertIn(
+            "activates dataset-level predictive propagation through explicit "
+            "requests",
+            text,
+        )
         self.assertNotIn(
             "uncertainty estimation and propagation",
             text,

--- a/tests/test_instrument_channel_calibration_predictive_orchestration_contract.py
+++ b/tests/test_instrument_channel_calibration_predictive_orchestration_contract.py
@@ -490,21 +490,29 @@ class TestPredictiveOrchestrationExecutionBoundary(unittest.TestCase):
         self.assertFalse(payload["fitted_coefficient_uncertainty_propagated"])
         self.assertNotIn("predictive_uncertainty", payload)
 
-    def test_opt_in_request_is_defined_but_not_activated(self):
+    def test_opt_in_request_returns_predictive_orchestration(self):
         plan, times, flux, wavelengths, channels, error = self._data_and_plan()
         request = InstrumentChannelCalibrationPredictiveUncertaintyRequest(
             covariance_mode="marginal_variance"
         )
-        with self.assertRaisesRegex(NotImplementedError, "not yet activated"):
-            execute_instrument_channel_calibration_plan(
-                plan,
-                times,
-                flux,
-                wavelengths,
-                channels,
-                flux_error=error,
-                predictive_uncertainty_request=request,
-            )
+        result = execute_instrument_channel_calibration_plan(
+            plan,
+            times,
+            flux,
+            wavelengths,
+            channels,
+            flux_error=error,
+            predictive_uncertainty_request=request,
+        )
+        payload = result.to_dict()
+
+        self.assertIsNotNone(result.predictive_uncertainty)
+        self.assertTrue(payload["fitted_coefficient_uncertainty_propagated"])
+        self.assertTrue(payload["predictive_uncertainty"]["requested"])
+        self.assertEqual(
+            payload["predictive_uncertainty"]["n_available_channels"],
+            1,
+        )
 
     def test_execution_request_input_is_strict(self):
         plan, times, flux, wavelengths, channels, error = self._data_and_plan()

--- a/tests/test_instrument_channel_calibration_predictive_orchestration_execution.py
+++ b/tests/test_instrument_channel_calibration_predictive_orchestration_execution.py
@@ -1,0 +1,346 @@
+"""Dataset predictive-uncertainty orchestration execution tests."""
+
+from __future__ import annotations
+
+import json
+import unittest
+
+import numpy as np
+
+from pgmuvi.instrument_channel_calibration import (
+    InstrumentChannelCalibrationChannelPlan,
+    InstrumentChannelCalibrationDisposition,
+    InstrumentChannelCalibrationGroupPlan,
+    InstrumentChannelCalibrationPredictiveUncertaintyRequest,
+    InstrumentChannelPairingMethod,
+    assess_instrument_channel_calibration_requirement,
+    define_instrument_channel_calibration_plan,
+    execute_instrument_channel_calibration_plan,
+)
+
+
+class TestPredictiveOrchestrationExecution(unittest.TestCase):
+    @staticmethod
+    def _data(*, include_unique=True):
+        times = np.tile(np.arange(3, dtype=float), 3)
+        wavelengths = np.ones(9, dtype=float)
+        channels = np.repeat(
+            np.asarray(["A", "B", "C"], dtype=object),
+            3,
+        )
+        flux = np.concatenate(
+            (
+                np.asarray([3.0, 5.0, 7.0]),
+                np.asarray([1.0, 2.0, 3.0]),
+                np.asarray([0.5, 1.5, 2.5]),
+            )
+        )
+        error = np.concatenate(
+            (
+                np.full(3, 0.3),
+                np.full(3, 0.1),
+                np.full(3, 0.2),
+            )
+        )
+        if include_unique:
+            times = np.concatenate((times, np.asarray([0.0, 1.0])))
+            wavelengths = np.concatenate(
+                (wavelengths, np.asarray([2.0, 2.0]))
+            )
+            channels = np.concatenate(
+                (
+                    channels,
+                    np.asarray(["D", "D"], dtype=object),
+                )
+            )
+            flux = np.concatenate((flux, np.asarray([4.0, 5.0])))
+            error = np.concatenate((error, np.asarray([0.4, 0.4])))
+        return times, flux, error, wavelengths, channels
+
+    @classmethod
+    def _plan(
+        cls,
+        *,
+        include_unique=True,
+        c_disposition=InstrumentChannelCalibrationDisposition.SKIPPED,
+    ):
+        _, _, _, wavelengths, channels = cls._data(
+            include_unique=include_unique
+        )
+        assessment = assess_instrument_channel_calibration_requirement(
+            wavelengths,
+            channels,
+        )
+        channel_plans = [
+            InstrumentChannelCalibrationChannelPlan(
+                channel="B",
+                disposition=InstrumentChannelCalibrationDisposition.PLANNED,
+                pairing_method=InstrumentChannelPairingMethod.EXACT_TIMESTAMP,
+                time_unit="day",
+                calibration_family="affine",
+            ),
+        ]
+        if c_disposition is InstrumentChannelCalibrationDisposition.PLANNED:
+            channel_plans.append(
+                InstrumentChannelCalibrationChannelPlan(
+                    channel="C",
+                    disposition=(
+                        InstrumentChannelCalibrationDisposition.PLANNED
+                    ),
+                    pairing_method=(
+                        InstrumentChannelPairingMethod.EXACT_TIMESTAMP
+                    ),
+                    time_unit="day",
+                    calibration_family="affine",
+                )
+            )
+        else:
+            channel_plans.append(
+                InstrumentChannelCalibrationChannelPlan(
+                    channel="C",
+                    disposition=c_disposition,
+                    reason=(
+                        "Caller excluded channel C."
+                        if c_disposition
+                        is InstrumentChannelCalibrationDisposition.SKIPPED
+                        else "Calibration is unavailable for channel C."
+                    ),
+                )
+            )
+
+        return define_instrument_channel_calibration_plan(
+            assessment,
+            (
+                InstrumentChannelCalibrationGroupPlan(
+                    physical_wavelength=1.0,
+                    reference_channel="A",
+                    channel_plans=tuple(channel_plans),
+                ),
+            ),
+        )
+
+    def test_marginal_request_returns_aligned_channel_blocks(self):
+        times, flux, error, wavelengths, channels = self._data()
+        source_rows = tuple(range(10, 120, 10))
+
+        result = execute_instrument_channel_calibration_plan(
+            self._plan(),
+            times,
+            flux,
+            wavelengths,
+            channels,
+            flux_error=error,
+            source_row_indices=source_rows,
+            predictive_uncertainty_request=(
+                InstrumentChannelCalibrationPredictiveUncertaintyRequest(
+                    covariance_mode="marginal_variance"
+                )
+            ),
+        )
+        payload = result.to_dict()
+        json.dumps(payload, allow_nan=False)
+
+        predictive = result.predictive_uncertainty
+        self.assertIsNotNone(predictive)
+        self.assertEqual(predictive.n_available_channels, 1)
+        self.assertEqual(predictive.n_skipped_channels, 1)
+        self.assertEqual(
+            predictive.unaffected_source_row_indices,
+            (100, 110),
+        )
+
+        group = predictive.group_results[0]
+        self.assertEqual(
+            group.reference_source_row_indices,
+            (10, 20, 30),
+        )
+        available, skipped = group.channel_results
+        self.assertEqual(available.channel, "B")
+        self.assertEqual(available.source_row_indices, (40, 50, 60))
+        self.assertEqual(available.disposition.value, "available")
+        self.assertEqual(skipped.channel, "C")
+        self.assertEqual(skipped.disposition.value, "skipped")
+        self.assertEqual(skipped.source_row_indices, (70, 80, 90))
+
+        ordinary = np.asarray(result.calibrated_flux_error)[3:6]
+        predictive_std = np.asarray(
+            available.predictive_uncertainty
+            .predictive_standard_deviation
+        )
+        self.assertTrue(np.all(predictive_std >= ordinary))
+        self.assertIn("predictive_uncertainty", payload)
+        self.assertTrue(payload["fitted_coefficient_uncertainty_propagated"])
+
+    def test_full_covariance_remains_separate_for_same_wavelength_channels(self):
+        times, flux, error, wavelengths, channels = self._data(
+            include_unique=False
+        )
+        result = execute_instrument_channel_calibration_plan(
+            self._plan(
+                include_unique=False,
+                c_disposition=(
+                    InstrumentChannelCalibrationDisposition.PLANNED
+                ),
+            ),
+            times,
+            flux,
+            wavelengths,
+            channels,
+            flux_error=error,
+            predictive_uncertainty_request=(
+                InstrumentChannelCalibrationPredictiveUncertaintyRequest(
+                    covariance_mode="full_covariance"
+                )
+            ),
+        )
+
+        predictive = result.predictive_uncertainty
+        group = predictive.group_results[0]
+        self.assertEqual(
+            tuple(item.channel for item in group.channel_results),
+            ("B", "C"),
+        )
+        for item in group.channel_results:
+            covariance = np.asarray(
+                item.predictive_uncertainty.predictive_covariance
+            )
+            self.assertEqual(covariance.shape, (3, 3))
+
+        payload = predictive.to_dict()
+        self.assertTrue(payload["predictive_covariance_blocks_available"])
+        self.assertFalse(payload["global_dense_predictive_covariance_emitted"])
+        self.assertFalse(
+            payload["cross_observational_channel_covariance_emitted"]
+        )
+        self.assertFalse(
+            payload["cross_observational_channel_covariance_assumed_zero"]
+        )
+
+    def test_unavailable_plan_channel_has_structural_unavailable_result(self):
+        times, flux, error, wavelengths, channels = self._data(
+            include_unique=False
+        )
+        result = execute_instrument_channel_calibration_plan(
+            self._plan(
+                include_unique=False,
+                c_disposition=(
+                    InstrumentChannelCalibrationDisposition.UNAVAILABLE
+                ),
+            ),
+            times,
+            flux,
+            wavelengths,
+            channels,
+            flux_error=error,
+            predictive_uncertainty_request=(
+                InstrumentChannelCalibrationPredictiveUncertaintyRequest(
+                    covariance_mode="marginal_variance"
+                )
+            ),
+        )
+
+        channel_results = (
+            result.predictive_uncertainty.group_results[0].channel_results
+        )
+        unavailable = next(
+            item for item in channel_results if item.channel == "C"
+        )
+        nested = unavailable.predictive_uncertainty
+
+        self.assertEqual(unavailable.disposition.value, "unavailable")
+        self.assertIsNone(nested.measurement_variance)
+        self.assertIsNone(nested.predictive_variance)
+        self.assertIsNone(nested.predictive_covariance)
+        np.testing.assert_allclose(result.calibrated_flux[6:9], flux[6:9])
+
+    def test_request_without_measurement_errors_records_zero_contribution(self):
+        times, flux, _, wavelengths, channels = self._data(
+            include_unique=False
+        )
+        result = execute_instrument_channel_calibration_plan(
+            self._plan(),
+            times,
+            flux,
+            wavelengths,
+            channels,
+            predictive_uncertainty_request=(
+                InstrumentChannelCalibrationPredictiveUncertaintyRequest(
+                    covariance_mode="marginal_variance"
+                )
+            ),
+        )
+
+        self.assertIsNone(result.calibrated_flux_error)
+        predictive = (
+            result.predictive_uncertainty.group_results[0]
+            .channel_results[0].predictive_uncertainty
+        )
+        self.assertFalse(
+            predictive.input_measurement_uncertainty_supplied
+        )
+        np.testing.assert_allclose(
+            predictive.measurement_variance,
+            np.zeros(3),
+        )
+        self.assertFalse(
+            result.predictive_uncertainty
+            .ordinary_calibrated_flux_error_available
+        )
+
+    def test_request_on_dataset_without_shared_wavelengths_is_explicit(self):
+        times = np.asarray([0.0, 1.0, 2.0])
+        flux = np.asarray([1.0, 2.0, 3.0])
+        wavelengths = np.asarray([1.0, 2.0, 3.0])
+        channels = np.asarray(["A", "B", "C"], dtype=object)
+        assessment = assess_instrument_channel_calibration_requirement(
+            wavelengths,
+            channels,
+        )
+        plan = define_instrument_channel_calibration_plan(assessment, ())
+
+        result = execute_instrument_channel_calibration_plan(
+            plan,
+            times,
+            flux,
+            wavelengths,
+            channels,
+            source_row_indices=(10, 20, 30),
+            predictive_uncertainty_request=(
+                InstrumentChannelCalibrationPredictiveUncertaintyRequest(
+                    covariance_mode="full_covariance"
+                )
+            ),
+        )
+
+        predictive = result.predictive_uncertainty
+        self.assertTrue(predictive.requested)
+        self.assertEqual(predictive.group_results, ())
+        self.assertEqual(
+            predictive.unaffected_source_row_indices,
+            (10, 20, 30),
+        )
+        self.assertFalse(
+            predictive.fitted_coefficient_uncertainty_propagated
+        )
+
+    def test_default_execution_payload_remains_unchanged(self):
+        times, flux, error, wavelengths, channels = self._data(
+            include_unique=False
+        )
+        result = execute_instrument_channel_calibration_plan(
+            self._plan(),
+            times,
+            flux,
+            wavelengths,
+            channels,
+            flux_error=error,
+        )
+        payload = result.to_dict()
+
+        self.assertIsNone(result.predictive_uncertainty)
+        self.assertNotIn("predictive_uncertainty", payload)
+        self.assertFalse(payload["fitted_coefficient_uncertainty_propagated"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implement the dataset-level calibration predictive-uncertainty orchestration contract defined in PR152.

This pull request activates explicit predictive-uncertainty requests in `execute_instrument_channel_calibration_plan` while preserving the existing execution and serialization behavior when no request is supplied.

## Implementation

- Add optional predictive-uncertainty output to `InstrumentChannelCalibrationExecution`.
- Execute channel-local predictive propagation through the existing low-level predictive-uncertainty helper.
- Preserve exact source-row identity, partitioning, and ordering.
- Return explicit channel, shared-physical-wavelength group, and dataset orchestration records.
- Support marginal variance and per-observational-channel full covariance modes.
- Keep same-physical-wavelength observational channels separate.
- Represent reference rows as not applicable.
- Represent skipped and unavailable channels explicitly and nonnumerically.
- Preserve unavailable coefficient covariance without a measurement-only fallback.
- Preserve `calibrated_flux_error` as the ordinary measurement-only error vector.
- Preserve the prior execution payload exactly when predictive propagation is not requested.
- Remove the PR152 `NotImplementedError` activation boundary.

## Tests

Add implementation coverage for:

- marginal predictive blocks aligned to source rows;
- channel-local full covariance for multiple observational channels at one physical wavelength;
- structurally unavailable plan channels;
- propagation without measurement-error inputs;
- explicit requests on datasets with no shared-wavelength groups;
- unchanged default execution serialization.

The existing predictive-orchestration contract test now verifies successful explicit activation rather than the former `NotImplementedError` boundary.

## Documentation

Update the calibration API and future-work documentation to state that explicit dataset-level predictive propagation is implemented, while retaining the broader instrument-channel calibration future-work marker.

## Validation

- `python3 -m unittest discover -s tests -p 'test_*.py' -v`
  - **2,505 tests passed**
- Calibration-focused discovery:
  - **120 tests passed**
- Documentation contract discovery:
  - **4 tests passed**
- `ruff check -v --output-format=full --show-fixes ./pgmuvi`
  - passed
- `python3 -m py_compile ...`
  - passed
- `make -C docs clean`
  - passed
- `make -C docs html-strict`
  - passed
- `git diff --check`
  - passed

## Scope

Six files changed, with one new implementation-test module. No generated files, local paths, debug artifacts, or private data references are included.
