### PR TITLE
Implement instrument-specific calibration pairing-rule resolution

### DIFF
--- a/docs/source/future_work.rst
+++ b/docs/source/future_work.rst
@@ -134,11 +134,13 @@ Wavelength-model extensions
     activates dataset-level predictive propagation through explicit requests,
     and defines an immutable instrument-specific pairing-rule contract with
     explicit instrument/channel identity, tolerance provenance, validation
-    status, evidence references, and a strict resolution request boundary.
-    This does not close the marker: automatic rule resolution remains unimplemented,
-    and a populated scientifically validated rule catalogue,
-    workflow integration, and representative calibration validation remain
-    future work.
+    status, evidence references, and a strict resolution request boundary,
+    and implements deterministic exact-identity rule resolution over explicitly
+    supplied catalogues.  Resolution returns only a scientifically validated,
+    evidence-backed rule and rejects absent, duplicate, or unvalidated matches
+    without fallback.  This does not close the marker: a
+    populated scientifically validated rule catalogue, workflow integration,
+    and representative calibration validation remain future work.
 
 **TBD[multi-periodic-wavelength-models]**
     Add a documented and validated multi-periodic workflow beyond the current

--- a/docs/source/pgmuvi.instrument_channel_calibration.rst
+++ b/docs/source/pgmuvi.instrument_channel_calibration.rst
@@ -38,13 +38,13 @@ Both construction methods currently use a dynamic-programming grid with
 channels should restrict the input observations to the time range relevant to
 the calibration before constructing pairs.
 
-Instrument-specific pairing and tolerance contract
---------------------------------------------------
+Instrument-specific pairing and tolerance resolution
+----------------------------------------------------
 
 The immutable
 :class:`~pgmuvi.instrument_channel_calibration.InstrumentChannelPairingRule`
-record defines a JSON-safe contract for instrument-specific pairing guidance.
-It records explicit reference and target instrument identities, explicit
+record provides JSON-safe instrument-specific pairing guidance.  It records
+explicit reference and target instrument identities, explicit
 observational-channel identities, physical wavelength, pairing method, time
 unit, maximum separation, tolerance provenance, scientific-validation status,
 and an evidence reference when validation is claimed.  Physical wavelength is
@@ -53,17 +53,21 @@ identity.
 
 :class:`~pgmuvi.instrument_channel_calibration.InstrumentChannelPairingRuleRequest`
 records the exact instrument, observational-channel, and physical-wavelength
-identity for a future lookup.  The
+identity requested by the caller.  The
 :func:`~pgmuvi.instrument_channel_calibration.resolve_instrument_channel_pairing_rule`
-callable validates requests and candidate-rule collections, including duplicate
-identifier and ambiguous-identity rejection.
+callable performs deterministic exact-identity lookup over an
+explicitly supplied rule catalogue.  It rejects duplicate identifiers,
+duplicate explicit
+identities, absent exact matches, and matching rules that are not
+scientifically validated.  A successful lookup returns the single
+evidence-backed rule without fallback.
 
-This contract is **defined but not activated**.  Valid resolution requests raise
-``NotImplementedError``.  No rule is selected automatically, and a validated
-rule record does not by itself authorize automatic reference-channel,
-pairing-method, or time-tolerance selection.  Populating rules with
-instrument-specific evidence and activating rule resolution require separate
-implementation and validation work.
+This explicit resolver does not select a reference observational channel,
+pairing method, or time tolerance automatically.  It does not perform
+approximate physical-wavelength matching, infer tolerance from cadence, provide
+a built-in instrument catalogue, or integrate the result into calibration
+planning or normal light-curve fitting.  Those activation and validation steps
+remain separate future work.
 
 Dataset-level orchestration contract
 ------------------------------------

--- a/pgmuvi/instrument_channel_calibration.py
+++ b/pgmuvi/instrument_channel_calibration.py
@@ -912,9 +912,9 @@ class InstrumentChannelPairingRule:
     observational-channel identity.
 
     A rule can document unvalidated guidance or scientifically validated
-    guidance. It does not authorize automatic reference-channel, pairing-method,
-    or tolerance selection. Automatic rule resolution remains deliberately
-    unimplemented.
+    guidance. Deterministic resolution is available only through an explicit
+    request and an explicitly supplied rule catalogue. A rule does not authorize
+    automatic reference-channel, pairing-method, or tolerance selection.
     """
 
     rule_id: str
@@ -1226,7 +1226,9 @@ class InstrumentChannelPairingRule:
             "automatic_pairing_method_selection": False,
             "automatic_time_tolerance_selection": False,
             "automatic_rule_selection_permitted": False,
-            "activation_status": "defined_not_activated",
+            "explicit_rule_resolution_implemented": True,
+            "workflow_integration_implemented": False,
+            "activation_status": "explicit_resolution_available",
             "marker": INSTRUMENT_CHANNEL_CALIBRATION_TBD_MARKER,
         }
 
@@ -1341,6 +1343,8 @@ class InstrumentChannelPairingRuleRequest:
             "selection_requested": True,
             "scientifically_validated_rule_required": True,
             "automatic_rule_selection_implemented": False,
+            "explicit_rule_resolution_implemented": True,
+            "workflow_integration_implemented": False,
             "physical_wavelength_used_without_channel_identity": False,
             "marker": INSTRUMENT_CHANNEL_CALIBRATION_TBD_MARKER,
         }
@@ -1350,13 +1354,15 @@ def resolve_instrument_channel_pairing_rule(
     request: InstrumentChannelPairingRuleRequest,
     rules: Any,
 ) -> InstrumentChannelPairingRule:
-    """Validate a future instrument-specific rule-resolution request.
+    """Resolve one evidence-backed rule by exact explicit identity.
 
-    The contract requires explicit instrument and observational-channel
-    identities and rejects duplicate rule identifiers or ambiguous duplicate
-    identity records. Automatic rule resolution is not activated by this
-    contract PR and therefore raises :class:`NotImplementedError` after input
-    validation.
+    The caller supplies both the request and the candidate catalogue. Resolution
+    requires exact equality of reference instrument, reference observational
+    channel, target instrument, target observational channel, and physical
+    wavelength. Duplicate identifiers and duplicate identities are rejected
+    before lookup. The resolver returns only a scientifically validated rule and
+    never performs fallback, approximate wavelength matching, tolerance
+    inference, or automatic reference-channel selection.
     """
 
     if not isinstance(request, InstrumentChannelPairingRuleRequest):
@@ -1394,10 +1400,25 @@ def resolve_instrument_channel_pairing_rule(
             "coordinates."
         )
 
-    raise NotImplementedError(
-        "Instrument-specific pairing-rule resolution is defined but not "
-        "implemented."
+    matching_rules = tuple(
+        rule
+        for rule in normalized_rules
+        if rule.identity_key == request.identity_key
     )
+    if not matching_rules:
+        raise ValueError(
+            "No pairing rule matches the exact requested instrument, "
+            "observational-channel, and physical-wavelength identity."
+        )
+
+    resolved_rule = matching_rules[0]
+    if not resolved_rule.scientifically_validated:
+        raise ValueError(
+            f"Pairing rule {resolved_rule.rule_id!r} matches the requested "
+            "identity but is not scientifically validated."
+        )
+
+    return resolved_rule
 
 
 def _normalize_pairing_method(

--- a/tests/test_instrument_channel_pairing_rule_contract.py
+++ b/tests/test_instrument_channel_pairing_rule_contract.py
@@ -88,9 +88,13 @@ class TestInstrumentChannelPairingRuleContract(unittest.TestCase):
         self.assertFalse(
             payload["automatic_rule_selection_permitted"]
         )
+        self.assertTrue(
+            payload["explicit_rule_resolution_implemented"]
+        )
+        self.assertFalse(payload["workflow_integration_implemented"])
         self.assertEqual(
             payload["activation_status"],
-            "defined_not_activated",
+            "explicit_resolution_available",
         )
 
         with self.assertRaises(FrozenInstanceError):
@@ -242,11 +246,15 @@ class TestInstrumentChannelPairingRuleContract(unittest.TestCase):
         self.assertFalse(
             payload["automatic_rule_selection_implemented"]
         )
+        self.assertTrue(
+            payload["explicit_rule_resolution_implemented"]
+        )
+        self.assertFalse(payload["workflow_integration_implemented"])
 
         with self.assertRaises(FrozenInstanceError):
             request.channel = "replacement"
 
-    def test_resolver_validates_inputs_then_remains_inactive(self):
+    def test_resolver_returns_exact_scientifically_validated_match(self):
         request = InstrumentChannelPairingRuleRequest(
             reference_instrument="Survey A",
             reference_channel="SurveyA/V",
@@ -254,12 +262,20 @@ class TestInstrumentChannelPairingRuleContract(unittest.TestCase):
             channel="SurveyB/V",
             physical_wavelength=0.55,
         )
-        rule = self._nearest_rule()
+        matching_rule = self._nearest_rule()
+        same_wavelength_other_channel = self._nearest_rule(
+            rule_id="same-wavelength-other-channel",
+            channel="SurveyB/I",
+        )
+        same_channels_other_wavelength = self._nearest_rule(
+            rule_id="same-channels-other-wavelength",
+            physical_wavelength=0.551,
+        )
 
         with self.assertRaisesRegex(TypeError, "request must be"):
             resolve_instrument_channel_pairing_rule(
                 object(),
-                (rule,),
+                (matching_rule,),
             )
 
         with self.assertRaisesRegex(ValueError, "at least one"):
@@ -269,8 +285,76 @@ class TestInstrumentChannelPairingRuleContract(unittest.TestCase):
             )
 
         with self.assertRaisesRegex(
-            NotImplementedError,
-            "defined but not implemented",
+            TypeError,
+            "only InstrumentChannelPairingRule",
+        ):
+            resolve_instrument_channel_pairing_rule(
+                request,
+                (matching_rule, object()),
+            )
+
+        resolved = resolve_instrument_channel_pairing_rule(
+            request,
+            (
+                same_wavelength_other_channel,
+                same_channels_other_wavelength,
+                matching_rule,
+            ),
+        )
+
+        self.assertIs(resolved, matching_rule)
+        self.assertTrue(resolved.scientifically_validated)
+        self.assertEqual(
+            resolved.evidence_reference,
+            "validation:representative-lpv-v1",
+        )
+
+    def test_resolver_rejects_absent_exact_identity_without_fallback(self):
+        rule = self._nearest_rule()
+        requests = (
+            InstrumentChannelPairingRuleRequest(
+                reference_instrument="Survey A",
+                reference_channel="SurveyA/V",
+                channel_instrument="Survey B",
+                channel="SurveyB/I",
+                physical_wavelength=0.55,
+            ),
+            InstrumentChannelPairingRuleRequest(
+                reference_instrument="Survey A",
+                reference_channel="SurveyA/V",
+                channel_instrument="Survey B",
+                channel="SurveyB/V",
+                physical_wavelength=0.5500000000000002,
+            ),
+        )
+
+        for request in requests:
+            with self.subTest(identity=request.identity_key):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "No pairing rule matches the exact requested",
+                ):
+                    resolve_instrument_channel_pairing_rule(
+                        request,
+                        (rule,),
+                    )
+
+    def test_resolver_rejects_matching_unvalidated_rule(self):
+        request = InstrumentChannelPairingRuleRequest(
+            reference_instrument="Survey A",
+            reference_channel="SurveyA/V",
+            channel_instrument="Survey B",
+            channel="SurveyB/V",
+            physical_wavelength=0.55,
+        )
+        rule = self._nearest_rule(
+            validation_status="defined_not_validated",
+            evidence_reference=None,
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "not scientifically validated",
         ):
             resolve_instrument_channel_pairing_rule(
                 request,
@@ -320,9 +404,11 @@ class TestInstrumentChannelPairingRuleContract(unittest.TestCase):
             "InstrumentChannelPairingRule",
             "InstrumentChannelPairingRuleRequest",
             "resolve_instrument_channel_pairing_rule",
-            "defined but not activated",
+            "deterministic exact-identity lookup",
             "physical wavelength",
             "observational channel",
+            "scientifically validated",
+            "without fallback",
         ):
             self.assertIn(token, api_text)
 
@@ -331,7 +417,11 @@ class TestInstrumentChannelPairingRuleContract(unittest.TestCase):
             future_text,
         )
         self.assertIn(
-            "automatic rule resolution remains unimplemented",
+            "deterministic exact-identity rule resolution",
+            future_text,
+        )
+        self.assertIn(
+            "populated scientifically validated rule catalogue",
             future_text,
         )
         self.assertIn(


### PR DESCRIPTION
## Summary

- implement deterministic resolution of an instrument-specific calibration pairing rule from a caller-supplied catalogue
- require an exact five-field instrument, observational-channel, and physical-wavelength identity match
- reject duplicate rule identifiers, duplicate exact identities, absent matches, ambiguous catalogues, and matching rules that are not scientifically validated
- preserve distinct observational channels that share one physical wavelength
- document that automatic rule selection, a populated validated catalogue, cadence-derived tolerances, and workflow integration remain future work

## Validation

- 2,518 full unit tests passed
- 155 instrument-channel regression tests passed
- 13 pairing-rule contract tests passed
- package compilation passed
- Ruff passed for the complete package and the changed test module
- strict documentation build passed
- documentation TBD-marker audit passed
- staged and committed diff hygiene passed

## Scope boundary

This pull request does not introduce a default pairing-rule catalogue, approximate wavelength matching, cadence inference, automatic reference-channel selection, automatic tolerance selection, fitting-workflow integration, or any fallback behavior.
