### PR TITLE
Define instrument-specific calibration pairing and tolerance contract

### DIFF
--- a/docs/source/future_work.rst
+++ b/docs/source/future_work.rst
@@ -131,10 +131,14 @@ Wavelength-model extensions
     observational-channel records, and defines the explicit request,
     per-observational-channel block, row-identity, disposition, and
     dataset-summary contract for ordinary predictive propagation, and
-    activates dataset-level predictive propagation through explicit requests.
-    This does not close the marker:
-    scientifically validated instrument-specific tolerance guidance, workflow
-    integration, and representative calibration validation remain future work.
+    activates dataset-level predictive propagation through explicit requests,
+    and defines an immutable instrument-specific pairing-rule contract with
+    explicit instrument/channel identity, tolerance provenance, validation
+    status, evidence references, and a strict resolution request boundary.
+    This does not close the marker: automatic rule resolution remains unimplemented,
+    and a populated scientifically validated rule catalogue,
+    workflow integration, and representative calibration validation remain
+    future work.
 
 **TBD[multi-periodic-wavelength-models]**
     Add a documented and validated multi-periodic workflow beyond the current

--- a/docs/source/pgmuvi.instrument_channel_calibration.rst
+++ b/docs/source/pgmuvi.instrument_channel_calibration.rst
@@ -38,6 +38,33 @@ Both construction methods currently use a dynamic-programming grid with
 channels should restrict the input observations to the time range relevant to
 the calibration before constructing pairs.
 
+Instrument-specific pairing and tolerance contract
+--------------------------------------------------
+
+The immutable
+:class:`~pgmuvi.instrument_channel_calibration.InstrumentChannelPairingRule`
+record defines a JSON-safe contract for instrument-specific pairing guidance.
+It records explicit reference and target instrument identities, explicit
+observational-channel identities, physical wavelength, pairing method, time
+unit, maximum separation, tolerance provenance, scientific-validation status,
+and an evidence reference when validation is claimed.  Physical wavelength is
+contextual metadata and is never used in place of observational-channel
+identity.
+
+:class:`~pgmuvi.instrument_channel_calibration.InstrumentChannelPairingRuleRequest`
+records the exact instrument, observational-channel, and physical-wavelength
+identity for a future lookup.  The
+:func:`~pgmuvi.instrument_channel_calibration.resolve_instrument_channel_pairing_rule`
+callable validates requests and candidate-rule collections, including duplicate
+identifier and ambiguous-identity rejection.
+
+This contract is **defined but not activated**.  Valid resolution requests raise
+``NotImplementedError``.  No rule is selected automatically, and a validated
+rule record does not by itself authorize automatic reference-channel,
+pairing-method, or time-tolerance selection.  Populating rules with
+instrument-specific evidence and activating rule resolution require separate
+implementation and validation work.
+
 Dataset-level orchestration contract
 ------------------------------------
 
@@ -305,8 +332,8 @@ The low-level paired affine fit and application primitives do not complete the
 instrument-channel calibration work.  The marker remains open because PGMUVI
 still lacks:
 
-* scientifically validated instrument-specific rules for choosing
-  pairing methods and tolerances;
+* a populated and validated instrument-specific pairing-rule catalogue
+  plus activation of automatic rule resolution;
 * integration into the normal light-curve fitting workflow; and
 * validation across representative instruments, filters, and LPV sources.
 

--- a/pgmuvi/instrument_channel_calibration.py
+++ b/pgmuvi/instrument_channel_calibration.py
@@ -33,6 +33,12 @@ INSTRUMENT_CHANNEL_CALIBRATION_TBD_MARKER = (
 INSTRUMENT_CHANNEL_PAIRING_SCHEMA_VERSION = (
     "pgmuvi-instrument-channel-pairing-v2"
 )
+INSTRUMENT_CHANNEL_PAIRING_RULE_SCHEMA_VERSION = (
+    "pgmuvi-instrument-channel-pairing-rule-v1"
+)
+INSTRUMENT_CHANNEL_PAIRING_RULE_REQUEST_SCHEMA_VERSION = (
+    "pgmuvi-instrument-channel-pairing-rule-request-v1"
+)
 INSTRUMENT_CHANNEL_CALIBRATION_PLAN_SCHEMA_VERSION = (
     "pgmuvi-instrument-channel-calibration-plan-v1"
 )
@@ -67,6 +73,8 @@ __all__ = [
     "INSTRUMENT_CHANNEL_CALIBRATION_SCHEMA_VERSION",
     "INSTRUMENT_CHANNEL_CALIBRATION_TBD_MARKER",
     "INSTRUMENT_CHANNEL_CALIBRATION_UNCERTAINTY_SCHEMA_VERSION",
+    "INSTRUMENT_CHANNEL_PAIRING_RULE_REQUEST_SCHEMA_VERSION",
+    "INSTRUMENT_CHANNEL_PAIRING_RULE_SCHEMA_VERSION",
     "INSTRUMENT_CHANNEL_PAIRING_SCHEMA_VERSION",
     "InstrumentChannelCalibration",
     "InstrumentChannelCalibrationAssessment",
@@ -92,6 +100,10 @@ __all__ = [
     "InstrumentChannelCalibrationUncertaintyStatus",
     "InstrumentChannelPairing",
     "InstrumentChannelPairingMethod",
+    "InstrumentChannelPairingRule",
+    "InstrumentChannelPairingRuleRequest",
+    "InstrumentChannelPairingRuleValidationStatus",
+    "InstrumentChannelPairingToleranceProvenance",
     "SharedWavelengthChannelGroup",
     "apply_instrument_channel_calibration",
     "apply_instrument_channel_calibration_with_predictive_uncertainty",
@@ -101,6 +113,7 @@ __all__ = [
     "estimate_scale_dependent_instrument_channel_calibration_coefficient_uncertainty",
     "execute_instrument_channel_calibration_plan",
     "fit_instrument_channel_calibration",
+    "resolve_instrument_channel_pairing_rule",
     "select_instrument_channel_calibration_uncertainty_estimator",
 ]
 
@@ -124,6 +137,22 @@ class InstrumentChannelPairingMethod(_StringEnum):
 
     EXACT_TIMESTAMP = "exact_timestamp"
     NEAREST_WITHIN_TOLERANCE = "nearest_within_tolerance"
+
+
+class InstrumentChannelPairingRuleValidationStatus(_StringEnum):
+    """Scientific-validation state for an instrument-specific pairing rule."""
+
+    DEFINED_NOT_VALIDATED = "defined_not_validated"
+    SCIENTIFICALLY_VALIDATED = "scientifically_validated"
+
+
+class InstrumentChannelPairingToleranceProvenance(_StringEnum):
+    """Origin of an instrument-specific time-tolerance choice."""
+
+    EXACT_TIMESTAMP = "exact_timestamp"
+    CALLER_SUPPLIED = "caller_supplied"
+    INSTRUMENT_DOCUMENTATION = "instrument_documentation"
+    EMPIRICAL_VALIDATION = "empirical_validation"
 
 
 class InstrumentChannelCalibrationDisposition(_StringEnum):
@@ -870,6 +899,505 @@ class InstrumentChannelPairing:
             "automatic_time_tolerance_selection": False,
             "scientific_pairing_validation_performed": False,
         }
+
+
+
+
+@dataclass(frozen=True)
+class InstrumentChannelPairingRule:
+    """Immutable instrument-specific pairing and tolerance guidance.
+
+    The record identifies both instruments and both observational channels
+    explicitly. Physical wavelength is contextual metadata and never replaces
+    observational-channel identity.
+
+    A rule can document unvalidated guidance or scientifically validated
+    guidance. It does not authorize automatic reference-channel, pairing-method,
+    or tolerance selection. Automatic rule resolution remains deliberately
+    unimplemented.
+    """
+
+    rule_id: str
+    reference_instrument: str
+    reference_channel: str
+    channel_instrument: str
+    channel: str
+    physical_wavelength: float
+    pairing_method: InstrumentChannelPairingMethod | str
+    time_unit: str
+    maximum_time_separation: float | None
+    tolerance_provenance: (
+        InstrumentChannelPairingToleranceProvenance | str
+    )
+    validation_status: (
+        InstrumentChannelPairingRuleValidationStatus | str
+    )
+    evidence_reference: str | None = None
+    notes: str | None = None
+    schema_version: str = INSTRUMENT_CHANNEL_PAIRING_RULE_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if self.schema_version != (
+            INSTRUMENT_CHANNEL_PAIRING_RULE_SCHEMA_VERSION
+        ):
+            raise ValueError(
+                "Unsupported instrument-channel pairing-rule schema version: "
+                f"{self.schema_version!r}."
+            )
+
+        rule_id = self._normalize_required_text(
+            self.rule_id,
+            name="rule_id",
+        )
+        reference_instrument = self._normalize_required_text(
+            self.reference_instrument,
+            name="reference_instrument",
+        )
+        channel_instrument = self._normalize_required_text(
+            self.channel_instrument,
+            name="channel_instrument",
+        )
+        reference_channel = _normalize_calibration_channel(
+            self.reference_channel,
+            name="reference_channel",
+        )
+        channel = _normalize_calibration_channel(
+            self.channel,
+            name="channel",
+        )
+        if reference_channel == channel:
+            raise ValueError(
+                "reference_channel and channel must identify different "
+                "observational channels."
+            )
+
+        if isinstance(self.physical_wavelength, (bool, np.bool_)):
+            raise TypeError(
+                "physical_wavelength must be numeric, not boolean."
+            )
+        physical_wavelength = float(self.physical_wavelength)
+        if (
+            not math.isfinite(physical_wavelength)
+            or physical_wavelength <= 0.0
+        ):
+            raise ValueError(
+                "physical_wavelength must be finite and positive."
+            )
+
+        pairing_method = _normalize_pairing_method(
+            self.pairing_method
+        )
+
+        time_unit = self._normalize_required_text(
+            self.time_unit,
+            name="time_unit",
+        )
+
+        maximum_time_separation = self.maximum_time_separation
+        if maximum_time_separation is not None:
+            if isinstance(
+                maximum_time_separation,
+                (bool, np.bool_),
+            ):
+                raise TypeError(
+                    "maximum_time_separation must be numeric, not boolean."
+                )
+            maximum_time_separation = float(maximum_time_separation)
+            if (
+                not math.isfinite(maximum_time_separation)
+                or maximum_time_separation < 0.0
+            ):
+                raise ValueError(
+                    "maximum_time_separation must be finite and "
+                    "non-negative when supplied."
+                )
+
+        provenance = self.tolerance_provenance
+        if not isinstance(
+            provenance,
+            InstrumentChannelPairingToleranceProvenance,
+        ):
+            try:
+                provenance = InstrumentChannelPairingToleranceProvenance(
+                    str(provenance)
+                )
+            except ValueError as exc:
+                raise ValueError(
+                    "Unsupported instrument-channel pairing tolerance "
+                    f"provenance: {self.tolerance_provenance!r}."
+                ) from exc
+
+        validation_status = self.validation_status
+        if not isinstance(
+            validation_status,
+            InstrumentChannelPairingRuleValidationStatus,
+        ):
+            try:
+                validation_status = (
+                    InstrumentChannelPairingRuleValidationStatus(
+                        str(validation_status)
+                    )
+                )
+            except ValueError as exc:
+                raise ValueError(
+                    "Unsupported instrument-channel pairing-rule validation "
+                    f"status: {self.validation_status!r}."
+                ) from exc
+
+        evidence_reference = self._normalize_optional_text(
+            self.evidence_reference,
+            name="evidence_reference",
+        )
+        notes = self._normalize_optional_text(
+            self.notes,
+            name="notes",
+        )
+
+        if pairing_method is InstrumentChannelPairingMethod.EXACT_TIMESTAMP:
+            if (
+                maximum_time_separation is not None
+                and maximum_time_separation != 0.0
+            ):
+                raise ValueError(
+                    "exact_timestamp rules permit no non-zero "
+                    "maximum_time_separation."
+                )
+            if provenance is not (
+                InstrumentChannelPairingToleranceProvenance.EXACT_TIMESTAMP
+            ):
+                raise ValueError(
+                    "exact_timestamp rules require "
+                    "tolerance_provenance='exact_timestamp'."
+                )
+        else:
+            if (
+                maximum_time_separation is None
+                or maximum_time_separation <= 0.0
+            ):
+                raise ValueError(
+                    "nearest_within_tolerance rules require a finite "
+                    "positive maximum_time_separation."
+                )
+            if provenance is (
+                InstrumentChannelPairingToleranceProvenance.EXACT_TIMESTAMP
+            ):
+                raise ValueError(
+                    "nearest_within_tolerance rules cannot use "
+                    "exact_timestamp tolerance provenance."
+                )
+
+        if validation_status is (
+            InstrumentChannelPairingRuleValidationStatus
+            .SCIENTIFICALLY_VALIDATED
+        ):
+            if evidence_reference is None:
+                raise ValueError(
+                    "Scientifically validated pairing rules require an "
+                    "evidence_reference."
+                )
+            if provenance is (
+                InstrumentChannelPairingToleranceProvenance.CALLER_SUPPLIED
+            ):
+                raise ValueError(
+                    "Scientifically validated pairing rules cannot use "
+                    "caller_supplied tolerance provenance."
+                )
+
+        object.__setattr__(self, "rule_id", rule_id)
+        object.__setattr__(
+            self,
+            "reference_instrument",
+            reference_instrument,
+        )
+        object.__setattr__(
+            self,
+            "reference_channel",
+            reference_channel,
+        )
+        object.__setattr__(
+            self,
+            "channel_instrument",
+            channel_instrument,
+        )
+        object.__setattr__(self, "channel", channel)
+        object.__setattr__(
+            self,
+            "physical_wavelength",
+            physical_wavelength,
+        )
+        object.__setattr__(
+            self,
+            "pairing_method",
+            pairing_method,
+        )
+        object.__setattr__(self, "time_unit", time_unit)
+        object.__setattr__(
+            self,
+            "maximum_time_separation",
+            maximum_time_separation,
+        )
+        object.__setattr__(
+            self,
+            "tolerance_provenance",
+            provenance,
+        )
+        object.__setattr__(
+            self,
+            "validation_status",
+            validation_status,
+        )
+        object.__setattr__(
+            self,
+            "evidence_reference",
+            evidence_reference,
+        )
+        object.__setattr__(self, "notes", notes)
+
+    @staticmethod
+    def _normalize_required_text(
+        value: Any,
+        *,
+        name: str,
+    ) -> str:
+        if not isinstance(value, str):
+            raise TypeError(f"{name} must be a string.")
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError(f"{name} must be non-empty.")
+        return normalized
+
+    @classmethod
+    def _normalize_optional_text(
+        cls,
+        value: Any,
+        *,
+        name: str,
+    ) -> str | None:
+        if value is None:
+            return None
+        return cls._normalize_required_text(value, name=name)
+
+    @property
+    def scientifically_validated(self) -> bool:
+        """Whether the rule records scientific validation and evidence."""
+
+        return self.validation_status is (
+            InstrumentChannelPairingRuleValidationStatus
+            .SCIENTIFICALLY_VALIDATED
+        )
+
+    @property
+    def identity_key(
+        self,
+    ) -> tuple[str, str, str, str, float]:
+        """Return the explicit instrument/channel/wavelength rule identity."""
+
+        return (
+            self.reference_instrument,
+            self.reference_channel,
+            self.channel_instrument,
+            self.channel,
+            self.physical_wavelength,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a strict JSON-safe representation."""
+
+        return {
+            "schema_version": self.schema_version,
+            "rule_id": self.rule_id,
+            "reference_instrument": self.reference_instrument,
+            "reference_channel": self.reference_channel,
+            "channel_instrument": self.channel_instrument,
+            "channel": self.channel,
+            "physical_wavelength": self.physical_wavelength,
+            "pairing_method": self.pairing_method.value,
+            "time_unit": self.time_unit,
+            "maximum_time_separation": self.maximum_time_separation,
+            "tolerance_provenance": self.tolerance_provenance.value,
+            "validation_status": self.validation_status.value,
+            "evidence_reference": self.evidence_reference,
+            "notes": self.notes,
+            "scientifically_validated": self.scientifically_validated,
+            "observational_channel_identity_explicit": True,
+            "instrument_identity_explicit": True,
+            "physical_wavelength_used_as_rule_identity": False,
+            "automatic_reference_channel_selection": False,
+            "automatic_pairing_method_selection": False,
+            "automatic_time_tolerance_selection": False,
+            "automatic_rule_selection_permitted": False,
+            "activation_status": "defined_not_activated",
+            "marker": INSTRUMENT_CHANNEL_CALIBRATION_TBD_MARKER,
+        }
+
+
+@dataclass(frozen=True)
+class InstrumentChannelPairingRuleRequest:
+    """Explicit request to resolve one instrument-specific pairing rule."""
+
+    reference_instrument: str
+    reference_channel: str
+    channel_instrument: str
+    channel: str
+    physical_wavelength: float
+    schema_version: str = (
+        INSTRUMENT_CHANNEL_PAIRING_RULE_REQUEST_SCHEMA_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if self.schema_version != (
+            INSTRUMENT_CHANNEL_PAIRING_RULE_REQUEST_SCHEMA_VERSION
+        ):
+            raise ValueError(
+                "Unsupported instrument-channel pairing-rule request schema "
+                f"version: {self.schema_version!r}."
+            )
+
+        reference_instrument = (
+            InstrumentChannelPairingRule._normalize_required_text(
+                self.reference_instrument,
+                name="reference_instrument",
+            )
+        )
+        channel_instrument = (
+            InstrumentChannelPairingRule._normalize_required_text(
+                self.channel_instrument,
+                name="channel_instrument",
+            )
+        )
+        reference_channel = _normalize_calibration_channel(
+            self.reference_channel,
+            name="reference_channel",
+        )
+        channel = _normalize_calibration_channel(
+            self.channel,
+            name="channel",
+        )
+        if reference_channel == channel:
+            raise ValueError(
+                "reference_channel and channel must identify different "
+                "observational channels."
+            )
+
+        if isinstance(self.physical_wavelength, (bool, np.bool_)):
+            raise TypeError(
+                "physical_wavelength must be numeric, not boolean."
+            )
+        physical_wavelength = float(self.physical_wavelength)
+        if (
+            not math.isfinite(physical_wavelength)
+            or physical_wavelength <= 0.0
+        ):
+            raise ValueError(
+                "physical_wavelength must be finite and positive."
+            )
+
+        object.__setattr__(
+            self,
+            "reference_instrument",
+            reference_instrument,
+        )
+        object.__setattr__(
+            self,
+            "reference_channel",
+            reference_channel,
+        )
+        object.__setattr__(
+            self,
+            "channel_instrument",
+            channel_instrument,
+        )
+        object.__setattr__(self, "channel", channel)
+        object.__setattr__(
+            self,
+            "physical_wavelength",
+            physical_wavelength,
+        )
+
+    @property
+    def identity_key(
+        self,
+    ) -> tuple[str, str, str, str, float]:
+        """Return the exact requested rule identity."""
+
+        return (
+            self.reference_instrument,
+            self.reference_channel,
+            self.channel_instrument,
+            self.channel,
+            self.physical_wavelength,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a strict JSON-safe request representation."""
+
+        return {
+            "schema_version": self.schema_version,
+            "reference_instrument": self.reference_instrument,
+            "reference_channel": self.reference_channel,
+            "channel_instrument": self.channel_instrument,
+            "channel": self.channel,
+            "physical_wavelength": self.physical_wavelength,
+            "selection_requested": True,
+            "scientifically_validated_rule_required": True,
+            "automatic_rule_selection_implemented": False,
+            "physical_wavelength_used_without_channel_identity": False,
+            "marker": INSTRUMENT_CHANNEL_CALIBRATION_TBD_MARKER,
+        }
+
+
+def resolve_instrument_channel_pairing_rule(
+    request: InstrumentChannelPairingRuleRequest,
+    rules: Any,
+) -> InstrumentChannelPairingRule:
+    """Validate a future instrument-specific rule-resolution request.
+
+    The contract requires explicit instrument and observational-channel
+    identities and rejects duplicate rule identifiers or ambiguous duplicate
+    identity records. Automatic rule resolution is not activated by this
+    contract PR and therefore raises :class:`NotImplementedError` after input
+    validation.
+    """
+
+    if not isinstance(request, InstrumentChannelPairingRuleRequest):
+        raise TypeError(
+            "request must be an InstrumentChannelPairingRuleRequest instance."
+        )
+
+    try:
+        normalized_rules = tuple(rules)
+    except TypeError as exc:
+        raise TypeError(
+            "rules must be an iterable of InstrumentChannelPairingRule "
+            "instances."
+        ) from exc
+
+    if not normalized_rules:
+        raise ValueError("rules must contain at least one pairing rule.")
+    if any(
+        not isinstance(rule, InstrumentChannelPairingRule)
+        for rule in normalized_rules
+    ):
+        raise TypeError(
+            "rules must contain only InstrumentChannelPairingRule instances."
+        )
+
+    rule_ids = tuple(rule.rule_id for rule in normalized_rules)
+    if len(set(rule_ids)) != len(rule_ids):
+        raise ValueError("Pairing-rule identifiers must be unique.")
+
+    identity_keys = tuple(rule.identity_key for rule in normalized_rules)
+    if len(set(identity_keys)) != len(identity_keys):
+        raise ValueError(
+            "Pairing-rule identities must be unique across explicit "
+            "instrument, observational-channel, and physical-wavelength "
+            "coordinates."
+        )
+
+    raise NotImplementedError(
+        "Instrument-specific pairing-rule resolution is defined but not "
+        "implemented."
+    )
 
 
 def _normalize_pairing_method(

--- a/tests/test_instrument_channel_pairing_rule_contract.py
+++ b/tests/test_instrument_channel_pairing_rule_contract.py
@@ -1,0 +1,344 @@
+"""Instrument-specific pairing and tolerance contract tests."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+import json
+from pathlib import Path
+import unittest
+
+import numpy as np
+
+from pgmuvi.instrument_channel_calibration import (
+    INSTRUMENT_CHANNEL_PAIRING_RULE_REQUEST_SCHEMA_VERSION,
+    INSTRUMENT_CHANNEL_PAIRING_RULE_SCHEMA_VERSION,
+    InstrumentChannelPairingMethod,
+    InstrumentChannelPairingRule,
+    InstrumentChannelPairingRuleRequest,
+    InstrumentChannelPairingRuleValidationStatus,
+    InstrumentChannelPairingToleranceProvenance,
+    resolve_instrument_channel_pairing_rule,
+)
+
+
+class TestInstrumentChannelPairingRuleContract(unittest.TestCase):
+    @staticmethod
+    def _nearest_rule(**overrides):
+        values = {
+            "rule_id": "survey-a-to-survey-b-v1",
+            "reference_instrument": "Survey A",
+            "reference_channel": "SurveyA/V",
+            "channel_instrument": "Survey B",
+            "channel": "SurveyB/V",
+            "physical_wavelength": 0.55,
+            "pairing_method": (
+                InstrumentChannelPairingMethod
+                .NEAREST_WITHIN_TOLERANCE
+            ),
+            "time_unit": "day",
+            "maximum_time_separation": 0.25,
+            "tolerance_provenance": (
+                InstrumentChannelPairingToleranceProvenance
+                .EMPIRICAL_VALIDATION
+            ),
+            "validation_status": (
+                InstrumentChannelPairingRuleValidationStatus
+                .SCIENTIFICALLY_VALIDATED
+            ),
+            "evidence_reference": "validation:representative-lpv-v1",
+        }
+        values.update(overrides)
+        return InstrumentChannelPairingRule(**values)
+
+    def test_exact_rule_is_immutable_and_json_safe(self):
+        rule = InstrumentChannelPairingRule(
+            rule_id="instrument-a-exact-v1",
+            reference_instrument="Instrument A",
+            reference_channel="InstrumentA/stream-0",
+            channel_instrument="Instrument A",
+            channel="InstrumentA/stream-1",
+            physical_wavelength=1.25,
+            pairing_method="exact_timestamp",
+            time_unit="day",
+            maximum_time_separation=None,
+            tolerance_provenance="exact_timestamp",
+            validation_status="defined_not_validated",
+            notes="Contract-only exact-time rule.",
+        )
+
+        self.assertEqual(
+            rule.schema_version,
+            INSTRUMENT_CHANNEL_PAIRING_RULE_SCHEMA_VERSION,
+        )
+        self.assertEqual(
+            rule.pairing_method,
+            InstrumentChannelPairingMethod.EXACT_TIMESTAMP,
+        )
+        self.assertFalse(rule.scientifically_validated)
+
+        payload = rule.to_dict()
+        json.dumps(payload, allow_nan=False)
+        self.assertTrue(
+            payload["observational_channel_identity_explicit"]
+        )
+        self.assertTrue(payload["instrument_identity_explicit"])
+        self.assertFalse(
+            payload["physical_wavelength_used_as_rule_identity"]
+        )
+        self.assertFalse(
+            payload["automatic_rule_selection_permitted"]
+        )
+        self.assertEqual(
+            payload["activation_status"],
+            "defined_not_activated",
+        )
+
+        with self.assertRaises(FrozenInstanceError):
+            rule.time_unit = "second"
+
+    def test_validated_nearest_rule_preserves_evidence(self):
+        rule = self._nearest_rule()
+
+        self.assertTrue(rule.scientifically_validated)
+        self.assertEqual(
+            rule.tolerance_provenance,
+            InstrumentChannelPairingToleranceProvenance
+            .EMPIRICAL_VALIDATION,
+        )
+        self.assertEqual(
+            rule.identity_key,
+            (
+                "Survey A",
+                "SurveyA/V",
+                "Survey B",
+                "SurveyB/V",
+                0.55,
+            ),
+        )
+
+        payload = rule.to_dict()
+        self.assertEqual(
+            payload["evidence_reference"],
+            "validation:representative-lpv-v1",
+        )
+        self.assertEqual(
+            payload["maximum_time_separation"],
+            0.25,
+        )
+
+    def test_exact_rule_rejects_nonzero_tolerance(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "permit no non-zero",
+        ):
+            InstrumentChannelPairingRule(
+                rule_id="bad-exact",
+                reference_instrument="A",
+                reference_channel="A0",
+                channel_instrument="B",
+                channel="B0",
+                physical_wavelength=1.0,
+                pairing_method="exact_timestamp",
+                time_unit="day",
+                maximum_time_separation=0.1,
+                tolerance_provenance="exact_timestamp",
+                validation_status="defined_not_validated",
+            )
+
+    def test_exact_rule_requires_exact_provenance(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "require.*exact_timestamp",
+        ):
+            InstrumentChannelPairingRule(
+                rule_id="bad-exact-provenance",
+                reference_instrument="A",
+                reference_channel="A0",
+                channel_instrument="B",
+                channel="B0",
+                physical_wavelength=1.0,
+                pairing_method="exact_timestamp",
+                time_unit="day",
+                maximum_time_separation=None,
+                tolerance_provenance="caller_supplied",
+                validation_status="defined_not_validated",
+            )
+
+    def test_nearest_rule_requires_positive_tolerance(self):
+        for value in (None, 0.0, -0.1, np.inf):
+            with self.subTest(value=value):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "finite (positive|and non-negative)",
+                ):
+                    self._nearest_rule(
+                        maximum_time_separation=value,
+                    )
+
+    def test_validated_rule_requires_noncaller_evidence(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "evidence_reference",
+        ):
+            self._nearest_rule(evidence_reference=None)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "cannot use caller_supplied",
+        ):
+            self._nearest_rule(
+                tolerance_provenance="caller_supplied",
+            )
+
+    def test_identity_and_numeric_inputs_are_strict(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "different observational channels",
+        ):
+            self._nearest_rule(channel="SurveyA/V")
+
+        with self.assertRaisesRegex(
+            TypeError,
+            "not boolean",
+        ):
+            self._nearest_rule(physical_wavelength=True)
+
+        with self.assertRaisesRegex(
+            TypeError,
+            "not boolean",
+        ):
+            self._nearest_rule(maximum_time_separation=True)
+
+    def test_request_is_explicit_immutable_and_json_safe(self):
+        request = InstrumentChannelPairingRuleRequest(
+            reference_instrument="Survey A",
+            reference_channel="SurveyA/V",
+            channel_instrument="Survey B",
+            channel="SurveyB/V",
+            physical_wavelength=0.55,
+        )
+
+        self.assertEqual(
+            request.schema_version,
+            INSTRUMENT_CHANNEL_PAIRING_RULE_REQUEST_SCHEMA_VERSION,
+        )
+        self.assertEqual(
+            request.identity_key,
+            (
+                "Survey A",
+                "SurveyA/V",
+                "Survey B",
+                "SurveyB/V",
+                0.55,
+            ),
+        )
+
+        payload = request.to_dict()
+        json.dumps(payload, allow_nan=False)
+        self.assertTrue(payload["selection_requested"])
+        self.assertTrue(
+            payload["scientifically_validated_rule_required"]
+        )
+        self.assertFalse(
+            payload["automatic_rule_selection_implemented"]
+        )
+
+        with self.assertRaises(FrozenInstanceError):
+            request.channel = "replacement"
+
+    def test_resolver_validates_inputs_then_remains_inactive(self):
+        request = InstrumentChannelPairingRuleRequest(
+            reference_instrument="Survey A",
+            reference_channel="SurveyA/V",
+            channel_instrument="Survey B",
+            channel="SurveyB/V",
+            physical_wavelength=0.55,
+        )
+        rule = self._nearest_rule()
+
+        with self.assertRaisesRegex(TypeError, "request must be"):
+            resolve_instrument_channel_pairing_rule(
+                object(),
+                (rule,),
+            )
+
+        with self.assertRaisesRegex(ValueError, "at least one"):
+            resolve_instrument_channel_pairing_rule(
+                request,
+                (),
+            )
+
+        with self.assertRaisesRegex(
+            NotImplementedError,
+            "defined but not implemented",
+        ):
+            resolve_instrument_channel_pairing_rule(
+                request,
+                (rule,),
+            )
+
+    def test_resolver_rejects_ambiguous_rule_sets(self):
+        request = InstrumentChannelPairingRuleRequest(
+            reference_instrument="Survey A",
+            reference_channel="SurveyA/V",
+            channel_instrument="Survey B",
+            channel="SurveyB/V",
+            physical_wavelength=0.55,
+        )
+        rule = self._nearest_rule()
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "identifiers must be unique",
+        ):
+            resolve_instrument_channel_pairing_rule(
+                request,
+                (rule, rule),
+            )
+
+        second = self._nearest_rule(rule_id="second-id")
+        with self.assertRaisesRegex(
+            ValueError,
+            "identities must be unique",
+        ):
+            resolve_instrument_channel_pairing_rule(
+                request,
+                (rule, second),
+            )
+
+    def test_public_documentation_records_contract_boundary(self):
+        repo = Path(__file__).resolve().parents[1]
+        api_text = (
+            repo
+            / "docs/source/pgmuvi.instrument_channel_calibration.rst"
+        ).read_text(encoding="utf-8")
+        future_text = (
+            repo / "docs/source/future_work.rst"
+        ).read_text(encoding="utf-8")
+
+        for token in (
+            "InstrumentChannelPairingRule",
+            "InstrumentChannelPairingRuleRequest",
+            "resolve_instrument_channel_pairing_rule",
+            "defined but not activated",
+            "physical wavelength",
+            "observational channel",
+        ):
+            self.assertIn(token, api_text)
+
+        self.assertIn(
+            "instrument-specific pairing-rule contract",
+            future_text,
+        )
+        self.assertIn(
+            "automatic rule resolution remains unimplemented",
+            future_text,
+        )
+        self.assertIn(
+            "TBD[instrument-channel-calibration]",
+            future_text,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- define immutable, JSON-safe instrument-specific pairing-rule and resolution-request contracts;
- preserve explicit instrument and observational-channel identity independently of physical wavelength;
- record pairing method, time unit, maximum separation, tolerance provenance, validation status, and evidence references;
- reject inconsistent exact and nearest-within-tolerance configurations;
- require evidence when a rule claims scientific validation;
- expose a deliberately inactive resolver that validates its inputs and then raises `NotImplementedError`;
- document that no automatic reference-channel, pairing-method, tolerance, or rule selection is activated;
- keep `TBD[instrument-channel-calibration]` open for rule population, scientific validation, workflow integration, and representative calibration validation.

## Scientific boundary

This pull request defines the contract only. It does not populate an instrument-specific rule catalogue, infer tolerances from cadence or physical wavelength, activate automatic rule selection, merge observational channels, alter physical wavelengths, or integrate calibration automatically into light-curve fitting.

## Validation

- complete unittest discovery: 2516 tests passed;
- instrument-channel regression collection: 153 tests passed;
- strict documentation build passed;
- documentation TBD-marker audit passed;
- Python compilation passed;
- Ruff passed for `./pgmuvi` and the new contract test;
- staged and committed diff inspection passed;
- committed scope: 4 files, 909 insertions, 6 deletions.

## Commit

`f4cdc16313955678d9df4738f7a772b051a35625` — Define instrument-specific calibration pairing and tolerance contract
