### PR TITLE
Implement explicit calibration catalogue loading and local activation

### DIFF
--- a/docs/source/future_work.rst
+++ b/docs/source/future_work.rst
@@ -144,16 +144,19 @@ Wavelength-model extensions
     deserialization.  The caller-supplied catalogue can participate only at the
     existing explicit resolver boundary.
 
-    The discovery and activation contract now defines explicit-source requests,
-    exact compatibility assessment, validated-only activation policy, and
-    fail-closed public callables.  This contract does not close
-    ``TBD[instrument-channel-calibration]``.  The discovery and activation
-    callables intentionally raise ``NotImplementedError`` until explicit-source
-    loading and catalogue activation are implemented.
+    The explicit-source loading and local activation implementation is now
+    available.  The
+    loader requires one caller-supplied path, strict UTF-8 JSON, strict semantic
+    deserialization, exact compatibility, and distinct source-access, parse,
+    semantic-validation, and compatibility failures.  It returns an
+    immutable loaded-catalogue snapshot with resolved-source and content-digest
+    provenance.  Explicit activation returns a separate
+    immutable local activation snapshot without process-global state or
+    implicit workflow integration.
 
-    A populated scientifically validated rule catalogue, normal light-curve
-    workflow integration, and representative calibration validation remain
-    future work.
+    This does not close ``TBD[instrument-channel-calibration]``.  A populated scientifically validated rule catalogue remains future work, together with
+    normal light-curve workflow integration and representative calibration
+    validation.
 
 **TBD[multi-periodic-wavelength-models]**
     Add a documented and validated multi-periodic workflow beyond the current

--- a/docs/source/pgmuvi.instrument_channel_calibration.rst
+++ b/docs/source/pgmuvi.instrument_channel_calibration.rst
@@ -74,28 +74,47 @@ upgrade a member rule that is not itself scientifically validated.
 
 The catalogue can be passed explicitly to the existing resolver because it
 iterates only over its recorded member rules.  Strict serialization and
-deserialization preserve catalogue and rule provenance.  The automatic discovery
-and automatic activation mechanisms remain unavailable unless and until the
-explicit fail-closed callables are implemented.
+deserialization preserve catalogue and rule provenance.
 
-The discovery and activation contract adds immutable
+The discovery and activation API uses immutable
 :class:`~pgmuvi.instrument_channel_calibration.InstrumentChannelPairingRuleCatalogueDiscoveryRequest`
 and
 :class:`~pgmuvi.instrument_channel_calibration.InstrumentChannelPairingRuleCatalogueActivationRequest`
 records.  Discovery requires one explicit source reference and the exact
 expected catalogue identifier, catalogue version, and schema version.  Ambient
 environment lookup, working-directory scans, package-resource fallback, and
-silent activation are prohibited.
+silent activation remain prohibited.
 
-The side-effect-free
-:func:`~pgmuvi.instrument_channel_calibration.assess_instrument_channel_pairing_rule_catalogue_compatibility`
-callable checks exact identity, version, schema, catalogue validation, and
-member-rule validation.  It never activates the catalogue and never falls back
-to another source or version.  The public discovery and activation callables
-fail closed with :exc:`NotImplementedError` until explicit-source loading and
-activation are implemented.
+:func:`~pgmuvi.instrument_channel_calibration.discover_instrument_channel_pairing_rule_catalogue`
+now implements one explicit-path loader.  It reads source bytes directly,
+requires strict UTF-8 JSON, rejects malformed input, duplicate object keys, and
+non-finite JSON constants, and then invokes strict catalogue deserialization.
+Dedicated source-access, parse, semantic-validation, and compatibility error
+types preserve the failure boundary without fallback or repair.
 
-The explicit resolver and the discovery/activation contract do not select a
+Successful loading returns an immutable
+:class:`~pgmuvi.instrument_channel_calibration.InstrumentChannelPairingRuleCatalogueLoadedSnapshot`
+containing the caller request, resolved source path, byte size, SHA-256 digest,
+strict catalogue, and exact compatibility report.  Loading does not activate
+the catalogue.
+
+:func:`~pgmuvi.instrument_channel_calibration.activate_instrument_channel_pairing_rule_catalogue`
+accepts only a loaded snapshot and an explicit activation request.  It rechecks
+exact identity, version, schema, catalogue validation, and member-rule
+validation, then returns an immutable
+:class:`~pgmuvi.instrument_channel_calibration.InstrumentChannelPairingRuleCatalogueActivationSnapshot`.
+The snapshot is local-only: activation does not mutate process-global state,
+install an ambient registry, or enable workflow integration.  Compatibility
+assessment remains side-effect free and never falls back to another source or
+version.
+
+The automatic discovery of catalogues across ambient or multiple candidate
+sources remains unavailable, and automatic activation remains prohibited.  The
+implementation
+loads only the one caller-supplied explicit path and returns immutable local
+snapshots.  It never installs a catalogue into process-global state.
+
+The explicit resolver and loading/activation implementation do not select a
 reference observational channel, pairing method, or time tolerance
 automatically.  They do not perform approximate physical-wavelength matching,
 infer tolerance from cadence, provide populated built-in catalogue content, or

--- a/pgmuvi/instrument_channel_calibration.py
+++ b/pgmuvi/instrument_channel_calibration.py
@@ -48,6 +48,12 @@ INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_ACTIVATION_REQUEST_SCHEMA_VERSION = (
 INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_COMPATIBILITY_SCHEMA_VERSION = (
     "pgmuvi-instrument-channel-pairing-rule-catalogue-compatibility-v1"
 )
+INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_LOADED_SNAPSHOT_SCHEMA_VERSION = (
+    "pgmuvi-instrument-channel-pairing-rule-catalogue-loaded-snapshot-v1"
+)
+INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_ACTIVATION_SNAPSHOT_SCHEMA_VERSION = (
+    "pgmuvi-instrument-channel-pairing-rule-catalogue-activation-snapshot-v1"
+)
 INSTRUMENT_CHANNEL_PAIRING_RULE_REQUEST_SCHEMA_VERSION = (
     "pgmuvi-instrument-channel-pairing-rule-request-v1"
 )
@@ -86,8 +92,10 @@ __all__ = [
     "INSTRUMENT_CHANNEL_CALIBRATION_TBD_MARKER",
     "INSTRUMENT_CHANNEL_CALIBRATION_UNCERTAINTY_SCHEMA_VERSION",
     "INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_ACTIVATION_REQUEST_SCHEMA_VERSION",
+    "INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_ACTIVATION_SNAPSHOT_SCHEMA_VERSION",
     "INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_COMPATIBILITY_SCHEMA_VERSION",
     "INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_DISCOVERY_REQUEST_SCHEMA_VERSION",
+    "INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_LOADED_SNAPSHOT_SCHEMA_VERSION",
     "INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_SCHEMA_VERSION",
     "INSTRUMENT_CHANNEL_PAIRING_RULE_REQUEST_SCHEMA_VERSION",
     "INSTRUMENT_CHANNEL_PAIRING_RULE_SCHEMA_VERSION",
@@ -119,9 +127,16 @@ __all__ = [
     "InstrumentChannelPairingRule",
     "InstrumentChannelPairingRuleCatalogue",
     "InstrumentChannelPairingRuleCatalogueActivationRequest",
+    "InstrumentChannelPairingRuleCatalogueActivationSnapshot",
+    "InstrumentChannelPairingRuleCatalogueCompatibilityError",
     "InstrumentChannelPairingRuleCatalogueCompatibilityReport",
     "InstrumentChannelPairingRuleCatalogueDiscoveryRequest",
+    "InstrumentChannelPairingRuleCatalogueError",
+    "InstrumentChannelPairingRuleCatalogueLoadedSnapshot",
+    "InstrumentChannelPairingRuleCatalogueParseError",
     "InstrumentChannelPairingRuleCatalogueSource",
+    "InstrumentChannelPairingRuleCatalogueSourceAccessError",
+    "InstrumentChannelPairingRuleCatalogueValidationError",
     "InstrumentChannelPairingRuleRequest",
     "InstrumentChannelPairingRuleValidationStatus",
     "InstrumentChannelPairingToleranceProvenance",
@@ -174,6 +189,43 @@ class InstrumentChannelPairingRuleCatalogueSource(_StringEnum):
     """Explicit source kind allowed by the discovery contract."""
 
     EXPLICIT_PATH = "explicit_path"
+
+
+class InstrumentChannelPairingRuleCatalogueError(RuntimeError):
+    """Base error for explicit pairing-rule catalogue loading or activation."""
+
+
+class InstrumentChannelPairingRuleCatalogueSourceAccessError(
+    InstrumentChannelPairingRuleCatalogueError
+):
+    """Raised when the caller-supplied catalogue source cannot be accessed."""
+
+
+class InstrumentChannelPairingRuleCatalogueParseError(
+    InstrumentChannelPairingRuleCatalogueError
+):
+    """Raised when source bytes are not strict UTF-8 JSON."""
+
+
+class InstrumentChannelPairingRuleCatalogueValidationError(
+    InstrumentChannelPairingRuleCatalogueError
+):
+    """Raised when parsed JSON violates the strict catalogue contract."""
+
+
+class InstrumentChannelPairingRuleCatalogueCompatibilityError(
+    InstrumentChannelPairingRuleCatalogueError
+):
+    """Raised when a valid catalogue is not exactly activation-compatible."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        reasons: tuple[str, ...] = (),
+    ) -> None:
+        super().__init__(message)
+        self.reasons = tuple(reasons)
 
 
 class InstrumentChannelPairingToleranceProvenance(_StringEnum):
@@ -1697,7 +1749,7 @@ class InstrumentChannelPairingRuleCatalogueDiscoveryRequest:
             "environment_lookup_permitted": False,
             "working_directory_scan_permitted": False,
             "packaged_catalogue_fallback_permitted": False,
-            "discovery_implemented": False,
+            "discovery_implemented": True,
             "marker": INSTRUMENT_CHANNEL_CALIBRATION_TBD_MARKER,
         }
 
@@ -1796,7 +1848,7 @@ class InstrumentChannelPairingRuleCatalogueActivationRequest:
                 self.workflow_integration_requested
             ),
             "silent_activation_permitted": False,
-            "activation_implemented": False,
+            "activation_implemented": True,
             "marker": INSTRUMENT_CHANNEL_CALIBRATION_TBD_MARKER,
         }
 
@@ -2018,10 +2070,296 @@ def assess_instrument_channel_pairing_rule_catalogue_compatibility(
     )
 
 
+@dataclass(frozen=True)
+class InstrumentChannelPairingRuleCatalogueLoadedSnapshot:
+    """Immutable result of loading one explicit catalogue source.
+
+    The snapshot preserves the caller request, strict catalogue object,
+    resolved source identity, byte size, content digest, and exact
+    compatibility report. Loading does not activate the catalogue.
+    """
+
+    discovery_request: InstrumentChannelPairingRuleCatalogueDiscoveryRequest
+    catalogue: InstrumentChannelPairingRuleCatalogue
+    resolved_source_reference: str
+    source_size_bytes: int
+    source_sha256: str
+    compatibility_report: (
+        InstrumentChannelPairingRuleCatalogueCompatibilityReport
+    )
+    schema_version: str = (
+        INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_LOADED_SNAPSHOT_SCHEMA_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if self.schema_version != (
+            INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_LOADED_SNAPSHOT_SCHEMA_VERSION
+        ):
+            raise ValueError(
+                "Unsupported loaded pairing-rule catalogue snapshot schema "
+                f"version: {self.schema_version!r}."
+            )
+        if not isinstance(
+            self.discovery_request,
+            InstrumentChannelPairingRuleCatalogueDiscoveryRequest,
+        ):
+            raise TypeError(
+                "discovery_request must be an "
+                "InstrumentChannelPairingRuleCatalogueDiscoveryRequest."
+            )
+        if not isinstance(
+            self.catalogue,
+            InstrumentChannelPairingRuleCatalogue,
+        ):
+            raise TypeError(
+                "catalogue must be an InstrumentChannelPairingRuleCatalogue."
+            )
+        if not isinstance(
+            self.compatibility_report,
+            InstrumentChannelPairingRuleCatalogueCompatibilityReport,
+        ):
+            raise TypeError(
+                "compatibility_report must be an "
+                "InstrumentChannelPairingRuleCatalogueCompatibilityReport."
+            )
+
+        resolved_source_reference = (
+            InstrumentChannelPairingRule._normalize_required_text(
+                self.resolved_source_reference,
+                name="resolved_source_reference",
+            )
+        )
+        if isinstance(self.source_size_bytes, (bool, np.bool_)):
+            raise TypeError("source_size_bytes must be an integer.")
+        source_size_bytes = int(self.source_size_bytes)
+        if source_size_bytes < 0:
+            raise ValueError("source_size_bytes must be non-negative.")
+
+        source_sha256 = (
+            InstrumentChannelPairingRule._normalize_required_text(
+                self.source_sha256,
+                name="source_sha256",
+            )
+        )
+        if (
+            len(source_sha256) != 64
+            or source_sha256 != source_sha256.lower()
+            or any(
+                character not in "0123456789abcdef"
+                for character in source_sha256
+            )
+        ):
+            raise ValueError(
+                "source_sha256 must be a lowercase 64-character hexadecimal "
+                "SHA-256 digest."
+            )
+
+        expected_request = (
+            InstrumentChannelPairingRuleCatalogueActivationRequest(
+                catalogue_id=(
+                    self.discovery_request.expected_catalogue_id
+                ),
+                catalogue_version=(
+                    self.discovery_request.expected_catalogue_version
+                ),
+                catalogue_schema_version=(
+                    self.discovery_request.expected_catalogue_schema_version
+                ),
+            )
+        )
+        if self.compatibility_report.request != expected_request:
+            raise ValueError(
+                "compatibility_report request must exactly match the "
+                "discovery request expectations."
+            )
+        if (
+            self.compatibility_report.observed_catalogue_id
+            != self.catalogue.catalogue_id
+            or self.compatibility_report.observed_catalogue_version
+            != self.catalogue.catalogue_version
+            or self.compatibility_report.observed_catalogue_schema_version
+            != self.catalogue.schema_version
+        ):
+            raise ValueError(
+                "compatibility_report observed identity must match catalogue."
+            )
+        if (
+            not self.compatibility_report.compatible
+            or not self.compatibility_report.activation_permitted
+        ):
+            raise ValueError(
+                "A loaded snapshot requires an exactly compatible catalogue."
+            )
+
+        object.__setattr__(
+            self,
+            "resolved_source_reference",
+            resolved_source_reference,
+        )
+        object.__setattr__(
+            self,
+            "source_size_bytes",
+            source_size_bytes,
+        )
+        object.__setattr__(self, "source_sha256", source_sha256)
+
+    @property
+    def source_reference(self) -> str:
+        """Return the caller-supplied explicit source reference."""
+
+        return self.discovery_request.source_reference
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a strict JSON-safe loaded-snapshot representation."""
+
+        return {
+            "schema_version": self.schema_version,
+            "discovery_request": self.discovery_request.to_dict(),
+            "source_reference": self.source_reference,
+            "resolved_source_reference": self.resolved_source_reference,
+            "source_size_bytes": self.source_size_bytes,
+            "source_sha256": self.source_sha256,
+            "catalogue": self.catalogue.to_dict(),
+            "compatibility_report": self.compatibility_report.to_dict(),
+            "catalogue_loaded": True,
+            "catalogue_activated": False,
+            "process_global_state_modified": False,
+            "workflow_integration_active": False,
+            "marker": INSTRUMENT_CHANNEL_CALIBRATION_TBD_MARKER,
+        }
+
+
+@dataclass(frozen=True)
+class InstrumentChannelPairingRuleCatalogueActivationSnapshot:
+    """Immutable local activation result with no ambient state mutation."""
+
+    activation_request: InstrumentChannelPairingRuleCatalogueActivationRequest
+    loaded_snapshot: InstrumentChannelPairingRuleCatalogueLoadedSnapshot
+    compatibility_report: (
+        InstrumentChannelPairingRuleCatalogueCompatibilityReport
+    )
+    local_only: bool = True
+    process_global_state_modified: bool = False
+    workflow_integration_active: bool = False
+    schema_version: str = (
+        INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_ACTIVATION_SNAPSHOT_SCHEMA_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if self.schema_version != (
+            INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_ACTIVATION_SNAPSHOT_SCHEMA_VERSION
+        ):
+            raise ValueError(
+                "Unsupported pairing-rule catalogue activation-snapshot "
+                f"schema version: {self.schema_version!r}."
+            )
+        if not isinstance(
+            self.activation_request,
+            InstrumentChannelPairingRuleCatalogueActivationRequest,
+        ):
+            raise TypeError(
+                "activation_request must be an "
+                "InstrumentChannelPairingRuleCatalogueActivationRequest."
+            )
+        if not isinstance(
+            self.loaded_snapshot,
+            InstrumentChannelPairingRuleCatalogueLoadedSnapshot,
+        ):
+            raise TypeError(
+                "loaded_snapshot must be an "
+                "InstrumentChannelPairingRuleCatalogueLoadedSnapshot."
+            )
+        if not isinstance(
+            self.compatibility_report,
+            InstrumentChannelPairingRuleCatalogueCompatibilityReport,
+        ):
+            raise TypeError(
+                "compatibility_report must be an "
+                "InstrumentChannelPairingRuleCatalogueCompatibilityReport."
+            )
+
+        for name in (
+            "local_only",
+            "process_global_state_modified",
+            "workflow_integration_active",
+        ):
+            if not isinstance(getattr(self, name), bool):
+                raise TypeError(f"{name} must be a bool.")
+
+        if not self.local_only:
+            raise ValueError("Catalogue activation must remain local-only.")
+        if self.process_global_state_modified:
+            raise ValueError(
+                "Catalogue activation cannot modify process-global state."
+            )
+        if self.workflow_integration_active:
+            raise ValueError(
+                "Catalogue activation cannot implicitly enable workflow "
+                "integration."
+            )
+        if self.compatibility_report.request != self.activation_request:
+            raise ValueError(
+                "compatibility_report request must match activation_request."
+            )
+        if (
+            self.compatibility_report.observed_catalogue_id
+            != self.catalogue.catalogue_id
+            or self.compatibility_report.observed_catalogue_version
+            != self.catalogue.catalogue_version
+            or self.compatibility_report.observed_catalogue_schema_version
+            != self.catalogue.schema_version
+        ):
+            raise ValueError(
+                "compatibility_report observed identity must match catalogue."
+            )
+        if (
+            not self.compatibility_report.compatible
+            or not self.compatibility_report.activation_permitted
+        ):
+            raise ValueError(
+                "An activation snapshot requires exact compatibility."
+            )
+
+    @property
+    def catalogue(self) -> InstrumentChannelPairingRuleCatalogue:
+        """Return the immutable catalogue carried by the loaded snapshot."""
+
+        return self.loaded_snapshot.catalogue
+
+    @property
+    def source_reference(self) -> str:
+        """Return the caller-supplied explicit source reference."""
+
+        return self.loaded_snapshot.source_reference
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a strict JSON-safe local-activation representation."""
+
+        return {
+            "schema_version": self.schema_version,
+            "activation_request": self.activation_request.to_dict(),
+            "loaded_snapshot": self.loaded_snapshot.to_dict(),
+            "compatibility_report": self.compatibility_report.to_dict(),
+            "catalogue_id": self.catalogue.catalogue_id,
+            "catalogue_version": self.catalogue.catalogue_version,
+            "catalogue_schema_version": self.catalogue.schema_version,
+            "source_reference": self.source_reference,
+            "local_only": self.local_only,
+            "process_global_state_modified": (
+                self.process_global_state_modified
+            ),
+            "workflow_integration_active": (
+                self.workflow_integration_active
+            ),
+            "catalogue_activated": True,
+            "marker": INSTRUMENT_CHANNEL_CALIBRATION_TBD_MARKER,
+        }
+
+
 def discover_instrument_channel_pairing_rule_catalogue(
     request: InstrumentChannelPairingRuleCatalogueDiscoveryRequest,
-) -> InstrumentChannelPairingRuleCatalogue:
-    """Fail closed until explicit-source catalogue discovery is implemented."""
+) -> InstrumentChannelPairingRuleCatalogueLoadedSnapshot:
+    """Load one explicit UTF-8 JSON catalogue and enforce compatibility."""
 
     if not isinstance(
         request,
@@ -2031,18 +2369,128 @@ def discover_instrument_channel_pairing_rule_catalogue(
             "request must be an "
             "InstrumentChannelPairingRuleCatalogueDiscoveryRequest."
         )
-    raise NotImplementedError(
-        "Instrument-channel pairing-rule catalogue discovery is contract-only. "
-        "No explicit file loader, ambient search, environment lookup, package "
-        "resource lookup, or built-in populated catalogue is implemented."
+    if (
+        request.source
+        is not InstrumentChannelPairingRuleCatalogueSource.EXPLICIT_PATH
+    ):
+        raise InstrumentChannelPairingRuleCatalogueSourceAccessError(
+            "Only an explicit catalogue path is implemented."
+        )
+
+    import hashlib
+    import json
+    from pathlib import Path
+
+    supplied_path = Path(request.source_reference).expanduser()
+    try:
+        resolved_path = supplied_path.resolve(strict=True)
+    except (OSError, RuntimeError) as exc:
+        raise InstrumentChannelPairingRuleCatalogueSourceAccessError(
+            "Cannot resolve explicit pairing-rule catalogue source "
+            f"{request.source_reference!r}: {exc}"
+        ) from exc
+
+    if not resolved_path.is_file():
+        raise InstrumentChannelPairingRuleCatalogueSourceAccessError(
+            "Explicit pairing-rule catalogue source is not a regular file: "
+            f"{resolved_path!s}."
+        )
+
+    try:
+        source_bytes = resolved_path.read_bytes()
+    except OSError as exc:
+        raise InstrumentChannelPairingRuleCatalogueSourceAccessError(
+            "Cannot read explicit pairing-rule catalogue source "
+            f"{resolved_path!s}: {exc}"
+        ) from exc
+
+    try:
+        source_text = source_bytes.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise InstrumentChannelPairingRuleCatalogueParseError(
+            "Explicit pairing-rule catalogue source is not valid UTF-8."
+        ) from exc
+
+    def reject_duplicate_keys(
+        pairs: list[tuple[str, Any]],
+    ) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in result:
+                raise ValueError(
+                    f"Duplicate JSON object key {key!r} is not permitted."
+                )
+            result[key] = value
+        return result
+
+    def reject_non_finite_constant(value: str) -> None:
+        raise ValueError(
+            f"Non-finite JSON numeric constant {value!r} is not permitted."
+        )
+
+    try:
+        payload = json.loads(
+            source_text,
+            object_pairs_hook=reject_duplicate_keys,
+            parse_constant=reject_non_finite_constant,
+        )
+    except (json.JSONDecodeError, ValueError) as exc:
+        raise InstrumentChannelPairingRuleCatalogueParseError(
+            "Explicit pairing-rule catalogue source is not strict JSON: "
+            f"{exc}"
+        ) from exc
+
+    if not isinstance(payload, dict):
+        raise InstrumentChannelPairingRuleCatalogueValidationError(
+            "Pairing-rule catalogue JSON must contain one top-level object."
+        )
+
+    try:
+        catalogue = InstrumentChannelPairingRuleCatalogue.from_dict(payload)
+    except (KeyError, TypeError, ValueError) as exc:
+        raise InstrumentChannelPairingRuleCatalogueValidationError(
+            "Parsed pairing-rule catalogue violates the strict semantic "
+            f"contract: {exc}"
+        ) from exc
+
+    compatibility_request = (
+        InstrumentChannelPairingRuleCatalogueActivationRequest(
+            catalogue_id=request.expected_catalogue_id,
+            catalogue_version=request.expected_catalogue_version,
+            catalogue_schema_version=(
+                request.expected_catalogue_schema_version
+            ),
+        )
+    )
+    compatibility_report = (
+        assess_instrument_channel_pairing_rule_catalogue_compatibility(
+            compatibility_request,
+            catalogue,
+        )
+    )
+    if not compatibility_report.compatible:
+        reasons = compatibility_report.reasons
+        raise InstrumentChannelPairingRuleCatalogueCompatibilityError(
+            "Loaded pairing-rule catalogue is not exactly compatible: "
+            + ", ".join(reasons),
+            reasons=reasons,
+        )
+
+    return InstrumentChannelPairingRuleCatalogueLoadedSnapshot(
+        discovery_request=request,
+        catalogue=catalogue,
+        resolved_source_reference=str(resolved_path),
+        source_size_bytes=len(source_bytes),
+        source_sha256=hashlib.sha256(source_bytes).hexdigest(),
+        compatibility_report=compatibility_report,
     )
 
 
 def activate_instrument_channel_pairing_rule_catalogue(
     request: InstrumentChannelPairingRuleCatalogueActivationRequest,
-    catalogue: InstrumentChannelPairingRuleCatalogue,
-) -> InstrumentChannelPairingRuleCatalogue:
-    """Fail closed until catalogue activation is implemented."""
+    loaded_snapshot: InstrumentChannelPairingRuleCatalogueLoadedSnapshot,
+) -> InstrumentChannelPairingRuleCatalogueActivationSnapshot:
+    """Return an explicit local activation snapshot without global mutation."""
 
     if not isinstance(
         request,
@@ -2053,16 +2501,33 @@ def activate_instrument_channel_pairing_rule_catalogue(
             "InstrumentChannelPairingRuleCatalogueActivationRequest."
         )
     if not isinstance(
-        catalogue,
-        InstrumentChannelPairingRuleCatalogue,
+        loaded_snapshot,
+        InstrumentChannelPairingRuleCatalogueLoadedSnapshot,
     ):
         raise TypeError(
-            "catalogue must be an InstrumentChannelPairingRuleCatalogue."
+            "loaded_snapshot must be an "
+            "InstrumentChannelPairingRuleCatalogueLoadedSnapshot."
         )
-    raise NotImplementedError(
-        "Instrument-channel pairing-rule catalogue activation is contract-only. "
-        "No catalogue is activated or integrated into calibration planning or "
-        "normal light-curve fitting."
+
+    compatibility_report = (
+        assess_instrument_channel_pairing_rule_catalogue_compatibility(
+            request,
+            loaded_snapshot.catalogue,
+        )
+    )
+    if not compatibility_report.compatible:
+        reasons = compatibility_report.reasons
+        raise InstrumentChannelPairingRuleCatalogueCompatibilityError(
+            "Pairing-rule catalogue cannot be activated because exact "
+            "compatibility failed: "
+            + ", ".join(reasons),
+            reasons=reasons,
+        )
+
+    return InstrumentChannelPairingRuleCatalogueActivationSnapshot(
+        activation_request=request,
+        loaded_snapshot=loaded_snapshot,
+        compatibility_report=compatibility_report,
     )
 
 

--- a/tests/test_instrument_channel_pairing_rule_catalogue_discovery_activation_contract.py
+++ b/tests/test_instrument_channel_pairing_rule_catalogue_discovery_activation_contract.py
@@ -125,7 +125,7 @@ class TestPairingRuleCatalogueDiscoveryActivationContract(
         self.assertFalse(
             payload["packaged_catalogue_fallback_permitted"]
         )
-        self.assertFalse(payload["discovery_implemented"])
+        self.assertTrue(payload["discovery_implemented"])
 
         with self.assertRaises(FrozenInstanceError):
             request.source_reference = "replacement.json"
@@ -160,7 +160,7 @@ class TestPairingRuleCatalogueDiscoveryActivationContract(
         self.assertFalse(payload["allow_catalogue_fallback"])
         self.assertFalse(payload["workflow_integration_requested"])
         self.assertFalse(payload["silent_activation_permitted"])
-        self.assertFalse(payload["activation_implemented"])
+        self.assertTrue(payload["activation_implemented"])
 
         with self.assertRaises(FrozenInstanceError):
             request.catalogue_version = "replacement"
@@ -335,29 +335,17 @@ class TestPairingRuleCatalogueDiscoveryActivationContract(
                 reasons=("catalogue_id_mismatch",),
             )
 
-    def test_discovery_and_activation_callables_fail_closed(self):
-        discovery_request = self._discovery_request()
-        activation_request = self._activation_request()
-        catalogue = self._catalogue()
+    def test_discovery_and_activation_callables_require_typed_inputs(self):
+        with self.assertRaises(TypeError):
+            discover_instrument_channel_pairing_rule_catalogue(object())
 
-        with self.assertRaisesRegex(
-            NotImplementedError,
-            "discovery is contract-only",
-        ):
-            discover_instrument_channel_pairing_rule_catalogue(
-                discovery_request
-            )
-
-        with self.assertRaisesRegex(
-            NotImplementedError,
-            "activation is contract-only",
-        ):
+        with self.assertRaises(TypeError):
             activate_instrument_channel_pairing_rule_catalogue(
-                activation_request,
-                catalogue,
+                object(),
+                object(),
             )
 
-    def test_public_documentation_records_fail_closed_boundary(self):
+    def test_public_documentation_records_implemented_boundary(self):
         repo = Path(__file__).resolve().parents[1]
         api_text = (
             repo
@@ -368,22 +356,21 @@ class TestPairingRuleCatalogueDiscoveryActivationContract(
         ).read_text(encoding="utf-8")
 
         for token in (
-            "InstrumentChannelPairingRuleCatalogueDiscoveryRequest",
-            "InstrumentChannelPairingRuleCatalogueActivationRequest",
-            "assess_instrument_channel_pairing_rule_catalogue_compatibility",
-            "one explicit source reference",
-            "Ambient",
-            "silent activation",
-            "NotImplementedError",
+            "InstrumentChannelPairingRuleCatalogueLoadedSnapshot",
+            "InstrumentChannelPairingRuleCatalogueActivationSnapshot",
+            "strict UTF-8 JSON",
+            "duplicate object keys",
+            "source-access, parse, semantic-validation, and compatibility",
+            "process-global",
             "never falls back",
         ):
             self.assertIn(token, api_text)
 
         for token in (
-            "discovery and activation contract",
-            "exact compatibility assessment",
-            "fail-closed public",
-            "NotImplementedError",
+            "explicit-source loading and local activation",
+            "immutable loaded-catalogue snapshot",
+            "immutable local activation snapshot",
+            "process-global",
             "populated scientifically",
             "TBD[instrument-channel-calibration]",
         ):

--- a/tests/test_instrument_channel_pairing_rule_catalogue_loading_activation.py
+++ b/tests/test_instrument_channel_pairing_rule_catalogue_loading_activation.py
@@ -1,0 +1,392 @@
+"""Explicit catalogue loading and local-activation implementation tests."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+from pgmuvi.instrument_channel_calibration import (
+    INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_SCHEMA_VERSION,
+    InstrumentChannelPairingMethod,
+    InstrumentChannelPairingRule,
+    InstrumentChannelPairingRuleCatalogue,
+    InstrumentChannelPairingRuleCatalogueActivationRequest,
+    InstrumentChannelPairingRuleCatalogueActivationSnapshot,
+    InstrumentChannelPairingRuleCatalogueCompatibilityError,
+    InstrumentChannelPairingRuleCatalogueDiscoveryRequest,
+    InstrumentChannelPairingRuleCatalogueLoadedSnapshot,
+    InstrumentChannelPairingRuleCatalogueParseError,
+    InstrumentChannelPairingRuleCatalogueSource,
+    InstrumentChannelPairingRuleCatalogueSourceAccessError,
+    InstrumentChannelPairingRuleCatalogueValidationError,
+    InstrumentChannelPairingRuleValidationStatus,
+    InstrumentChannelPairingToleranceProvenance,
+    activate_instrument_channel_pairing_rule_catalogue,
+    discover_instrument_channel_pairing_rule_catalogue,
+)
+
+
+class TestPairingRuleCatalogueLoadingActivation(unittest.TestCase):
+    @staticmethod
+    def _validated_rule(**overrides):
+        values = {
+            "rule_id": "survey-a-to-survey-b-v1",
+            "reference_instrument": "Survey A",
+            "reference_channel": "SurveyA/V",
+            "channel_instrument": "Survey B",
+            "channel": "SurveyB/V",
+            "physical_wavelength": 0.55,
+            "pairing_method": (
+                InstrumentChannelPairingMethod
+                .NEAREST_WITHIN_TOLERANCE
+            ),
+            "time_unit": "day",
+            "maximum_time_separation": 0.25,
+            "tolerance_provenance": (
+                InstrumentChannelPairingToleranceProvenance
+                .EMPIRICAL_VALIDATION
+            ),
+            "validation_status": (
+                InstrumentChannelPairingRuleValidationStatus
+                .SCIENTIFICALLY_VALIDATED
+            ),
+            "evidence_reference": "validation:representative-lpv-v1",
+        }
+        values.update(overrides)
+        return InstrumentChannelPairingRule(**values)
+
+    @classmethod
+    def _catalogue(cls, **overrides):
+        values = {
+            "catalogue_id": "pgmuvi-pairing-rules",
+            "catalogue_version": "2026.1",
+            "provenance_reference": "catalogue:design-record-v1",
+            "rules": (cls._validated_rule(),),
+            "validation_status": (
+                InstrumentChannelPairingRuleValidationStatus
+                .SCIENTIFICALLY_VALIDATED
+            ),
+            "evidence_reference": "catalogue:validation-report-v1",
+        }
+        values.update(overrides)
+        return InstrumentChannelPairingRuleCatalogue(**values)
+
+    @staticmethod
+    def _discovery_request(path: Path, **overrides):
+        values = {
+            "source": (
+                InstrumentChannelPairingRuleCatalogueSource
+                .EXPLICIT_PATH
+            ),
+            "source_reference": str(path),
+            "expected_catalogue_id": "pgmuvi-pairing-rules",
+            "expected_catalogue_version": "2026.1",
+            "expected_catalogue_schema_version": (
+                INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_SCHEMA_VERSION
+            ),
+        }
+        values.update(overrides)
+        return InstrumentChannelPairingRuleCatalogueDiscoveryRequest(
+            **values
+        )
+
+    @staticmethod
+    def _activation_request(**overrides):
+        values = {
+            "catalogue_id": "pgmuvi-pairing-rules",
+            "catalogue_version": "2026.1",
+            "catalogue_schema_version": (
+                INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_SCHEMA_VERSION
+            ),
+        }
+        values.update(overrides)
+        return InstrumentChannelPairingRuleCatalogueActivationRequest(
+            **values
+        )
+
+    @staticmethod
+    def _write_catalogue(
+        path: Path,
+        catalogue: InstrumentChannelPairingRuleCatalogue,
+    ) -> bytes:
+        payload = json.dumps(
+            catalogue.to_dict(),
+            allow_nan=False,
+            indent=2,
+            sort_keys=True,
+        ).encode("utf-8")
+        path.write_bytes(payload)
+        return payload
+
+    def test_explicit_path_load_returns_immutable_provenance_snapshot(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            source_path = Path(temporary_directory) / "catalogue.json"
+            source_bytes = self._write_catalogue(
+                source_path,
+                self._catalogue(),
+            )
+            request = self._discovery_request(source_path)
+
+            snapshot = (
+                discover_instrument_channel_pairing_rule_catalogue(
+                    request
+                )
+            )
+
+            self.assertIsInstance(
+                snapshot,
+                InstrumentChannelPairingRuleCatalogueLoadedSnapshot,
+            )
+            self.assertEqual(snapshot.discovery_request, request)
+            self.assertEqual(snapshot.catalogue, self._catalogue())
+            self.assertEqual(snapshot.source_reference, str(source_path))
+            self.assertEqual(
+                snapshot.resolved_source_reference,
+                str(source_path.resolve()),
+            )
+            self.assertEqual(
+                snapshot.source_size_bytes,
+                len(source_bytes),
+            )
+            self.assertEqual(len(snapshot.source_sha256), 64)
+            self.assertTrue(snapshot.compatibility_report.compatible)
+            self.assertTrue(
+                snapshot.compatibility_report.activation_permitted
+            )
+
+            payload = snapshot.to_dict()
+            json.dumps(payload, allow_nan=False)
+            self.assertTrue(payload["catalogue_loaded"])
+            self.assertFalse(payload["catalogue_activated"])
+            self.assertFalse(payload["process_global_state_modified"])
+            self.assertFalse(payload["workflow_integration_active"])
+
+            with self.assertRaises(FrozenInstanceError):
+                snapshot.source_sha256 = "replacement"
+
+    def test_local_activation_returns_distinct_immutable_snapshot(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            source_path = Path(temporary_directory) / "catalogue.json"
+            self._write_catalogue(source_path, self._catalogue())
+            loaded = discover_instrument_channel_pairing_rule_catalogue(
+                self._discovery_request(source_path)
+            )
+            request = self._activation_request()
+
+            activation = (
+                activate_instrument_channel_pairing_rule_catalogue(
+                    request,
+                    loaded,
+                )
+            )
+
+            self.assertIsInstance(
+                activation,
+                InstrumentChannelPairingRuleCatalogueActivationSnapshot,
+            )
+            self.assertIsNot(activation, loaded)
+            self.assertEqual(activation.loaded_snapshot, loaded)
+            self.assertEqual(activation.catalogue, loaded.catalogue)
+            self.assertEqual(
+                activation.source_reference,
+                str(source_path),
+            )
+            self.assertTrue(activation.local_only)
+            self.assertFalse(activation.process_global_state_modified)
+            self.assertFalse(activation.workflow_integration_active)
+
+            payload = activation.to_dict()
+            json.dumps(payload, allow_nan=False)
+            self.assertTrue(payload["catalogue_activated"])
+            self.assertTrue(payload["local_only"])
+            self.assertFalse(payload["process_global_state_modified"])
+            self.assertFalse(payload["workflow_integration_active"])
+
+            second_activation = (
+                activate_instrument_channel_pairing_rule_catalogue(
+                    request,
+                    loaded,
+                )
+            )
+            self.assertIsNot(second_activation, activation)
+            self.assertEqual(second_activation, activation)
+
+            with self.assertRaises(FrozenInstanceError):
+                activation.local_only = False
+
+    def test_missing_or_non_file_source_has_source_access_failure(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            missing = root / "missing.json"
+
+            with self.assertRaises(
+                InstrumentChannelPairingRuleCatalogueSourceAccessError
+            ):
+                discover_instrument_channel_pairing_rule_catalogue(
+                    self._discovery_request(missing)
+                )
+
+            with self.assertRaises(
+                InstrumentChannelPairingRuleCatalogueSourceAccessError
+            ):
+                discover_instrument_channel_pairing_rule_catalogue(
+                    self._discovery_request(root)
+                )
+
+    def test_invalid_utf8_and_json_have_parse_failures(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+
+            invalid_utf8 = root / "invalid-utf8.json"
+            invalid_utf8.write_bytes(b"\xff\xfe")
+            with self.assertRaises(
+                InstrumentChannelPairingRuleCatalogueParseError
+            ):
+                discover_instrument_channel_pairing_rule_catalogue(
+                    self._discovery_request(invalid_utf8)
+                )
+
+            malformed = root / "malformed.json"
+            malformed.write_text("{", encoding="utf-8")
+            with self.assertRaises(
+                InstrumentChannelPairingRuleCatalogueParseError
+            ):
+                discover_instrument_channel_pairing_rule_catalogue(
+                    self._discovery_request(malformed)
+                )
+
+    def test_duplicate_keys_and_nonfinite_constants_are_rejected(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+
+            duplicate = root / "duplicate.json"
+            duplicate.write_text(
+                '{"catalogue_id": "first", "catalogue_id": "second"}',
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(
+                InstrumentChannelPairingRuleCatalogueParseError,
+                "Duplicate JSON object key",
+            ):
+                discover_instrument_channel_pairing_rule_catalogue(
+                    self._discovery_request(duplicate)
+                )
+
+            nonfinite = root / "nonfinite.json"
+            nonfinite.write_text(
+                '{"value": NaN}',
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(
+                InstrumentChannelPairingRuleCatalogueParseError,
+                "Non-finite JSON numeric constant",
+            ):
+                discover_instrument_channel_pairing_rule_catalogue(
+                    self._discovery_request(nonfinite)
+                )
+
+    def test_semantic_contract_failures_are_distinct_from_parse_failures(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+
+            top_level_list = root / "list.json"
+            top_level_list.write_text("[]", encoding="utf-8")
+            with self.assertRaises(
+                InstrumentChannelPairingRuleCatalogueValidationError
+            ):
+                discover_instrument_channel_pairing_rule_catalogue(
+                    self._discovery_request(top_level_list)
+                )
+
+            incomplete = root / "incomplete.json"
+            incomplete.write_text(
+                '{"catalogue_id": "pgmuvi-pairing-rules"}',
+                encoding="utf-8",
+            )
+            with self.assertRaises(
+                InstrumentChannelPairingRuleCatalogueValidationError
+            ):
+                discover_instrument_channel_pairing_rule_catalogue(
+                    self._discovery_request(incomplete)
+                )
+
+    def test_discovery_compatibility_failure_preserves_reason_codes(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            source_path = Path(temporary_directory) / "catalogue.json"
+            self._write_catalogue(source_path, self._catalogue())
+
+            with self.assertRaises(
+                InstrumentChannelPairingRuleCatalogueCompatibilityError
+            ) as context:
+                discover_instrument_channel_pairing_rule_catalogue(
+                    self._discovery_request(
+                        source_path,
+                        expected_catalogue_version="different-version",
+                    )
+                )
+
+            self.assertEqual(
+                context.exception.reasons,
+                ("catalogue_version_mismatch",),
+            )
+
+    def test_unvalidated_catalogue_fails_compatibility_not_semantics(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            source_path = Path(temporary_directory) / "catalogue.json"
+            catalogue = self._catalogue(
+                validation_status=(
+                    InstrumentChannelPairingRuleValidationStatus
+                    .DEFINED_NOT_VALIDATED
+                ),
+                evidence_reference=None,
+            )
+            self._write_catalogue(source_path, catalogue)
+
+            with self.assertRaises(
+                InstrumentChannelPairingRuleCatalogueCompatibilityError
+            ) as context:
+                discover_instrument_channel_pairing_rule_catalogue(
+                    self._discovery_request(source_path)
+                )
+
+            self.assertEqual(
+                context.exception.reasons,
+                ("catalogue_not_scientifically_validated",),
+            )
+
+    def test_activation_rechecks_exact_compatibility(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            source_path = Path(temporary_directory) / "catalogue.json"
+            self._write_catalogue(source_path, self._catalogue())
+            loaded = discover_instrument_channel_pairing_rule_catalogue(
+                self._discovery_request(source_path)
+            )
+
+            with self.assertRaises(
+                InstrumentChannelPairingRuleCatalogueCompatibilityError
+            ) as context:
+                activate_instrument_channel_pairing_rule_catalogue(
+                    self._activation_request(
+                        catalogue_version="different-version"
+                    ),
+                    loaded,
+                )
+
+            self.assertEqual(
+                context.exception.reasons,
+                ("catalogue_version_mismatch",),
+            )
+
+    def test_activation_rejects_raw_catalogue_to_preserve_boundary(self):
+        with self.assertRaisesRegex(TypeError, "loaded_snapshot"):
+            activate_instrument_channel_pairing_rule_catalogue(
+                self._activation_request(),
+                self._catalogue(),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implement the explicit-source pairing-rule catalogue loading and local activation boundary defined in the preceding contract PR.

This pull request:

- loads exactly one caller-supplied catalogue path;
- requires strict UTF-8 JSON;
- rejects malformed JSON, duplicate object keys, and non-finite constants;
- performs strict catalogue deserialization and semantic validation;
- enforces exact catalogue identity, version, schema, catalogue-validation, and member-validation compatibility;
- preserves distinct source-access, parse, semantic-validation, and compatibility failures;
- returns an immutable loaded-catalogue snapshot with source-path, byte-size, SHA-256, catalogue, and compatibility provenance;
- returns a separate immutable local activation snapshot;
- does not install process-global catalogue state;
- does not perform ambient discovery or fallback;
- does not activate calibration in the normal light-curve fitting workflow.

## Public API

Adds:

- `INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_LOADED_SNAPSHOT_SCHEMA_VERSION`
- `INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_ACTIVATION_SNAPSHOT_SCHEMA_VERSION`
- `InstrumentChannelPairingRuleCatalogueError`
- `InstrumentChannelPairingRuleCatalogueSourceAccessError`
- `InstrumentChannelPairingRuleCatalogueParseError`
- `InstrumentChannelPairingRuleCatalogueValidationError`
- `InstrumentChannelPairingRuleCatalogueCompatibilityError`
- `InstrumentChannelPairingRuleCatalogueLoadedSnapshot`
- `InstrumentChannelPairingRuleCatalogueActivationSnapshot`

Implements:

- `discover_instrument_channel_pairing_rule_catalogue`
- `activate_instrument_channel_pairing_rule_catalogue`

## Failure boundaries

Catalogue loading fails distinctly when:

1. the explicit source cannot be resolved, is not a regular file, or cannot be read;
2. source bytes are not valid UTF-8;
3. JSON is malformed, contains duplicate object keys, or contains non-finite constants;
4. parsed JSON violates the strict catalogue semantic contract;
5. the catalogue is not exactly compatible with the requested identity, version, schema, or scientific-validation requirements.

Compatibility failures retain deterministic reason codes.

## Activation semantics

Activation:

- accepts an explicit activation request and a loaded snapshot;
- rechecks exact compatibility;
- returns a new immutable local activation snapshot;
- does not mutate the loaded snapshot;
- does not mutate process-global state;
- does not enable workflow integration;
- does not fall back to another catalogue or version.

## Tests

Validation completed successfully:

- 26 catalogue-focused tests passed;
- 181 instrument-channel regression tests passed;
- 2,737 full repository tests passed;
- Ruff passed;
- strict Sphinx documentation passed;
- the documentation TBD-marker audit passed;
- public-export and runtime smoke checks passed;
- ambient/global-state audits passed;
- `git diff --check` passed.

## Deliberately not included

This pull request does not add:

- ambient discovery;
- environment-variable lookup;
- current-working-directory scanning;
- package-resource fallback;
- a populated scientifically validated catalogue;
- automatic calibration-rule application;
- integration with normal light-curve fitting;
- representative real-data calibration validation.

`TBD[instrument-channel-calibration]` remains open.
