### PR TITLE
Define instrument-specific calibration catalogue discovery and activation contract

### DIFF
--- a/docs/source/future_work.rst
+++ b/docs/source/future_work.rst
@@ -142,10 +142,18 @@ Wavelength-model extensions
     pairing-rule catalogue contract with explicit catalogue identity, version,
     aggregate validation semantics, member uniqueness, and strict round-trip
     deserialization.  The caller-supplied catalogue can participate only at the
-    existing explicit resolver boundary; automatic discovery and automatic
-    activation remain unavailable.  This does not close the marker: a
-    populated scientifically validated rule catalogue, workflow integration,
-    and representative calibration validation remain future work.
+    existing explicit resolver boundary.
+
+    The discovery and activation contract now defines explicit-source requests,
+    exact compatibility assessment, validated-only activation policy, and
+    fail-closed public callables.  This contract does not close
+    ``TBD[instrument-channel-calibration]``.  The discovery and activation
+    callables intentionally raise ``NotImplementedError`` until explicit-source
+    loading and catalogue activation are implemented.
+
+    A populated scientifically validated rule catalogue, normal light-curve
+    workflow integration, and representative calibration validation remain
+    future work.
 
 **TBD[multi-periodic-wavelength-models]**
     Add a documented and validated multi-periodic workflow beyond the current

--- a/docs/source/pgmuvi.instrument_channel_calibration.rst
+++ b/docs/source/pgmuvi.instrument_channel_calibration.rst
@@ -74,16 +74,32 @@ upgrade a member rule that is not itself scientifically validated.
 
 The catalogue can be passed explicitly to the existing resolver because it
 iterates only over its recorded member rules.  Strict serialization and
-deserialization preserve catalogue and rule provenance.  This does not provide
-a populated built-in catalogue, automatic discovery, automatic activation,
-approximate matching, or implicit workflow integration.
+deserialization preserve catalogue and rule provenance.  The automatic discovery
+and automatic activation mechanisms remain unavailable unless and until the
+explicit fail-closed callables are implemented.
 
-This explicit resolver does not select a reference observational channel,
-pairing method, or time tolerance automatically.  It does not perform
-approximate physical-wavelength matching, infer tolerance from cadence, provide
-a built-in instrument catalogue, or integrate the result into calibration
-planning or normal light-curve fitting.  Those activation and validation steps
-remain separate future work.
+The discovery and activation contract adds immutable
+:class:`~pgmuvi.instrument_channel_calibration.InstrumentChannelPairingRuleCatalogueDiscoveryRequest`
+and
+:class:`~pgmuvi.instrument_channel_calibration.InstrumentChannelPairingRuleCatalogueActivationRequest`
+records.  Discovery requires one explicit source reference and the exact
+expected catalogue identifier, catalogue version, and schema version.  Ambient
+environment lookup, working-directory scans, package-resource fallback, and
+silent activation are prohibited.
+
+The side-effect-free
+:func:`~pgmuvi.instrument_channel_calibration.assess_instrument_channel_pairing_rule_catalogue_compatibility`
+callable checks exact identity, version, schema, catalogue validation, and
+member-rule validation.  It never activates the catalogue and never falls back
+to another source or version.  The public discovery and activation callables
+fail closed with :exc:`NotImplementedError` until explicit-source loading and
+activation are implemented.
+
+The explicit resolver and the discovery/activation contract do not select a
+reference observational channel, pairing method, or time tolerance
+automatically.  They do not perform approximate physical-wavelength matching,
+infer tolerance from cadence, provide populated built-in catalogue content, or
+integrate a catalogue into calibration planning or normal light-curve fitting.
 
 Dataset-level orchestration contract
 ------------------------------------

--- a/pgmuvi/instrument_channel_calibration.py
+++ b/pgmuvi/instrument_channel_calibration.py
@@ -39,6 +39,15 @@ INSTRUMENT_CHANNEL_PAIRING_RULE_SCHEMA_VERSION = (
 INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_SCHEMA_VERSION = (
     "pgmuvi-instrument-channel-pairing-rule-catalogue-v1"
 )
+INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_DISCOVERY_REQUEST_SCHEMA_VERSION = (
+    "pgmuvi-instrument-channel-pairing-rule-catalogue-discovery-request-v1"
+)
+INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_ACTIVATION_REQUEST_SCHEMA_VERSION = (
+    "pgmuvi-instrument-channel-pairing-rule-catalogue-activation-request-v1"
+)
+INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_COMPATIBILITY_SCHEMA_VERSION = (
+    "pgmuvi-instrument-channel-pairing-rule-catalogue-compatibility-v1"
+)
 INSTRUMENT_CHANNEL_PAIRING_RULE_REQUEST_SCHEMA_VERSION = (
     "pgmuvi-instrument-channel-pairing-rule-request-v1"
 )
@@ -76,6 +85,9 @@ __all__ = [
     "INSTRUMENT_CHANNEL_CALIBRATION_SCHEMA_VERSION",
     "INSTRUMENT_CHANNEL_CALIBRATION_TBD_MARKER",
     "INSTRUMENT_CHANNEL_CALIBRATION_UNCERTAINTY_SCHEMA_VERSION",
+    "INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_ACTIVATION_REQUEST_SCHEMA_VERSION",
+    "INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_COMPATIBILITY_SCHEMA_VERSION",
+    "INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_DISCOVERY_REQUEST_SCHEMA_VERSION",
     "INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_SCHEMA_VERSION",
     "INSTRUMENT_CHANNEL_PAIRING_RULE_REQUEST_SCHEMA_VERSION",
     "INSTRUMENT_CHANNEL_PAIRING_RULE_SCHEMA_VERSION",
@@ -106,15 +118,22 @@ __all__ = [
     "InstrumentChannelPairingMethod",
     "InstrumentChannelPairingRule",
     "InstrumentChannelPairingRuleCatalogue",
+    "InstrumentChannelPairingRuleCatalogueActivationRequest",
+    "InstrumentChannelPairingRuleCatalogueCompatibilityReport",
+    "InstrumentChannelPairingRuleCatalogueDiscoveryRequest",
+    "InstrumentChannelPairingRuleCatalogueSource",
     "InstrumentChannelPairingRuleRequest",
     "InstrumentChannelPairingRuleValidationStatus",
     "InstrumentChannelPairingToleranceProvenance",
     "SharedWavelengthChannelGroup",
+    "activate_instrument_channel_pairing_rule_catalogue",
     "apply_instrument_channel_calibration",
     "apply_instrument_channel_calibration_with_predictive_uncertainty",
     "assess_instrument_channel_calibration_requirement",
+    "assess_instrument_channel_pairing_rule_catalogue_compatibility",
     "construct_instrument_channel_pairing",
     "define_instrument_channel_calibration_plan",
+    "discover_instrument_channel_pairing_rule_catalogue",
     "estimate_scale_dependent_instrument_channel_calibration_coefficient_uncertainty",
     "execute_instrument_channel_calibration_plan",
     "fit_instrument_channel_calibration",
@@ -149,6 +168,12 @@ class InstrumentChannelPairingRuleValidationStatus(_StringEnum):
 
     DEFINED_NOT_VALIDATED = "defined_not_validated"
     SCIENTIFICALLY_VALIDATED = "scientifically_validated"
+
+
+class InstrumentChannelPairingRuleCatalogueSource(_StringEnum):
+    """Explicit source kind allowed by the discovery contract."""
+
+    EXPLICIT_PATH = "explicit_path"
 
 
 class InstrumentChannelPairingToleranceProvenance(_StringEnum):
@@ -1550,6 +1575,495 @@ class InstrumentChannelPairingRuleCatalogue:
             )
 
         return catalogue
+
+
+@dataclass(frozen=True)
+class InstrumentChannelPairingRuleCatalogueDiscoveryRequest:
+    """Fail-closed request to discover one explicitly identified catalogue.
+
+    The request records one caller-supplied source reference and the exact
+    catalogue identity, version, and schema expected at that source. It does
+    not permit environment-variable lookup, current-working-directory scans,
+    package-resource fallback, or any other ambient search.
+    """
+
+    source: InstrumentChannelPairingRuleCatalogueSource | str
+    source_reference: str
+    expected_catalogue_id: str
+    expected_catalogue_version: str
+    expected_catalogue_schema_version: str = (
+        INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_SCHEMA_VERSION
+    )
+    allow_ambient_search: bool = False
+    schema_version: str = (
+        INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_DISCOVERY_REQUEST_SCHEMA_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if self.schema_version != (
+            INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_DISCOVERY_REQUEST_SCHEMA_VERSION
+        ):
+            raise ValueError(
+                "Unsupported pairing-rule catalogue discovery-request schema "
+                f"version: {self.schema_version!r}."
+            )
+
+        source = self.source
+        if not isinstance(
+            source,
+            InstrumentChannelPairingRuleCatalogueSource,
+        ):
+            try:
+                source = InstrumentChannelPairingRuleCatalogueSource(
+                    str(source)
+                )
+            except ValueError as exc:
+                raise ValueError(
+                    "Unsupported pairing-rule catalogue discovery source: "
+                    f"{self.source!r}."
+                ) from exc
+
+        source_reference = (
+            InstrumentChannelPairingRule._normalize_required_text(
+                self.source_reference,
+                name="source_reference",
+            )
+        )
+        expected_catalogue_id = (
+            InstrumentChannelPairingRule._normalize_required_text(
+                self.expected_catalogue_id,
+                name="expected_catalogue_id",
+            )
+        )
+        expected_catalogue_version = (
+            InstrumentChannelPairingRule._normalize_required_text(
+                self.expected_catalogue_version,
+                name="expected_catalogue_version",
+            )
+        )
+        expected_catalogue_schema_version = (
+            InstrumentChannelPairingRule._normalize_required_text(
+                self.expected_catalogue_schema_version,
+                name="expected_catalogue_schema_version",
+            )
+        )
+
+        if not isinstance(self.allow_ambient_search, bool):
+            raise TypeError("allow_ambient_search must be a bool.")
+        if self.allow_ambient_search:
+            raise ValueError(
+                "Ambient pairing-rule catalogue search is not permitted. "
+                "Supply one explicit source reference."
+            )
+
+        object.__setattr__(self, "source", source)
+        object.__setattr__(
+            self,
+            "source_reference",
+            source_reference,
+        )
+        object.__setattr__(
+            self,
+            "expected_catalogue_id",
+            expected_catalogue_id,
+        )
+        object.__setattr__(
+            self,
+            "expected_catalogue_version",
+            expected_catalogue_version,
+        )
+        object.__setattr__(
+            self,
+            "expected_catalogue_schema_version",
+            expected_catalogue_schema_version,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a strict JSON-safe discovery-request representation."""
+
+        return {
+            "schema_version": self.schema_version,
+            "source": self.source.value,
+            "source_reference": self.source_reference,
+            "expected_catalogue_id": self.expected_catalogue_id,
+            "expected_catalogue_version": (
+                self.expected_catalogue_version
+            ),
+            "expected_catalogue_schema_version": (
+                self.expected_catalogue_schema_version
+            ),
+            "allow_ambient_search": self.allow_ambient_search,
+            "explicit_source_required": True,
+            "environment_lookup_permitted": False,
+            "working_directory_scan_permitted": False,
+            "packaged_catalogue_fallback_permitted": False,
+            "discovery_implemented": False,
+            "marker": INSTRUMENT_CHANNEL_CALIBRATION_TBD_MARKER,
+        }
+
+
+@dataclass(frozen=True)
+class InstrumentChannelPairingRuleCatalogueActivationRequest:
+    """Explicit validated-only catalogue activation request.
+
+    Activation requires the exact catalogue identity, version, and schema.
+    Unvalidated catalogue content, fallback to another catalogue, and normal
+    light-curve workflow integration are prohibited by this contract.
+    """
+
+    catalogue_id: str
+    catalogue_version: str
+    catalogue_schema_version: str
+    explicit_activation: bool = True
+    require_scientifically_validated: bool = True
+    allow_unvalidated_rules: bool = False
+    allow_catalogue_fallback: bool = False
+    workflow_integration_requested: bool = False
+    schema_version: str = (
+        INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_ACTIVATION_REQUEST_SCHEMA_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if self.schema_version != (
+            INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_ACTIVATION_REQUEST_SCHEMA_VERSION
+        ):
+            raise ValueError(
+                "Unsupported pairing-rule catalogue activation-request schema "
+                f"version: {self.schema_version!r}."
+            )
+
+        for name in (
+            "catalogue_id",
+            "catalogue_version",
+            "catalogue_schema_version",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                InstrumentChannelPairingRule._normalize_required_text(
+                    getattr(self, name),
+                    name=name,
+                ),
+            )
+
+        for name in (
+            "explicit_activation",
+            "require_scientifically_validated",
+            "allow_unvalidated_rules",
+            "allow_catalogue_fallback",
+            "workflow_integration_requested",
+        ):
+            if not isinstance(getattr(self, name), bool):
+                raise TypeError(f"{name} must be a bool.")
+
+        if not self.explicit_activation:
+            raise ValueError(
+                "Catalogue activation must be explicitly requested."
+            )
+        if not self.require_scientifically_validated:
+            raise ValueError(
+                "Catalogue activation requires scientific validation."
+            )
+        if self.allow_unvalidated_rules:
+            raise ValueError(
+                "Unvalidated pairing rules cannot be activated."
+            )
+        if self.allow_catalogue_fallback:
+            raise ValueError(
+                "Catalogue activation cannot fall back to another catalogue."
+            )
+        if self.workflow_integration_requested:
+            raise ValueError(
+                "Normal light-curve workflow integration is not available "
+                "through the catalogue activation contract."
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a strict JSON-safe activation-request representation."""
+
+        return {
+            "schema_version": self.schema_version,
+            "catalogue_id": self.catalogue_id,
+            "catalogue_version": self.catalogue_version,
+            "catalogue_schema_version": self.catalogue_schema_version,
+            "explicit_activation": self.explicit_activation,
+            "require_scientifically_validated": (
+                self.require_scientifically_validated
+            ),
+            "allow_unvalidated_rules": self.allow_unvalidated_rules,
+            "allow_catalogue_fallback": self.allow_catalogue_fallback,
+            "workflow_integration_requested": (
+                self.workflow_integration_requested
+            ),
+            "silent_activation_permitted": False,
+            "activation_implemented": False,
+            "marker": INSTRUMENT_CHANNEL_CALIBRATION_TBD_MARKER,
+        }
+
+
+@dataclass(frozen=True)
+class InstrumentChannelPairingRuleCatalogueCompatibilityReport:
+    """Side-effect-free compatibility result for explicit activation."""
+
+    request: InstrumentChannelPairingRuleCatalogueActivationRequest
+    observed_catalogue_id: str
+    observed_catalogue_version: str
+    observed_catalogue_schema_version: str
+    catalogue_id_matches: bool
+    catalogue_version_matches: bool
+    catalogue_schema_version_matches: bool
+    catalogue_scientifically_validated: bool
+    all_rules_scientifically_validated: bool
+    compatible: bool
+    reasons: tuple[str, ...]
+    activation_permitted: bool
+    schema_version: str = (
+        INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_COMPATIBILITY_SCHEMA_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if self.schema_version != (
+            INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_COMPATIBILITY_SCHEMA_VERSION
+        ):
+            raise ValueError(
+                "Unsupported pairing-rule catalogue compatibility schema "
+                f"version: {self.schema_version!r}."
+            )
+        if not isinstance(
+            self.request,
+            InstrumentChannelPairingRuleCatalogueActivationRequest,
+        ):
+            raise TypeError(
+                "request must be an "
+                "InstrumentChannelPairingRuleCatalogueActivationRequest."
+            )
+
+        for name in (
+            "observed_catalogue_id",
+            "observed_catalogue_version",
+            "observed_catalogue_schema_version",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                InstrumentChannelPairingRule._normalize_required_text(
+                    getattr(self, name),
+                    name=name,
+                ),
+            )
+
+        for name in (
+            "catalogue_id_matches",
+            "catalogue_version_matches",
+            "catalogue_schema_version_matches",
+            "catalogue_scientifically_validated",
+            "all_rules_scientifically_validated",
+            "compatible",
+            "activation_permitted",
+        ):
+            if not isinstance(getattr(self, name), bool):
+                raise TypeError(f"{name} must be a bool.")
+
+        reasons = tuple(
+            InstrumentChannelPairingRule._normalize_required_text(
+                reason,
+                name="compatibility reason",
+            )
+            for reason in self.reasons
+        )
+        if len(set(reasons)) != len(reasons):
+            raise ValueError("Compatibility reasons must be unique.")
+
+        expected_reasons = []
+        if not self.catalogue_id_matches:
+            expected_reasons.append("catalogue_id_mismatch")
+        if not self.catalogue_version_matches:
+            expected_reasons.append("catalogue_version_mismatch")
+        if not self.catalogue_schema_version_matches:
+            expected_reasons.append("catalogue_schema_version_mismatch")
+        if not self.catalogue_scientifically_validated:
+            expected_reasons.append(
+                "catalogue_not_scientifically_validated"
+            )
+        if not self.all_rules_scientifically_validated:
+            expected_reasons.append(
+                "member_rules_not_all_scientifically_validated"
+            )
+
+        expected_reasons_tuple = tuple(expected_reasons)
+        expected_compatible = not expected_reasons_tuple
+
+        if self.compatible != expected_compatible:
+            raise ValueError(
+                "compatible must agree with all exact compatibility checks."
+            )
+        if self.activation_permitted != expected_compatible:
+            raise ValueError(
+                "activation_permitted must agree with compatibility."
+            )
+        if reasons != expected_reasons_tuple:
+            raise ValueError(
+                "reasons must exactly describe the failed compatibility "
+                "checks in deterministic order."
+            )
+
+        object.__setattr__(self, "reasons", reasons)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a strict JSON-safe compatibility representation."""
+
+        return {
+            "schema_version": self.schema_version,
+            "request": self.request.to_dict(),
+            "observed_catalogue_id": self.observed_catalogue_id,
+            "observed_catalogue_version": (
+                self.observed_catalogue_version
+            ),
+            "observed_catalogue_schema_version": (
+                self.observed_catalogue_schema_version
+            ),
+            "catalogue_id_matches": self.catalogue_id_matches,
+            "catalogue_version_matches": (
+                self.catalogue_version_matches
+            ),
+            "catalogue_schema_version_matches": (
+                self.catalogue_schema_version_matches
+            ),
+            "catalogue_scientifically_validated": (
+                self.catalogue_scientifically_validated
+            ),
+            "all_rules_scientifically_validated": (
+                self.all_rules_scientifically_validated
+            ),
+            "compatible": self.compatible,
+            "reasons": list(self.reasons),
+            "activation_permitted": self.activation_permitted,
+            "compatibility_check_has_side_effects": False,
+            "catalogue_activated": False,
+            "workflow_integration_implemented": False,
+            "marker": INSTRUMENT_CHANNEL_CALIBRATION_TBD_MARKER,
+        }
+
+
+def assess_instrument_channel_pairing_rule_catalogue_compatibility(
+    request: InstrumentChannelPairingRuleCatalogueActivationRequest,
+    catalogue: InstrumentChannelPairingRuleCatalogue,
+) -> InstrumentChannelPairingRuleCatalogueCompatibilityReport:
+    """Assess exact activation compatibility without activating a catalogue."""
+
+    if not isinstance(
+        request,
+        InstrumentChannelPairingRuleCatalogueActivationRequest,
+    ):
+        raise TypeError(
+            "request must be an "
+            "InstrumentChannelPairingRuleCatalogueActivationRequest."
+        )
+    if not isinstance(
+        catalogue,
+        InstrumentChannelPairingRuleCatalogue,
+    ):
+        raise TypeError(
+            "catalogue must be an InstrumentChannelPairingRuleCatalogue."
+        )
+
+    catalogue_id_matches = (
+        catalogue.catalogue_id == request.catalogue_id
+    )
+    catalogue_version_matches = (
+        catalogue.catalogue_version == request.catalogue_version
+    )
+    catalogue_schema_version_matches = (
+        catalogue.schema_version == request.catalogue_schema_version
+    )
+    catalogue_scientifically_validated = (
+        catalogue.scientifically_validated
+    )
+    all_rules_scientifically_validated = (
+        catalogue.all_rules_scientifically_validated
+    )
+
+    reasons: list[str] = []
+    if not catalogue_id_matches:
+        reasons.append("catalogue_id_mismatch")
+    if not catalogue_version_matches:
+        reasons.append("catalogue_version_mismatch")
+    if not catalogue_schema_version_matches:
+        reasons.append("catalogue_schema_version_mismatch")
+    if not catalogue_scientifically_validated:
+        reasons.append("catalogue_not_scientifically_validated")
+    if not all_rules_scientifically_validated:
+        reasons.append("member_rules_not_all_scientifically_validated")
+
+    compatible = not reasons
+    return InstrumentChannelPairingRuleCatalogueCompatibilityReport(
+        request=request,
+        observed_catalogue_id=catalogue.catalogue_id,
+        observed_catalogue_version=catalogue.catalogue_version,
+        observed_catalogue_schema_version=catalogue.schema_version,
+        catalogue_id_matches=catalogue_id_matches,
+        catalogue_version_matches=catalogue_version_matches,
+        catalogue_schema_version_matches=(
+            catalogue_schema_version_matches
+        ),
+        catalogue_scientifically_validated=(
+            catalogue_scientifically_validated
+        ),
+        all_rules_scientifically_validated=(
+            all_rules_scientifically_validated
+        ),
+        compatible=compatible,
+        reasons=tuple(reasons),
+        activation_permitted=compatible,
+    )
+
+
+def discover_instrument_channel_pairing_rule_catalogue(
+    request: InstrumentChannelPairingRuleCatalogueDiscoveryRequest,
+) -> InstrumentChannelPairingRuleCatalogue:
+    """Fail closed until explicit-source catalogue discovery is implemented."""
+
+    if not isinstance(
+        request,
+        InstrumentChannelPairingRuleCatalogueDiscoveryRequest,
+    ):
+        raise TypeError(
+            "request must be an "
+            "InstrumentChannelPairingRuleCatalogueDiscoveryRequest."
+        )
+    raise NotImplementedError(
+        "Instrument-channel pairing-rule catalogue discovery is contract-only. "
+        "No explicit file loader, ambient search, environment lookup, package "
+        "resource lookup, or built-in populated catalogue is implemented."
+    )
+
+
+def activate_instrument_channel_pairing_rule_catalogue(
+    request: InstrumentChannelPairingRuleCatalogueActivationRequest,
+    catalogue: InstrumentChannelPairingRuleCatalogue,
+) -> InstrumentChannelPairingRuleCatalogue:
+    """Fail closed until catalogue activation is implemented."""
+
+    if not isinstance(
+        request,
+        InstrumentChannelPairingRuleCatalogueActivationRequest,
+    ):
+        raise TypeError(
+            "request must be an "
+            "InstrumentChannelPairingRuleCatalogueActivationRequest."
+        )
+    if not isinstance(
+        catalogue,
+        InstrumentChannelPairingRuleCatalogue,
+    ):
+        raise TypeError(
+            "catalogue must be an InstrumentChannelPairingRuleCatalogue."
+        )
+    raise NotImplementedError(
+        "Instrument-channel pairing-rule catalogue activation is contract-only. "
+        "No catalogue is activated or integrated into calibration planning or "
+        "normal light-curve fitting."
+    )
 
 
 @dataclass(frozen=True)

--- a/tests/test_instrument_channel_pairing_rule_catalogue_discovery_activation_contract.py
+++ b/tests/test_instrument_channel_pairing_rule_catalogue_discovery_activation_contract.py
@@ -1,0 +1,394 @@
+"""Pairing-rule catalogue discovery and activation contract tests."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError, replace
+import json
+from pathlib import Path
+import unittest
+
+from pgmuvi.instrument_channel_calibration import (
+    INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_ACTIVATION_REQUEST_SCHEMA_VERSION,
+    INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_COMPATIBILITY_SCHEMA_VERSION,
+    INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_DISCOVERY_REQUEST_SCHEMA_VERSION,
+    INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_SCHEMA_VERSION,
+    InstrumentChannelPairingMethod,
+    InstrumentChannelPairingRule,
+    InstrumentChannelPairingRuleCatalogue,
+    InstrumentChannelPairingRuleCatalogueActivationRequest,
+    InstrumentChannelPairingRuleCatalogueDiscoveryRequest,
+    InstrumentChannelPairingRuleCatalogueSource,
+    InstrumentChannelPairingRuleValidationStatus,
+    InstrumentChannelPairingToleranceProvenance,
+    activate_instrument_channel_pairing_rule_catalogue,
+    assess_instrument_channel_pairing_rule_catalogue_compatibility,
+    discover_instrument_channel_pairing_rule_catalogue,
+)
+
+
+class TestPairingRuleCatalogueDiscoveryActivationContract(
+    unittest.TestCase
+):
+    @staticmethod
+    def _validated_rule(**overrides):
+        values = {
+            "rule_id": "survey-a-to-survey-b-v1",
+            "reference_instrument": "Survey A",
+            "reference_channel": "SurveyA/V",
+            "channel_instrument": "Survey B",
+            "channel": "SurveyB/V",
+            "physical_wavelength": 0.55,
+            "pairing_method": (
+                InstrumentChannelPairingMethod
+                .NEAREST_WITHIN_TOLERANCE
+            ),
+            "time_unit": "day",
+            "maximum_time_separation": 0.25,
+            "tolerance_provenance": (
+                InstrumentChannelPairingToleranceProvenance
+                .EMPIRICAL_VALIDATION
+            ),
+            "validation_status": (
+                InstrumentChannelPairingRuleValidationStatus
+                .SCIENTIFICALLY_VALIDATED
+            ),
+            "evidence_reference": "validation:representative-lpv-v1",
+        }
+        values.update(overrides)
+        return InstrumentChannelPairingRule(**values)
+
+    @classmethod
+    def _catalogue(cls, **overrides):
+        values = {
+            "catalogue_id": "pgmuvi-pairing-rules",
+            "catalogue_version": "2026.1",
+            "provenance_reference": "catalogue:design-record-v1",
+            "rules": (cls._validated_rule(),),
+            "validation_status": (
+                InstrumentChannelPairingRuleValidationStatus
+                .SCIENTIFICALLY_VALIDATED
+            ),
+            "evidence_reference": "catalogue:validation-report-v1",
+        }
+        values.update(overrides)
+        return InstrumentChannelPairingRuleCatalogue(**values)
+
+    @staticmethod
+    def _discovery_request(**overrides):
+        values = {
+            "source": (
+                InstrumentChannelPairingRuleCatalogueSource
+                .EXPLICIT_PATH
+            ),
+            "source_reference": "/science/catalogues/pairing-rules.json",
+            "expected_catalogue_id": "pgmuvi-pairing-rules",
+            "expected_catalogue_version": "2026.1",
+        }
+        values.update(overrides)
+        return InstrumentChannelPairingRuleCatalogueDiscoveryRequest(
+            **values
+        )
+
+    @staticmethod
+    def _activation_request(**overrides):
+        values = {
+            "catalogue_id": "pgmuvi-pairing-rules",
+            "catalogue_version": "2026.1",
+            "catalogue_schema_version": (
+                INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_SCHEMA_VERSION
+            ),
+        }
+        values.update(overrides)
+        return InstrumentChannelPairingRuleCatalogueActivationRequest(
+            **values
+        )
+
+    def test_discovery_request_is_explicit_immutable_and_json_safe(self):
+        request = self._discovery_request()
+
+        self.assertEqual(
+            request.schema_version,
+            INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_DISCOVERY_REQUEST_SCHEMA_VERSION,
+        )
+        self.assertEqual(
+            request.source,
+            InstrumentChannelPairingRuleCatalogueSource.EXPLICIT_PATH,
+        )
+
+        payload = request.to_dict()
+        json.dumps(payload, allow_nan=False)
+
+        self.assertTrue(payload["explicit_source_required"])
+        self.assertFalse(payload["allow_ambient_search"])
+        self.assertFalse(payload["environment_lookup_permitted"])
+        self.assertFalse(payload["working_directory_scan_permitted"])
+        self.assertFalse(
+            payload["packaged_catalogue_fallback_permitted"]
+        )
+        self.assertFalse(payload["discovery_implemented"])
+
+        with self.assertRaises(FrozenInstanceError):
+            request.source_reference = "replacement.json"
+
+    def test_discovery_request_rejects_ambient_or_ambiguous_sources(self):
+        with self.assertRaisesRegex(ValueError, "Ambient"):
+            self._discovery_request(allow_ambient_search=True)
+
+        with self.assertRaisesRegex(ValueError, "Unsupported.*source"):
+            self._discovery_request(source="environment")
+
+        with self.assertRaisesRegex(ValueError, "non-empty"):
+            self._discovery_request(source_reference="  ")
+
+        with self.assertRaises(TypeError):
+            self._discovery_request(allow_ambient_search=1)
+
+    def test_activation_request_is_explicit_validated_only_and_json_safe(self):
+        request = self._activation_request()
+
+        self.assertEqual(
+            request.schema_version,
+            INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_ACTIVATION_REQUEST_SCHEMA_VERSION,
+        )
+
+        payload = request.to_dict()
+        json.dumps(payload, allow_nan=False)
+
+        self.assertTrue(payload["explicit_activation"])
+        self.assertTrue(payload["require_scientifically_validated"])
+        self.assertFalse(payload["allow_unvalidated_rules"])
+        self.assertFalse(payload["allow_catalogue_fallback"])
+        self.assertFalse(payload["workflow_integration_requested"])
+        self.assertFalse(payload["silent_activation_permitted"])
+        self.assertFalse(payload["activation_implemented"])
+
+        with self.assertRaises(FrozenInstanceError):
+            request.catalogue_version = "replacement"
+
+    def test_activation_request_rejects_unsafe_policy_relaxations(self):
+        cases = (
+            (
+                {"explicit_activation": False},
+                "explicitly requested",
+            ),
+            (
+                {"require_scientifically_validated": False},
+                "requires scientific validation",
+            ),
+            (
+                {"allow_unvalidated_rules": True},
+                "cannot be activated",
+            ),
+            (
+                {"allow_catalogue_fallback": True},
+                "cannot fall back",
+            ),
+            (
+                {"workflow_integration_requested": True},
+                "workflow integration is not available",
+            ),
+        )
+
+        for updates, message in cases:
+            with self.subTest(updates=updates):
+                with self.assertRaisesRegex(ValueError, message):
+                    self._activation_request(**updates)
+
+    def test_exact_compatibility_is_json_safe_and_side_effect_free(self):
+        request = self._activation_request()
+        catalogue = self._catalogue()
+
+        report = (
+            assess_instrument_channel_pairing_rule_catalogue_compatibility(
+                request,
+                catalogue,
+            )
+        )
+        payload = report.to_dict()
+        json.dumps(payload, allow_nan=False)
+
+        self.assertEqual(
+            report.schema_version,
+            INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_COMPATIBILITY_SCHEMA_VERSION,
+        )
+        self.assertTrue(report.compatible)
+        self.assertTrue(report.activation_permitted)
+        self.assertEqual(report.reasons, ())
+        self.assertTrue(report.catalogue_id_matches)
+        self.assertTrue(report.catalogue_version_matches)
+        self.assertTrue(report.catalogue_schema_version_matches)
+        self.assertTrue(report.catalogue_scientifically_validated)
+        self.assertTrue(report.all_rules_scientifically_validated)
+        self.assertFalse(
+            payload["compatibility_check_has_side_effects"]
+        )
+        self.assertFalse(payload["catalogue_activated"])
+        self.assertFalse(payload["workflow_integration_implemented"])
+
+    def test_compatibility_rejects_identity_version_and_schema_mismatch(self):
+        cases = (
+            (
+                {"catalogue_id": "different-catalogue"},
+                "catalogue_id_mismatch",
+            ),
+            (
+                {"catalogue_version": "2027.1"},
+                "catalogue_version_mismatch",
+            ),
+            (
+                {"catalogue_schema_version": "unsupported-schema"},
+                "catalogue_schema_version_mismatch",
+            ),
+        )
+        catalogue = self._catalogue()
+
+        for updates, expected_reason in cases:
+            with self.subTest(updates=updates):
+                report = (
+                    assess_instrument_channel_pairing_rule_catalogue_compatibility(
+                        self._activation_request(**updates),
+                        catalogue,
+                    )
+                )
+                self.assertFalse(report.compatible)
+                self.assertFalse(report.activation_permitted)
+                self.assertIn(expected_reason, report.reasons)
+
+    def test_compatibility_rejects_unvalidated_catalogue_or_members(self):
+        unvalidated_catalogue = self._catalogue(
+            validation_status=(
+                InstrumentChannelPairingRuleValidationStatus
+                .DEFINED_NOT_VALIDATED
+            ),
+            evidence_reference=None,
+        )
+        catalogue_report = (
+            assess_instrument_channel_pairing_rule_catalogue_compatibility(
+                self._activation_request(),
+                unvalidated_catalogue,
+            )
+        )
+        self.assertFalse(catalogue_report.compatible)
+        self.assertIn(
+            "catalogue_not_scientifically_validated",
+            catalogue_report.reasons,
+        )
+
+        unvalidated_rule = self._validated_rule(
+            validation_status=(
+                InstrumentChannelPairingRuleValidationStatus
+                .DEFINED_NOT_VALIDATED
+            ),
+            evidence_reference=None,
+        )
+        unvalidated_members = self._catalogue(
+            rules=(unvalidated_rule,),
+            validation_status=(
+                InstrumentChannelPairingRuleValidationStatus
+                .DEFINED_NOT_VALIDATED
+            ),
+            evidence_reference=None,
+        )
+        member_report = (
+            assess_instrument_channel_pairing_rule_catalogue_compatibility(
+                self._activation_request(),
+                unvalidated_members,
+            )
+        )
+        self.assertFalse(member_report.compatible)
+        self.assertIn(
+            "member_rules_not_all_scientifically_validated",
+            member_report.reasons,
+        )
+
+    def test_compatibility_report_rejects_forged_reason_codes(self):
+        compatible_report = (
+            assess_instrument_channel_pairing_rule_catalogue_compatibility(
+                self._activation_request(),
+                self._catalogue(),
+            )
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "reasons must exactly describe",
+        ):
+            replace(
+                compatible_report,
+                reasons=("arbitrary_reason",),
+            )
+
+        mismatch_report = (
+            assess_instrument_channel_pairing_rule_catalogue_compatibility(
+                self._activation_request(
+                    catalogue_version="different-version"
+                ),
+                self._catalogue(),
+            )
+        )
+        with self.assertRaisesRegex(
+            ValueError,
+            "reasons must exactly describe",
+        ):
+            replace(
+                mismatch_report,
+                reasons=("catalogue_id_mismatch",),
+            )
+
+    def test_discovery_and_activation_callables_fail_closed(self):
+        discovery_request = self._discovery_request()
+        activation_request = self._activation_request()
+        catalogue = self._catalogue()
+
+        with self.assertRaisesRegex(
+            NotImplementedError,
+            "discovery is contract-only",
+        ):
+            discover_instrument_channel_pairing_rule_catalogue(
+                discovery_request
+            )
+
+        with self.assertRaisesRegex(
+            NotImplementedError,
+            "activation is contract-only",
+        ):
+            activate_instrument_channel_pairing_rule_catalogue(
+                activation_request,
+                catalogue,
+            )
+
+    def test_public_documentation_records_fail_closed_boundary(self):
+        repo = Path(__file__).resolve().parents[1]
+        api_text = (
+            repo
+            / "docs/source/pgmuvi.instrument_channel_calibration.rst"
+        ).read_text(encoding="utf-8")
+        future_text = (
+            repo / "docs/source/future_work.rst"
+        ).read_text(encoding="utf-8")
+
+        for token in (
+            "InstrumentChannelPairingRuleCatalogueDiscoveryRequest",
+            "InstrumentChannelPairingRuleCatalogueActivationRequest",
+            "assess_instrument_channel_pairing_rule_catalogue_compatibility",
+            "one explicit source reference",
+            "Ambient",
+            "silent activation",
+            "NotImplementedError",
+            "never falls back",
+        ):
+            self.assertIn(token, api_text)
+
+        for token in (
+            "discovery and activation contract",
+            "exact compatibility assessment",
+            "fail-closed public",
+            "NotImplementedError",
+            "populated scientifically",
+            "TBD[instrument-channel-calibration]",
+        ):
+            self.assertIn(token, future_text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Define the public contract for explicit instrument-specific pairing-rule catalogue discovery, compatibility assessment, and activation.

This pull request:

- adds immutable discovery and activation request records;
- requires one caller-supplied catalogue source reference;
- prohibits ambient environment lookup, current-working-directory scans, package-resource fallback, and silent activation;
- adds exact catalogue identity, version, schema, and scientific-validation compatibility assessment;
- records deterministic incompatibility reason codes;
- rejects forged or inconsistent compatibility reports;
- exposes public discovery and activation callables that fail closed with `NotImplementedError`;
- preserves the existing explicit caller-supplied catalogue resolver;
- does not add populated scientific catalogue content;
- does not activate a catalogue or integrate calibration into normal light-curve fitting.

## Scientific and API boundaries

The contract preserves the distinction between:

- **observational channel**: instrument/filter/data-stream identity; and
- **physical wavelength**: the numeric wavelength coordinate.

A catalogue may be compatible only when:

- catalogue identifier matches exactly;
- catalogue version matches exactly;
- catalogue schema version matches exactly;
- the catalogue is scientifically validated; and
- every member rule is scientifically validated.

Compatibility assessment is side-effect free. Loading a catalogue does not imply activation, and no process-global or implicit activation mechanism is introduced.

`TBD[instrument-channel-calibration]` remains open. Explicit-source loading, populated scientifically validated rule content, activation implementation, normal workflow integration, and representative calibration validation remain future work.

## Files

- `pgmuvi/instrument_channel_calibration.py`
- `tests/test_instrument_channel_pairing_rule_catalogue_discovery_activation_contract.py`
- `docs/source/pgmuvi.instrument_channel_calibration.rst`
- `docs/source/future_work.rst`

## Validation

- 171 instrument-channel regression tests passed.
- 2,727 full repository tests passed.
- Ruff passed for `./pgmuvi`.
- Strict Sphinx documentation build passed.
- TBD marker audit passed.
- Public export and fail-closed behavior smoke checks passed.
- `git diff --check` passed.
- The committed change contains exactly the four intended files.
