### PR TITLE
Define instrument-specific calibration pairing-rule catalogue contract

### DIFF
--- a/docs/source/future_work.rst
+++ b/docs/source/future_work.rst
@@ -138,7 +138,12 @@ Wavelength-model extensions
     and implements deterministic exact-identity rule resolution over explicitly
     supplied catalogues.  Resolution returns only a scientifically validated,
     evidence-backed rule and rejects absent, duplicate, or unvalidated matches
-    without fallback.  This does not close the marker: a
+    without fallback, and defines an immutable strict JSON-safe
+    pairing-rule catalogue contract with explicit catalogue identity, version,
+    aggregate validation semantics, member uniqueness, and strict round-trip
+    deserialization.  The caller-supplied catalogue can participate only at the
+    existing explicit resolver boundary; automatic discovery and automatic
+    activation remain unavailable.  This does not close the marker: a
     populated scientifically validated rule catalogue, workflow integration,
     and representative calibration validation remain future work.
 

--- a/docs/source/pgmuvi.instrument_channel_calibration.rst
+++ b/docs/source/pgmuvi.instrument_channel_calibration.rst
@@ -62,6 +62,22 @@ identities, absent exact matches, and matching rules that are not
 scientifically validated.  A successful lookup returns the single
 evidence-backed rule without fallback.
 
+The immutable
+:class:`~pgmuvi.instrument_channel_calibration.InstrumentChannelPairingRuleCatalogue`
+defines the strict JSON-safe contract for a caller-supplied collection of
+rules.  It records an explicit catalogue identifier, catalogue version,
+provenance reference, catalogue-level validation status, optional validation
+evidence, and a non-empty immutable tuple of member rules.  Construction
+rejects duplicate rule identifiers and duplicate exact identities.  A
+scientifically validated catalogue must carry evidence and cannot silently
+upgrade a member rule that is not itself scientifically validated.
+
+The catalogue can be passed explicitly to the existing resolver because it
+iterates only over its recorded member rules.  Strict serialization and
+deserialization preserve catalogue and rule provenance.  This does not provide
+a populated built-in catalogue, automatic discovery, automatic activation,
+approximate matching, or implicit workflow integration.
+
 This explicit resolver does not select a reference observational channel,
 pairing method, or time tolerance automatically.  It does not perform
 approximate physical-wavelength matching, infer tolerance from cadence, provide
@@ -336,8 +352,8 @@ The low-level paired affine fit and application primitives do not complete the
 instrument-channel calibration work.  The marker remains open because PGMUVI
 still lacks:
 
-* a populated and validated instrument-specific pairing-rule catalogue
-  plus activation of automatic rule resolution;
+* populated scientifically validated pairing-rule catalogue content
+  plus automatic catalogue discovery and activation;
 * integration into the normal light-curve fitting workflow; and
 * validation across representative instruments, filters, and LPV sources.
 

--- a/pgmuvi/instrument_channel_calibration.py
+++ b/pgmuvi/instrument_channel_calibration.py
@@ -36,6 +36,9 @@ INSTRUMENT_CHANNEL_PAIRING_SCHEMA_VERSION = (
 INSTRUMENT_CHANNEL_PAIRING_RULE_SCHEMA_VERSION = (
     "pgmuvi-instrument-channel-pairing-rule-v1"
 )
+INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_SCHEMA_VERSION = (
+    "pgmuvi-instrument-channel-pairing-rule-catalogue-v1"
+)
 INSTRUMENT_CHANNEL_PAIRING_RULE_REQUEST_SCHEMA_VERSION = (
     "pgmuvi-instrument-channel-pairing-rule-request-v1"
 )
@@ -73,6 +76,7 @@ __all__ = [
     "INSTRUMENT_CHANNEL_CALIBRATION_SCHEMA_VERSION",
     "INSTRUMENT_CHANNEL_CALIBRATION_TBD_MARKER",
     "INSTRUMENT_CHANNEL_CALIBRATION_UNCERTAINTY_SCHEMA_VERSION",
+    "INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_SCHEMA_VERSION",
     "INSTRUMENT_CHANNEL_PAIRING_RULE_REQUEST_SCHEMA_VERSION",
     "INSTRUMENT_CHANNEL_PAIRING_RULE_SCHEMA_VERSION",
     "INSTRUMENT_CHANNEL_PAIRING_SCHEMA_VERSION",
@@ -101,6 +105,7 @@ __all__ = [
     "InstrumentChannelPairing",
     "InstrumentChannelPairingMethod",
     "InstrumentChannelPairingRule",
+    "InstrumentChannelPairingRuleCatalogue",
     "InstrumentChannelPairingRuleRequest",
     "InstrumentChannelPairingRuleValidationStatus",
     "InstrumentChannelPairingToleranceProvenance",
@@ -1231,6 +1236,320 @@ class InstrumentChannelPairingRule:
             "activation_status": "explicit_resolution_available",
             "marker": INSTRUMENT_CHANNEL_CALIBRATION_TBD_MARKER,
         }
+
+
+@dataclass(frozen=True)
+class InstrumentChannelPairingRuleCatalogue:
+    """Immutable caller-supplied pairing-rule catalogue contract.
+
+    The catalogue records its own identity, version, provenance, validation
+    status, and an immutable non-empty tuple of instrument-specific rules.
+    Construction validates unique rule identifiers and exact five-field rule
+    identities deterministically.
+
+    This record does not provide a built-in populated catalogue, automatic
+    discovery, automatic activation, cadence inference, or workflow
+    integration. Iteration exposes only the explicitly supplied member rules,
+    allowing use at the existing explicit resolver boundary.
+    """
+
+    catalogue_id: str
+    catalogue_version: str
+    provenance_reference: str
+    rules: tuple[InstrumentChannelPairingRule, ...]
+    validation_status: (
+        InstrumentChannelPairingRuleValidationStatus | str
+    )
+    evidence_reference: str | None = None
+    notes: str | None = None
+    schema_version: str = (
+        INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_SCHEMA_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if self.schema_version != (
+            INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_SCHEMA_VERSION
+        ):
+            raise ValueError(
+                "Unsupported instrument-channel pairing-rule catalogue "
+                f"schema version: {self.schema_version!r}."
+            )
+
+        catalogue_id = (
+            InstrumentChannelPairingRule._normalize_required_text(
+                self.catalogue_id,
+                name="catalogue_id",
+            )
+        )
+        catalogue_version = (
+            InstrumentChannelPairingRule._normalize_required_text(
+                self.catalogue_version,
+                name="catalogue_version",
+            )
+        )
+        provenance_reference = (
+            InstrumentChannelPairingRule._normalize_required_text(
+                self.provenance_reference,
+                name="provenance_reference",
+            )
+        )
+        evidence_reference = (
+            InstrumentChannelPairingRule._normalize_optional_text(
+                self.evidence_reference,
+                name="evidence_reference",
+            )
+        )
+        notes = InstrumentChannelPairingRule._normalize_optional_text(
+            self.notes,
+            name="notes",
+        )
+
+        rules = tuple(self.rules)
+        if not rules:
+            raise ValueError(
+                "A pairing-rule catalogue must contain at least one rule."
+            )
+        if any(
+            not isinstance(rule, InstrumentChannelPairingRule)
+            for rule in rules
+        ):
+            raise TypeError(
+                "rules must contain only InstrumentChannelPairingRule "
+                "instances."
+            )
+
+        rule_ids = tuple(rule.rule_id for rule in rules)
+        if len(set(rule_ids)) != len(rule_ids):
+            raise ValueError(
+                "Pairing-rule identifiers must be unique within a catalogue."
+            )
+
+        identity_keys = tuple(rule.identity_key for rule in rules)
+        if len(set(identity_keys)) != len(identity_keys):
+            raise ValueError(
+                "Pairing-rule identities must be unique within a catalogue "
+                "across explicit instrument, observational-channel, and "
+                "physical-wavelength coordinates."
+            )
+
+        validation_status = self.validation_status
+        if not isinstance(
+            validation_status,
+            InstrumentChannelPairingRuleValidationStatus,
+        ):
+            try:
+                validation_status = (
+                    InstrumentChannelPairingRuleValidationStatus(
+                        str(validation_status)
+                    )
+                )
+            except ValueError as exc:
+                raise ValueError(
+                    "Unsupported instrument-channel pairing-rule catalogue "
+                    f"validation status: {self.validation_status!r}."
+                ) from exc
+
+        if validation_status is (
+            InstrumentChannelPairingRuleValidationStatus
+            .SCIENTIFICALLY_VALIDATED
+        ):
+            if evidence_reference is None:
+                raise ValueError(
+                    "A scientifically validated pairing-rule catalogue "
+                    "requires an evidence_reference."
+                )
+            unvalidated_rule_ids = tuple(
+                rule.rule_id
+                for rule in rules
+                if not rule.scientifically_validated
+            )
+            if unvalidated_rule_ids:
+                raise ValueError(
+                    "A scientifically validated pairing-rule catalogue "
+                    "cannot contain rules that are not scientifically "
+                    f"validated: {unvalidated_rule_ids!r}."
+                )
+
+        object.__setattr__(self, "catalogue_id", catalogue_id)
+        object.__setattr__(
+            self,
+            "catalogue_version",
+            catalogue_version,
+        )
+        object.__setattr__(
+            self,
+            "provenance_reference",
+            provenance_reference,
+        )
+        object.__setattr__(self, "rules", rules)
+        object.__setattr__(
+            self,
+            "validation_status",
+            validation_status,
+        )
+        object.__setattr__(
+            self,
+            "evidence_reference",
+            evidence_reference,
+        )
+        object.__setattr__(self, "notes", notes)
+
+    @property
+    def scientifically_validated(self) -> bool:
+        """Whether the catalogue records scientific validation."""
+
+        return self.validation_status is (
+            InstrumentChannelPairingRuleValidationStatus
+            .SCIENTIFICALLY_VALIDATED
+        )
+
+    @property
+    def all_rules_scientifically_validated(self) -> bool:
+        """Whether every member rule is scientifically validated."""
+
+        return all(rule.scientifically_validated for rule in self.rules)
+
+    def __iter__(self) -> Any:
+        """Iterate over the explicitly supplied member rules."""
+
+        return iter(self.rules)
+
+    def __len__(self) -> int:
+        """Return the number of member rules."""
+
+        return len(self.rules)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a strict JSON-safe catalogue representation."""
+
+        return {
+            "schema_version": self.schema_version,
+            "catalogue_id": self.catalogue_id,
+            "catalogue_version": self.catalogue_version,
+            "provenance_reference": self.provenance_reference,
+            "validation_status": self.validation_status.value,
+            "evidence_reference": self.evidence_reference,
+            "notes": self.notes,
+            "rules": [rule.to_dict() for rule in self.rules],
+            "n_rules": len(self.rules),
+            "scientifically_validated": self.scientifically_validated,
+            "all_rules_scientifically_validated": (
+                self.all_rules_scientifically_validated
+            ),
+            "automatic_catalogue_discovery_implemented": False,
+            "automatic_catalogue_activation_implemented": False,
+            "workflow_integration_implemented": False,
+            "populated_builtin_catalogue_available": False,
+            "marker": INSTRUMENT_CHANNEL_CALIBRATION_TBD_MARKER,
+        }
+
+    @classmethod
+    def from_dict(
+        cls,
+        payload: Any,
+    ) -> InstrumentChannelPairingRuleCatalogue:
+        """Construct a catalogue from its strict serialized representation."""
+
+        if not isinstance(payload, dict):
+            raise TypeError(
+                "Pairing-rule catalogue payload must be a dictionary."
+            )
+
+        expected_keys = {
+            "schema_version",
+            "catalogue_id",
+            "catalogue_version",
+            "provenance_reference",
+            "validation_status",
+            "evidence_reference",
+            "notes",
+            "rules",
+            "n_rules",
+            "scientifically_validated",
+            "all_rules_scientifically_validated",
+            "automatic_catalogue_discovery_implemented",
+            "automatic_catalogue_activation_implemented",
+            "workflow_integration_implemented",
+            "populated_builtin_catalogue_available",
+            "marker",
+        }
+        if set(payload) != expected_keys:
+            raise ValueError(
+                "Pairing-rule catalogue payload must contain exactly the "
+                f"contract fields; observed={tuple(sorted(payload))!r}."
+            )
+
+        raw_rules = payload["rules"]
+        if not isinstance(raw_rules, list):
+            raise TypeError(
+                "Serialized pairing-rule catalogue rules must be a list."
+            )
+
+        rules = []
+        for index, rule_payload in enumerate(raw_rules):
+            if not isinstance(rule_payload, dict):
+                raise TypeError(
+                    "Each serialized pairing rule must be a dictionary; "
+                    f"index={index}."
+                )
+            try:
+                rule = InstrumentChannelPairingRule(
+                    schema_version=rule_payload["schema_version"],
+                    rule_id=rule_payload["rule_id"],
+                    reference_instrument=(
+                        rule_payload["reference_instrument"]
+                    ),
+                    reference_channel=rule_payload["reference_channel"],
+                    channel_instrument=rule_payload["channel_instrument"],
+                    channel=rule_payload["channel"],
+                    physical_wavelength=(
+                        rule_payload["physical_wavelength"]
+                    ),
+                    pairing_method=rule_payload["pairing_method"],
+                    time_unit=rule_payload["time_unit"],
+                    maximum_time_separation=(
+                        rule_payload["maximum_time_separation"]
+                    ),
+                    tolerance_provenance=(
+                        rule_payload["tolerance_provenance"]
+                    ),
+                    validation_status=rule_payload["validation_status"],
+                    evidence_reference=(
+                        rule_payload["evidence_reference"]
+                    ),
+                    notes=rule_payload["notes"],
+                )
+            except KeyError as exc:
+                raise ValueError(
+                    "Serialized pairing-rule payload is missing a required "
+                    f"field at index {index}: {exc.args[0]!r}."
+                ) from exc
+
+            if rule.to_dict() != rule_payload:
+                raise ValueError(
+                    "Serialized pairing-rule payload does not match the "
+                    f"strict contract representation at index {index}."
+                )
+            rules.append(rule)
+
+        catalogue = cls(
+            schema_version=payload["schema_version"],
+            catalogue_id=payload["catalogue_id"],
+            catalogue_version=payload["catalogue_version"],
+            provenance_reference=payload["provenance_reference"],
+            rules=tuple(rules),
+            validation_status=payload["validation_status"],
+            evidence_reference=payload["evidence_reference"],
+            notes=payload["notes"],
+        )
+
+        if catalogue.to_dict() != payload:
+            raise ValueError(
+                "Serialized pairing-rule catalogue payload does not match "
+                "the strict contract representation."
+            )
+
+        return catalogue
 
 
 @dataclass(frozen=True)

--- a/tests/test_instrument_channel_pairing_rule_catalogue_contract.py
+++ b/tests/test_instrument_channel_pairing_rule_catalogue_contract.py
@@ -1,0 +1,281 @@
+"""Instrument-specific pairing-rule catalogue contract tests."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+import json
+from pathlib import Path
+import unittest
+
+from pgmuvi.instrument_channel_calibration import (
+    INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_SCHEMA_VERSION,
+    InstrumentChannelPairingMethod,
+    InstrumentChannelPairingRule,
+    InstrumentChannelPairingRuleCatalogue,
+    InstrumentChannelPairingRuleRequest,
+    InstrumentChannelPairingRuleValidationStatus,
+    InstrumentChannelPairingToleranceProvenance,
+    resolve_instrument_channel_pairing_rule,
+)
+
+
+class TestInstrumentChannelPairingRuleCatalogueContract(
+    unittest.TestCase
+):
+    @staticmethod
+    def _validated_rule(**overrides):
+        values = {
+            "rule_id": "survey-a-to-survey-b-v1",
+            "reference_instrument": "Survey A",
+            "reference_channel": "SurveyA/V",
+            "channel_instrument": "Survey B",
+            "channel": "SurveyB/V",
+            "physical_wavelength": 0.55,
+            "pairing_method": (
+                InstrumentChannelPairingMethod
+                .NEAREST_WITHIN_TOLERANCE
+            ),
+            "time_unit": "day",
+            "maximum_time_separation": 0.25,
+            "tolerance_provenance": (
+                InstrumentChannelPairingToleranceProvenance
+                .EMPIRICAL_VALIDATION
+            ),
+            "validation_status": (
+                InstrumentChannelPairingRuleValidationStatus
+                .SCIENTIFICALLY_VALIDATED
+            ),
+            "evidence_reference": "validation:representative-lpv-v1",
+        }
+        values.update(overrides)
+        return InstrumentChannelPairingRule(**values)
+
+    @classmethod
+    def _catalogue(cls, **overrides):
+        values = {
+            "catalogue_id": "pgmuvi-pairing-rules",
+            "catalogue_version": "2026.1",
+            "provenance_reference": "catalogue:design-record-v1",
+            "rules": (
+                cls._validated_rule(),
+                cls._validated_rule(
+                    rule_id="survey-a-to-survey-c-v1",
+                    channel_instrument="Survey C",
+                    channel="SurveyC/V",
+                ),
+            ),
+            "validation_status": (
+                InstrumentChannelPairingRuleValidationStatus
+                .SCIENTIFICALLY_VALIDATED
+            ),
+            "evidence_reference": "catalogue:validation-report-v1",
+        }
+        values.update(overrides)
+        return InstrumentChannelPairingRuleCatalogue(**values)
+
+    def test_catalogue_is_immutable_json_safe_and_round_trips(self):
+        catalogue = self._catalogue()
+
+        self.assertEqual(
+            catalogue.schema_version,
+            INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_SCHEMA_VERSION,
+        )
+        self.assertEqual(len(catalogue), 2)
+        self.assertTrue(catalogue.scientifically_validated)
+        self.assertTrue(
+            catalogue.all_rules_scientifically_validated
+        )
+        self.assertEqual(tuple(catalogue), catalogue.rules)
+
+        payload = catalogue.to_dict()
+        json.dumps(payload, allow_nan=False)
+
+        self.assertEqual(payload["n_rules"], 2)
+        self.assertFalse(
+            payload["automatic_catalogue_discovery_implemented"]
+        )
+        self.assertFalse(
+            payload["automatic_catalogue_activation_implemented"]
+        )
+        self.assertFalse(payload["workflow_integration_implemented"])
+        self.assertFalse(
+            payload["populated_builtin_catalogue_available"]
+        )
+
+        restored = InstrumentChannelPairingRuleCatalogue.from_dict(
+            payload
+        )
+        self.assertEqual(restored, catalogue)
+        self.assertEqual(restored.to_dict(), payload)
+
+        with self.assertRaises(FrozenInstanceError):
+            catalogue.catalogue_version = "replacement"
+
+    def test_catalogue_requires_nonempty_typed_unique_rules(self):
+        with self.assertRaisesRegex(ValueError, "at least one rule"):
+            self._catalogue(rules=())
+
+        with self.assertRaisesRegex(
+            TypeError,
+            "only InstrumentChannelPairingRule",
+        ):
+            self._catalogue(rules=(self._validated_rule(), object()))
+
+        rule = self._validated_rule()
+        with self.assertRaisesRegex(
+            ValueError,
+            "identifiers must be unique",
+        ):
+            self._catalogue(rules=(rule, rule))
+
+        duplicate_identity = self._validated_rule(
+            rule_id="different-rule-id"
+        )
+        with self.assertRaisesRegex(
+            ValueError,
+            "identities must be unique",
+        ):
+            self._catalogue(rules=(rule, duplicate_identity))
+
+    def test_validated_catalogue_cannot_upgrade_unvalidated_rules(self):
+        unvalidated_rule = self._validated_rule(
+            validation_status="defined_not_validated",
+            evidence_reference=None,
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "requires an evidence_reference",
+        ):
+            self._catalogue(evidence_reference=None)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "cannot contain rules that are not scientifically validated",
+        ):
+            self._catalogue(rules=(unvalidated_rule,))
+
+        contract_only = self._catalogue(
+            rules=(unvalidated_rule,),
+            validation_status="defined_not_validated",
+            evidence_reference=None,
+        )
+        self.assertFalse(contract_only.scientifically_validated)
+        self.assertFalse(
+            contract_only.all_rules_scientifically_validated
+        )
+
+    def test_strict_deserialization_rejects_schema_and_flag_changes(self):
+        payload = self._catalogue().to_dict()
+
+        changed_schema = dict(payload)
+        changed_schema["schema_version"] = "unsupported"
+        with self.assertRaisesRegex(
+            ValueError,
+            "Unsupported.*catalogue schema version",
+        ):
+            InstrumentChannelPairingRuleCatalogue.from_dict(
+                changed_schema
+            )
+
+        changed_flag = dict(payload)
+        changed_flag[
+            "automatic_catalogue_activation_implemented"
+        ] = True
+        with self.assertRaisesRegex(
+            ValueError,
+            "strict contract representation",
+        ):
+            InstrumentChannelPairingRuleCatalogue.from_dict(
+                changed_flag
+            )
+
+        missing_field = dict(payload)
+        missing_field.pop("provenance_reference")
+        with self.assertRaisesRegex(
+            ValueError,
+            "exactly the contract fields",
+        ):
+            InstrumentChannelPairingRuleCatalogue.from_dict(
+                missing_field
+            )
+
+    def test_catalogue_uses_existing_explicit_resolver_boundary(self):
+        catalogue = self._catalogue()
+        request = InstrumentChannelPairingRuleRequest(
+            reference_instrument="Survey A",
+            reference_channel="SurveyA/V",
+            channel_instrument="Survey C",
+            channel="SurveyC/V",
+            physical_wavelength=0.55,
+        )
+
+        resolved = resolve_instrument_channel_pairing_rule(
+            request,
+            catalogue,
+        )
+
+        self.assertIs(resolved, catalogue.rules[1])
+        self.assertEqual(
+            resolved.rule_id,
+            "survey-a-to-survey-c-v1",
+        )
+
+        absent = InstrumentChannelPairingRuleRequest(
+            reference_instrument="Survey A",
+            reference_channel="SurveyA/V",
+            channel_instrument="Survey D",
+            channel="SurveyD/V",
+            physical_wavelength=0.55,
+        )
+        with self.assertRaisesRegex(
+            ValueError,
+            "No pairing rule matches the exact requested",
+        ):
+            resolve_instrument_channel_pairing_rule(
+                absent,
+                catalogue,
+            )
+
+    def test_public_documentation_preserves_activation_boundary(self):
+        repo = Path(__file__).resolve().parents[1]
+        api_text = (
+            repo
+            / "docs/source/pgmuvi.instrument_channel_calibration.rst"
+        ).read_text(encoding="utf-8")
+        future_text = (
+            repo / "docs/source/future_work.rst"
+        ).read_text(encoding="utf-8")
+
+        for token in (
+            "InstrumentChannelPairingRuleCatalogue",
+            "catalogue identifier",
+            "catalogue version",
+            "provenance reference",
+            "strict JSON-safe",
+            "automatic discovery",
+            "automatic activation",
+            "caller-supplied",
+        ):
+            self.assertIn(token, api_text)
+
+        self.assertIn(
+            "pairing-rule catalogue contract",
+            future_text,
+        )
+        self.assertIn(
+            "populated scientifically validated rule catalogue",
+            future_text,
+        )
+        self.assertIn(
+            "workflow integration",
+            future_text,
+        )
+        self.assertIn(
+            "TBD[instrument-channel-calibration]",
+            future_text,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Define the immutable, caller-supplied contract for an instrument-specific calibration pairing-rule catalogue.

The new contract:

- records an explicit catalogue identifier, version, provenance reference, validation status, evidence reference, notes, and immutable member-rule tuple;
- requires a non-empty catalogue;
- rejects duplicate rule identifiers;
- rejects duplicate exact five-field identities;
- prevents catalogue-level validation from upgrading unvalidated member rules;
- provides strict JSON-safe serialization and deserialization;
- rejects unsupported schema versions and altered contract fields;
- remains compatible with the existing explicit exact-identity resolver boundary.

## Deliberate boundaries

This pull request does **not**:

- add a populated built-in pairing-rule catalogue;
- discover catalogues automatically;
- activate catalogue selection automatically;
- infer pairing methods or tolerances from cadence;
- perform approximate physical-wavelength matching;
- integrate catalogue resolution into the normal light-curve fitting workflow;
- close `TBD[instrument-channel-calibration]`.

Those items remain explicit future work.

## Files changed

- `pgmuvi/instrument_channel_calibration.py`
- `tests/test_instrument_channel_pairing_rule_catalogue_contract.py`
- `docs/source/pgmuvi.instrument_channel_calibration.rst`
- `docs/source/future_work.rst`

## Validation

- 2,524 full unit tests passed.
- 161 instrument-channel regression tests passed.
- 6 new catalogue-contract tests passed.
- Existing 13 pairing-rule contract tests passed.
- Documentation contract regressions passed.
- Package compilation passed.
- Full-package Ruff passed.
- New-test Ruff passed.
- Strict documentation build passed.
- Documentation TBD-marker audit passed with 13 registered markers.
- Complete staged/committed diff SHA256:
  `15d0d6dad9325cedcdccc42b07cda140a133916d4aa6431fa6d1929678b74730`
