### PR TITLE
Define scientifically validated instrument-specific calibration catalogue contract

### DIFF
--- a/docs/source/future_work.rst
+++ b/docs/source/future_work.rst
@@ -145,18 +145,26 @@ Wavelength-model extensions
     existing explicit resolver boundary.
 
     The explicit-source loading and local activation implementation is now
-    available.  The
-    loader requires one caller-supplied path, strict UTF-8 JSON, strict semantic
-    deserialization, exact compatibility, and distinct source-access, parse,
-    semantic-validation, and compatibility failures.  It returns an
-    immutable loaded-catalogue snapshot with resolved-source and content-digest
-    provenance.  Explicit activation returns a separate
+    available.  The loader requires one caller-supplied path, strict UTF-8
+    JSON, strict semantic deserialization, exact compatibility, and distinct
+    source-access, parse, semantic-validation, and compatibility failures.  It
+    returns an immutable loaded-catalogue snapshot with resolved-source and
+    content-digest provenance.  Explicit activation returns a separate
     immutable local activation snapshot without process-global state or
     implicit workflow integration.
 
-    This does not close ``TBD[instrument-channel-calibration]``.  A populated scientifically validated rule catalogue remains future work, together with
-    normal light-curve workflow integration and representative calibration
-    validation.
+    The typed scientific-validation evidence contract now binds every rule
+    claim to exact instrument and observational-channel identity, contextual
+    physical wavelength, pairing configuration, immutable dataset identity,
+    protocol, result, justifications, applicability boundaries, acceptance
+    criteria, sample counts, and disposition.  Aggregate evidence is bound to
+    the exact ordered catalogue membership and member-validation identities.
+    Deterministic structural reports assess completeness and consistency but
+    do not execute or independently establish scientific validation.
+
+    This does not close ``TBD[instrument-channel-calibration]``.  A populated scientifically validated rule catalogue
+    remains future work, together with normal light-curve workflow integration
+    and representative calibration validation.
 
 **TBD[multi-periodic-wavelength-models]**
     Add a documented and validated multi-periodic workflow beyond the current

--- a/docs/source/pgmuvi.instrument_channel_calibration.rst
+++ b/docs/source/pgmuvi.instrument_channel_calibration.rst
@@ -76,6 +76,43 @@ The catalogue can be passed explicitly to the existing resolver because it
 iterates only over its recorded member rules.  Strict serialization and
 deserialization preserve catalogue and rule provenance.
 
+Scientific-validation evidence contract
+---------------------------------------
+
+A ``scientifically_validated`` status is no longer established by a free-form
+reference alone.  The immutable
+:class:`~pgmuvi.instrument_channel_calibration.InstrumentChannelPairingRuleValidationEvidence`
+record binds caller-supplied evidence to the complete rule identifier, both
+instrument identities, both observational-channel identities, contextual
+physical wavelength, pairing method, time unit, maximum separation, and
+tolerance provenance.  It also records an immutable validation-dataset
+reference and SHA-256 digest, protocol and result references, explicit
+justifications, applicability boundaries, acceptance criteria, sample counts,
+and a pass/fail disposition.
+
+The immutable
+:class:`~pgmuvi.instrument_channel_calibration.InstrumentChannelPairingRuleCatalogueValidationEvidence`
+record binds aggregate evidence to the exact catalogue identity, version,
+schema, ordered member-rule identifiers, and ordered member-validation
+identifiers.  A catalogue cannot become scientifically validated by upgrading
+an unvalidated member or by reusing aggregate evidence for a different member
+set or order.
+
+The side-effect-free
+:func:`~pgmuvi.instrument_channel_calibration.assess_instrument_channel_pairing_rule_scientific_validation`
+and
+:func:`~pgmuvi.instrument_channel_calibration.assess_instrument_channel_pairing_rule_catalogue_scientific_validation`
+callables return deterministic structural reports with exact reason codes.
+They verify that evidence is present, identity-bound, configuration-bound,
+passing, and internally consistent.  Structural assessment does not execute scientific validation,
+reproduce a study, or establish that a caller-supplied claim is scientifically
+correct.
+
+This contract adds no populated built-in evidence, real observational-channel
+rule, validation dataset, validation result, automatic rule selection, or
+workflow integration.  Real evidence and representative calibration
+validation remain future work.
+
 The discovery and activation API uses immutable
 :class:`~pgmuvi.instrument_channel_calibration.InstrumentChannelPairingRuleCatalogueDiscoveryRequest`
 and

--- a/pgmuvi/instrument_channel_calibration.py
+++ b/pgmuvi/instrument_channel_calibration.py
@@ -15,14 +15,13 @@ a light-curve fit.
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, replace
 from enum import Enum
-import math
 from typing import Any
 
 import numpy as np
 from scipy import optimize
-
 
 INSTRUMENT_CHANNEL_CALIBRATION_SCHEMA_VERSION = (
     "pgmuvi-instrument-channel-calibration-v1"
@@ -34,10 +33,10 @@ INSTRUMENT_CHANNEL_PAIRING_SCHEMA_VERSION = (
     "pgmuvi-instrument-channel-pairing-v2"
 )
 INSTRUMENT_CHANNEL_PAIRING_RULE_SCHEMA_VERSION = (
-    "pgmuvi-instrument-channel-pairing-rule-v1"
+    "pgmuvi-instrument-channel-pairing-rule-v2"
 )
 INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_SCHEMA_VERSION = (
-    "pgmuvi-instrument-channel-pairing-rule-catalogue-v1"
+    "pgmuvi-instrument-channel-pairing-rule-catalogue-v2"
 )
 INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_DISCOVERY_REQUEST_SCHEMA_VERSION = (
     "pgmuvi-instrument-channel-pairing-rule-catalogue-discovery-request-v1"
@@ -53,6 +52,18 @@ INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_LOADED_SNAPSHOT_SCHEMA_VERSION = (
 )
 INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_ACTIVATION_SNAPSHOT_SCHEMA_VERSION = (
     "pgmuvi-instrument-channel-pairing-rule-catalogue-activation-snapshot-v1"
+)
+INSTRUMENT_CHANNEL_PAIRING_RULE_VALIDATION_EVIDENCE_SCHEMA_VERSION = (
+    "pgmuvi-instrument-channel-pairing-rule-validation-evidence-v1"
+)
+INSTRUMENT_CHANNEL_PAIRING_RULE_SCIENTIFIC_VALIDATION_REPORT_SCHEMA_VERSION = (
+    "pgmuvi-instrument-channel-pairing-rule-scientific-validation-report-v1"
+)
+INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_VALIDATION_EVIDENCE_SCHEMA_VERSION = (
+    "pgmuvi-instrument-channel-pairing-rule-catalogue-validation-evidence-v1"
+)
+INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_SCIENTIFIC_VALIDATION_REPORT_SCHEMA_VERSION = (
+    "pgmuvi-instrument-channel-pairing-rule-catalogue-scientific-validation-report-v1"
 )
 INSTRUMENT_CHANNEL_PAIRING_RULE_REQUEST_SCHEMA_VERSION = (
     "pgmuvi-instrument-channel-pairing-rule-request-v1"
@@ -97,8 +108,12 @@ __all__ = [
     "INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_DISCOVERY_REQUEST_SCHEMA_VERSION",
     "INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_LOADED_SNAPSHOT_SCHEMA_VERSION",
     "INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_SCHEMA_VERSION",
+    "INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_SCIENTIFIC_VALIDATION_REPORT_SCHEMA_VERSION",
+    "INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_VALIDATION_EVIDENCE_SCHEMA_VERSION",
     "INSTRUMENT_CHANNEL_PAIRING_RULE_REQUEST_SCHEMA_VERSION",
     "INSTRUMENT_CHANNEL_PAIRING_RULE_SCHEMA_VERSION",
+    "INSTRUMENT_CHANNEL_PAIRING_RULE_SCIENTIFIC_VALIDATION_REPORT_SCHEMA_VERSION",
+    "INSTRUMENT_CHANNEL_PAIRING_RULE_VALIDATION_EVIDENCE_SCHEMA_VERSION",
     "INSTRUMENT_CHANNEL_PAIRING_SCHEMA_VERSION",
     "InstrumentChannelCalibration",
     "InstrumentChannelCalibrationAssessment",
@@ -134,10 +149,15 @@ __all__ = [
     "InstrumentChannelPairingRuleCatalogueError",
     "InstrumentChannelPairingRuleCatalogueLoadedSnapshot",
     "InstrumentChannelPairingRuleCatalogueParseError",
+    "InstrumentChannelPairingRuleCatalogueScientificValidationReport",
     "InstrumentChannelPairingRuleCatalogueSource",
     "InstrumentChannelPairingRuleCatalogueSourceAccessError",
     "InstrumentChannelPairingRuleCatalogueValidationError",
+    "InstrumentChannelPairingRuleCatalogueValidationEvidence",
     "InstrumentChannelPairingRuleRequest",
+    "InstrumentChannelPairingRuleScientificValidationDisposition",
+    "InstrumentChannelPairingRuleScientificValidationReport",
+    "InstrumentChannelPairingRuleValidationEvidence",
     "InstrumentChannelPairingRuleValidationStatus",
     "InstrumentChannelPairingToleranceProvenance",
     "SharedWavelengthChannelGroup",
@@ -146,6 +166,8 @@ __all__ = [
     "apply_instrument_channel_calibration_with_predictive_uncertainty",
     "assess_instrument_channel_calibration_requirement",
     "assess_instrument_channel_pairing_rule_catalogue_compatibility",
+    "assess_instrument_channel_pairing_rule_catalogue_scientific_validation",
+    "assess_instrument_channel_pairing_rule_scientific_validation",
     "construct_instrument_channel_pairing",
     "define_instrument_channel_calibration_plan",
     "discover_instrument_channel_pairing_rule_catalogue",
@@ -183,6 +205,15 @@ class InstrumentChannelPairingRuleValidationStatus(_StringEnum):
 
     DEFINED_NOT_VALIDATED = "defined_not_validated"
     SCIENTIFICALLY_VALIDATED = "scientifically_validated"
+
+
+class InstrumentChannelPairingRuleScientificValidationDisposition(
+    _StringEnum
+):
+    """Disposition recorded by caller-supplied scientific-validation evidence."""
+
+    PASSED = "passed"
+    FAILED = "failed"
 
 
 class InstrumentChannelPairingRuleCatalogueSource(_StringEnum):
@@ -235,6 +266,746 @@ class InstrumentChannelPairingToleranceProvenance(_StringEnum):
     CALLER_SUPPLIED = "caller_supplied"
     INSTRUMENT_DOCUMENTATION = "instrument_documentation"
     EMPIRICAL_VALIDATION = "empirical_validation"
+
+
+
+def _normalize_scientific_validation_text(
+    value: Any,
+    *,
+    name: str,
+) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{name} must be a string.")
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{name} must be non-empty.")
+    return normalized
+
+
+def _normalize_scientific_validation_text_sequence(
+    values: Any,
+    *,
+    name: str,
+) -> tuple[str, ...]:
+    try:
+        sequence = tuple(values)
+    except TypeError as exc:
+        raise TypeError(
+            f"{name} must be an iterable of non-empty strings."
+        ) from exc
+
+    normalized = tuple(
+        _normalize_scientific_validation_text(
+            value,
+            name=f"{name} entry",
+        )
+        for value in sequence
+    )
+    if not normalized:
+        raise ValueError(f"{name} must contain at least one entry.")
+    if len(set(normalized)) != len(normalized):
+        raise ValueError(f"{name} entries must be unique.")
+    return normalized
+
+
+def _normalize_scientific_validation_count(
+    value: Any,
+    *,
+    name: str,
+) -> int:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(
+        value,
+        (int, np.integer),
+    ):
+        raise TypeError(f"{name} must be an integer.")
+    normalized = int(value)
+    if normalized < 1:
+        raise ValueError(f"{name} must be at least 1.")
+    return normalized
+
+
+def _normalize_scientific_validation_sha256(
+    value: Any,
+    *,
+    name: str,
+) -> str:
+    normalized = _normalize_scientific_validation_text(
+        value,
+        name=name,
+    )
+    if (
+        len(normalized) != 64
+        or normalized != normalized.lower()
+        or any(
+            character not in "0123456789abcdef"
+            for character in normalized
+        )
+    ):
+        raise ValueError(
+            f"{name} must be a lowercase 64-character hexadecimal SHA-256 "
+            "digest."
+        )
+    return normalized
+
+
+@dataclass(frozen=True)
+class InstrumentChannelPairingRuleValidationEvidence:
+    """Immutable caller-supplied scientific evidence for one exact rule.
+
+    The record binds a validation claim to the complete rule identifier,
+    explicit instrument and observational-channel identities, contextual
+    physical wavelength, pairing configuration, immutable dataset identity,
+    protocol, result, justifications, applicability boundaries, acceptance
+    criteria, and disposition.
+
+    Construction validates evidence structure only. It does not execute a
+    scientific validation and does not independently establish that the claim
+    is correct.
+    """
+
+    validation_id: str
+    validation_version: str
+    rule_id: str
+    reference_instrument: str
+    reference_channel: str
+    channel_instrument: str
+    channel: str
+    physical_wavelength: float
+    pairing_method: InstrumentChannelPairingMethod | str
+    time_unit: str
+    maximum_time_separation: float | None
+    tolerance_provenance: (
+        InstrumentChannelPairingToleranceProvenance | str
+    )
+    validation_dataset_reference: str
+    validation_dataset_sha256: str
+    validation_protocol_reference: str
+    validation_result_reference: str
+    reference_channel_justification: str
+    pairing_method_justification: str
+    time_tolerance_justification: str
+    applicability_boundaries: tuple[str, ...]
+    acceptance_criteria: tuple[str, ...]
+    n_validation_sources: int
+    n_matched_pairs: int
+    disposition: (
+        InstrumentChannelPairingRuleScientificValidationDisposition | str
+    )
+    schema_version: str = (
+        INSTRUMENT_CHANNEL_PAIRING_RULE_VALIDATION_EVIDENCE_SCHEMA_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if self.schema_version != (
+            INSTRUMENT_CHANNEL_PAIRING_RULE_VALIDATION_EVIDENCE_SCHEMA_VERSION
+        ):
+            raise ValueError(
+                "Unsupported pairing-rule validation-evidence schema "
+                f"version: {self.schema_version!r}."
+            )
+
+        for name in (
+            "validation_id",
+            "validation_version",
+            "rule_id",
+            "reference_instrument",
+            "reference_channel",
+            "channel_instrument",
+            "channel",
+            "time_unit",
+            "validation_dataset_reference",
+            "validation_protocol_reference",
+            "validation_result_reference",
+            "reference_channel_justification",
+            "pairing_method_justification",
+            "time_tolerance_justification",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                _normalize_scientific_validation_text(
+                    getattr(self, name),
+                    name=name,
+                ),
+            )
+
+        if self.reference_channel == self.channel:
+            raise ValueError(
+                "reference_channel and channel must identify different "
+                "observational channels."
+            )
+
+        if isinstance(self.physical_wavelength, (bool, np.bool_)):
+            raise TypeError(
+                "physical_wavelength must be numeric, not boolean."
+            )
+        physical_wavelength = float(self.physical_wavelength)
+        if (
+            not math.isfinite(physical_wavelength)
+            or physical_wavelength <= 0.0
+        ):
+            raise ValueError(
+                "physical_wavelength must be finite and positive."
+            )
+
+        pairing_method = self.pairing_method
+        if not isinstance(pairing_method, InstrumentChannelPairingMethod):
+            try:
+                pairing_method = InstrumentChannelPairingMethod(
+                    str(pairing_method)
+                )
+            except ValueError as exc:
+                raise ValueError(
+                    "Unsupported validation-evidence pairing method: "
+                    f"{self.pairing_method!r}."
+                ) from exc
+
+        tolerance_provenance = self.tolerance_provenance
+        if not isinstance(
+            tolerance_provenance,
+            InstrumentChannelPairingToleranceProvenance,
+        ):
+            try:
+                tolerance_provenance = (
+                    InstrumentChannelPairingToleranceProvenance(
+                        str(tolerance_provenance)
+                    )
+                )
+            except ValueError as exc:
+                raise ValueError(
+                    "Unsupported validation-evidence tolerance provenance: "
+                    f"{self.tolerance_provenance!r}."
+                ) from exc
+
+        maximum_time_separation = self.maximum_time_separation
+        if maximum_time_separation is not None:
+            if isinstance(
+                maximum_time_separation,
+                (bool, np.bool_),
+            ):
+                raise TypeError(
+                    "maximum_time_separation must be numeric, not boolean."
+                )
+            maximum_time_separation = float(maximum_time_separation)
+            if (
+                not math.isfinite(maximum_time_separation)
+                or maximum_time_separation < 0.0
+            ):
+                raise ValueError(
+                    "maximum_time_separation must be finite and "
+                    "non-negative when supplied."
+                )
+
+        if pairing_method is InstrumentChannelPairingMethod.EXACT_TIMESTAMP:
+            if maximum_time_separation not in (None, 0.0):
+                raise ValueError(
+                    "Exact-timestamp validation evidence permits no non-zero "
+                    "maximum_time_separation."
+                )
+            if tolerance_provenance is not (
+                InstrumentChannelPairingToleranceProvenance.EXACT_TIMESTAMP
+            ):
+                raise ValueError(
+                    "Exact-timestamp validation evidence requires exact "
+                    "timestamp tolerance provenance."
+                )
+        else:
+            if (
+                maximum_time_separation is None
+                or maximum_time_separation <= 0.0
+            ):
+                raise ValueError(
+                    "Nearest-within-tolerance validation evidence requires a "
+                    "finite positive maximum_time_separation."
+                )
+            if tolerance_provenance is (
+                InstrumentChannelPairingToleranceProvenance.EXACT_TIMESTAMP
+            ):
+                raise ValueError(
+                    "Nearest-within-tolerance validation evidence cannot use "
+                    "exact-timestamp tolerance provenance."
+                )
+
+        disposition = self.disposition
+        if not isinstance(
+            disposition,
+            InstrumentChannelPairingRuleScientificValidationDisposition,
+        ):
+            try:
+                disposition = (
+                    InstrumentChannelPairingRuleScientificValidationDisposition(
+                        str(disposition)
+                    )
+                )
+            except ValueError as exc:
+                raise ValueError(
+                    "Unsupported scientific-validation disposition: "
+                    f"{self.disposition!r}."
+                ) from exc
+
+        object.__setattr__(
+            self,
+            "physical_wavelength",
+            physical_wavelength,
+        )
+        object.__setattr__(self, "pairing_method", pairing_method)
+        object.__setattr__(
+            self,
+            "maximum_time_separation",
+            maximum_time_separation,
+        )
+        object.__setattr__(
+            self,
+            "tolerance_provenance",
+            tolerance_provenance,
+        )
+        object.__setattr__(
+            self,
+            "validation_dataset_sha256",
+            _normalize_scientific_validation_sha256(
+                self.validation_dataset_sha256,
+                name="validation_dataset_sha256",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "applicability_boundaries",
+            _normalize_scientific_validation_text_sequence(
+                self.applicability_boundaries,
+                name="applicability_boundaries",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "acceptance_criteria",
+            _normalize_scientific_validation_text_sequence(
+                self.acceptance_criteria,
+                name="acceptance_criteria",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "n_validation_sources",
+            _normalize_scientific_validation_count(
+                self.n_validation_sources,
+                name="n_validation_sources",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "n_matched_pairs",
+            _normalize_scientific_validation_count(
+                self.n_matched_pairs,
+                name="n_matched_pairs",
+            ),
+        )
+        object.__setattr__(self, "disposition", disposition)
+
+    @property
+    def identity_key(
+        self,
+    ) -> tuple[str, str, str, str, str, float]:
+        """Return the complete rule and observational-channel identity."""
+
+        return (
+            self.rule_id,
+            self.reference_instrument,
+            self.reference_channel,
+            self.channel_instrument,
+            self.channel,
+            self.physical_wavelength,
+        )
+
+    @property
+    def configuration_key(
+        self,
+    ) -> tuple[
+        InstrumentChannelPairingMethod,
+        str,
+        float | None,
+        InstrumentChannelPairingToleranceProvenance,
+    ]:
+        """Return the exact pairing configuration validated by the evidence."""
+
+        return (
+            self.pairing_method,
+            self.time_unit,
+            self.maximum_time_separation,
+            self.tolerance_provenance,
+        )
+
+    @property
+    def passed(self) -> bool:
+        """Whether the caller-supplied validation evidence records a pass."""
+
+        return self.disposition is (
+            InstrumentChannelPairingRuleScientificValidationDisposition.PASSED
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a strict JSON-safe validation-evidence representation."""
+
+        return {
+            "schema_version": self.schema_version,
+            "validation_id": self.validation_id,
+            "validation_version": self.validation_version,
+            "rule_id": self.rule_id,
+            "reference_instrument": self.reference_instrument,
+            "reference_channel": self.reference_channel,
+            "channel_instrument": self.channel_instrument,
+            "channel": self.channel,
+            "physical_wavelength": self.physical_wavelength,
+            "pairing_method": self.pairing_method.value,
+            "time_unit": self.time_unit,
+            "maximum_time_separation": self.maximum_time_separation,
+            "tolerance_provenance": self.tolerance_provenance.value,
+            "validation_dataset_reference": (
+                self.validation_dataset_reference
+            ),
+            "validation_dataset_sha256": self.validation_dataset_sha256,
+            "validation_protocol_reference": (
+                self.validation_protocol_reference
+            ),
+            "validation_result_reference": (
+                self.validation_result_reference
+            ),
+            "reference_channel_justification": (
+                self.reference_channel_justification
+            ),
+            "pairing_method_justification": (
+                self.pairing_method_justification
+            ),
+            "time_tolerance_justification": (
+                self.time_tolerance_justification
+            ),
+            "applicability_boundaries": list(
+                self.applicability_boundaries
+            ),
+            "acceptance_criteria": list(self.acceptance_criteria),
+            "n_validation_sources": self.n_validation_sources,
+            "n_matched_pairs": self.n_matched_pairs,
+            "disposition": self.disposition.value,
+            "passed": self.passed,
+            "scientific_validation_execution_performed_by_pgmuvi": False,
+            "populated_builtin_evidence": False,
+            "marker": INSTRUMENT_CHANNEL_CALIBRATION_TBD_MARKER,
+        }
+
+    @classmethod
+    def from_dict(
+        cls,
+        payload: Any,
+    ) -> InstrumentChannelPairingRuleValidationEvidence:
+        """Construct evidence from its strict serialized representation."""
+
+        if not isinstance(payload, dict):
+            raise TypeError(
+                "Pairing-rule validation evidence must be a dictionary."
+            )
+
+        expected_keys = {
+            "schema_version",
+            "validation_id",
+            "validation_version",
+            "rule_id",
+            "reference_instrument",
+            "reference_channel",
+            "channel_instrument",
+            "channel",
+            "physical_wavelength",
+            "pairing_method",
+            "time_unit",
+            "maximum_time_separation",
+            "tolerance_provenance",
+            "validation_dataset_reference",
+            "validation_dataset_sha256",
+            "validation_protocol_reference",
+            "validation_result_reference",
+            "reference_channel_justification",
+            "pairing_method_justification",
+            "time_tolerance_justification",
+            "applicability_boundaries",
+            "acceptance_criteria",
+            "n_validation_sources",
+            "n_matched_pairs",
+            "disposition",
+            "passed",
+            "scientific_validation_execution_performed_by_pgmuvi",
+            "populated_builtin_evidence",
+            "marker",
+        }
+        if set(payload) != expected_keys:
+            raise ValueError(
+                "Pairing-rule validation-evidence payload must contain "
+                "exactly the contract fields."
+            )
+
+        evidence = cls(
+            schema_version=payload["schema_version"],
+            validation_id=payload["validation_id"],
+            validation_version=payload["validation_version"],
+            rule_id=payload["rule_id"],
+            reference_instrument=payload["reference_instrument"],
+            reference_channel=payload["reference_channel"],
+            channel_instrument=payload["channel_instrument"],
+            channel=payload["channel"],
+            physical_wavelength=payload["physical_wavelength"],
+            pairing_method=payload["pairing_method"],
+            time_unit=payload["time_unit"],
+            maximum_time_separation=(
+                payload["maximum_time_separation"]
+            ),
+            tolerance_provenance=payload["tolerance_provenance"],
+            validation_dataset_reference=(
+                payload["validation_dataset_reference"]
+            ),
+            validation_dataset_sha256=(
+                payload["validation_dataset_sha256"]
+            ),
+            validation_protocol_reference=(
+                payload["validation_protocol_reference"]
+            ),
+            validation_result_reference=(
+                payload["validation_result_reference"]
+            ),
+            reference_channel_justification=(
+                payload["reference_channel_justification"]
+            ),
+            pairing_method_justification=(
+                payload["pairing_method_justification"]
+            ),
+            time_tolerance_justification=(
+                payload["time_tolerance_justification"]
+            ),
+            applicability_boundaries=tuple(
+                payload["applicability_boundaries"]
+            ),
+            acceptance_criteria=tuple(payload["acceptance_criteria"]),
+            n_validation_sources=payload["n_validation_sources"],
+            n_matched_pairs=payload["n_matched_pairs"],
+            disposition=payload["disposition"],
+        )
+        if evidence.to_dict() != payload:
+            raise ValueError(
+                "Pairing-rule validation-evidence payload does not match "
+                "the strict contract representation."
+            )
+        return evidence
+
+
+@dataclass(frozen=True)
+class InstrumentChannelPairingRuleCatalogueValidationEvidence:
+    """Immutable aggregate validation evidence for one exact catalogue."""
+
+    validation_id: str
+    validation_version: str
+    catalogue_id: str
+    catalogue_version: str
+    catalogue_schema_version: str
+    member_rule_ids: tuple[str, ...]
+    member_validation_ids: tuple[str, ...]
+    validation_protocol_reference: str
+    validation_result_reference: str
+    applicability_boundaries: tuple[str, ...]
+    acceptance_criteria: tuple[str, ...]
+    disposition: (
+        InstrumentChannelPairingRuleScientificValidationDisposition | str
+    )
+    schema_version: str = (
+        INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_VALIDATION_EVIDENCE_SCHEMA_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if self.schema_version != (
+            INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_VALIDATION_EVIDENCE_SCHEMA_VERSION
+        ):
+            raise ValueError(
+                "Unsupported catalogue validation-evidence schema version: "
+                f"{self.schema_version!r}."
+            )
+
+        for name in (
+            "validation_id",
+            "validation_version",
+            "catalogue_id",
+            "catalogue_version",
+            "catalogue_schema_version",
+            "validation_protocol_reference",
+            "validation_result_reference",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                _normalize_scientific_validation_text(
+                    getattr(self, name),
+                    name=name,
+                ),
+            )
+
+        member_rule_ids = _normalize_scientific_validation_text_sequence(
+            self.member_rule_ids,
+            name="member_rule_ids",
+        )
+        member_validation_ids = (
+            _normalize_scientific_validation_text_sequence(
+                self.member_validation_ids,
+                name="member_validation_ids",
+            )
+        )
+        if len(member_rule_ids) != len(member_validation_ids):
+            raise ValueError(
+                "member_rule_ids and member_validation_ids must have the "
+                "same length."
+            )
+
+        disposition = self.disposition
+        if not isinstance(
+            disposition,
+            InstrumentChannelPairingRuleScientificValidationDisposition,
+        ):
+            try:
+                disposition = (
+                    InstrumentChannelPairingRuleScientificValidationDisposition(
+                        str(disposition)
+                    )
+                )
+            except ValueError as exc:
+                raise ValueError(
+                    "Unsupported catalogue scientific-validation "
+                    f"disposition: {self.disposition!r}."
+                ) from exc
+
+        object.__setattr__(self, "member_rule_ids", member_rule_ids)
+        object.__setattr__(
+            self,
+            "member_validation_ids",
+            member_validation_ids,
+        )
+        object.__setattr__(
+            self,
+            "applicability_boundaries",
+            _normalize_scientific_validation_text_sequence(
+                self.applicability_boundaries,
+                name="applicability_boundaries",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "acceptance_criteria",
+            _normalize_scientific_validation_text_sequence(
+                self.acceptance_criteria,
+                name="acceptance_criteria",
+            ),
+        )
+        object.__setattr__(self, "disposition", disposition)
+
+    @property
+    def passed(self) -> bool:
+        """Whether aggregate catalogue validation records a passing result."""
+
+        return self.disposition is (
+            InstrumentChannelPairingRuleScientificValidationDisposition.PASSED
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a strict JSON-safe aggregate-evidence representation."""
+
+        return {
+            "schema_version": self.schema_version,
+            "validation_id": self.validation_id,
+            "validation_version": self.validation_version,
+            "catalogue_id": self.catalogue_id,
+            "catalogue_version": self.catalogue_version,
+            "catalogue_schema_version": self.catalogue_schema_version,
+            "member_rule_ids": list(self.member_rule_ids),
+            "member_validation_ids": list(
+                self.member_validation_ids
+            ),
+            "validation_protocol_reference": (
+                self.validation_protocol_reference
+            ),
+            "validation_result_reference": (
+                self.validation_result_reference
+            ),
+            "applicability_boundaries": list(
+                self.applicability_boundaries
+            ),
+            "acceptance_criteria": list(self.acceptance_criteria),
+            "disposition": self.disposition.value,
+            "passed": self.passed,
+            "scientific_validation_execution_performed_by_pgmuvi": False,
+            "populated_builtin_evidence": False,
+            "marker": INSTRUMENT_CHANNEL_CALIBRATION_TBD_MARKER,
+        }
+
+    @classmethod
+    def from_dict(
+        cls,
+        payload: Any,
+    ) -> InstrumentChannelPairingRuleCatalogueValidationEvidence:
+        """Construct aggregate evidence from a strict representation."""
+
+        if not isinstance(payload, dict):
+            raise TypeError(
+                "Catalogue validation evidence must be a dictionary."
+            )
+
+        expected_keys = {
+            "schema_version",
+            "validation_id",
+            "validation_version",
+            "catalogue_id",
+            "catalogue_version",
+            "catalogue_schema_version",
+            "member_rule_ids",
+            "member_validation_ids",
+            "validation_protocol_reference",
+            "validation_result_reference",
+            "applicability_boundaries",
+            "acceptance_criteria",
+            "disposition",
+            "passed",
+            "scientific_validation_execution_performed_by_pgmuvi",
+            "populated_builtin_evidence",
+            "marker",
+        }
+        if set(payload) != expected_keys:
+            raise ValueError(
+                "Catalogue validation-evidence payload must contain exactly "
+                "the contract fields."
+            )
+
+        evidence = cls(
+            schema_version=payload["schema_version"],
+            validation_id=payload["validation_id"],
+            validation_version=payload["validation_version"],
+            catalogue_id=payload["catalogue_id"],
+            catalogue_version=payload["catalogue_version"],
+            catalogue_schema_version=(
+                payload["catalogue_schema_version"]
+            ),
+            member_rule_ids=tuple(payload["member_rule_ids"]),
+            member_validation_ids=tuple(
+                payload["member_validation_ids"]
+            ),
+            validation_protocol_reference=(
+                payload["validation_protocol_reference"]
+            ),
+            validation_result_reference=(
+                payload["validation_result_reference"]
+            ),
+            applicability_boundaries=tuple(
+                payload["applicability_boundaries"]
+            ),
+            acceptance_criteria=tuple(payload["acceptance_criteria"]),
+            disposition=payload["disposition"],
+        )
+        if evidence.to_dict() != payload:
+            raise ValueError(
+                "Catalogue validation-evidence payload does not match the "
+                "strict contract representation."
+            )
+        return evidence
 
 
 class InstrumentChannelCalibrationDisposition(_StringEnum):
@@ -1015,6 +1786,9 @@ class InstrumentChannelPairingRule:
         InstrumentChannelPairingRuleValidationStatus | str
     )
     evidence_reference: str | None = None
+    validation_evidence: (
+        InstrumentChannelPairingRuleValidationEvidence | None
+    ) = None
     notes: str | None = None
     schema_version: str = INSTRUMENT_CHANNEL_PAIRING_RULE_SCHEMA_VERSION
 
@@ -1168,6 +1942,19 @@ class InstrumentChannelPairingRule:
                     "exact_timestamp tolerance provenance."
                 )
 
+        validation_evidence = self.validation_evidence
+        if (
+            validation_evidence is not None
+            and not isinstance(
+                validation_evidence,
+                InstrumentChannelPairingRuleValidationEvidence,
+            )
+        ):
+            raise TypeError(
+                "validation_evidence must be an "
+                "InstrumentChannelPairingRuleValidationEvidence or None."
+            )
+
         if validation_status is (
             InstrumentChannelPairingRuleValidationStatus
             .SCIENTIFICALLY_VALIDATED
@@ -1175,7 +1962,7 @@ class InstrumentChannelPairingRule:
             if evidence_reference is None:
                 raise ValueError(
                     "Scientifically validated pairing rules require an "
-                    "evidence_reference."
+                    "evidence_reference and typed validation_evidence."
                 )
             if provenance is (
                 InstrumentChannelPairingToleranceProvenance.CALLER_SUPPLIED
@@ -1233,7 +2020,29 @@ class InstrumentChannelPairingRule:
             "evidence_reference",
             evidence_reference,
         )
+        object.__setattr__(
+            self,
+            "validation_evidence",
+            validation_evidence,
+        )
         object.__setattr__(self, "notes", notes)
+
+        validation_report = (
+            assess_instrument_channel_pairing_rule_scientific_validation(
+                self
+            )
+        )
+        if (
+            validation_status
+            is InstrumentChannelPairingRuleValidationStatus
+            .SCIENTIFICALLY_VALIDATED
+            and not validation_report.scientifically_validated
+        ):
+            raise ValueError(
+                "Scientifically validated pairing rules require complete, "
+                "identity-bound, configuration-bound, passing validation "
+                f"evidence; reasons={validation_report.reasons!r}."
+            )
 
     @staticmethod
     def _normalize_required_text(
@@ -1261,11 +2070,12 @@ class InstrumentChannelPairingRule:
 
     @property
     def scientifically_validated(self) -> bool:
-        """Whether the rule records scientific validation and evidence."""
+        """Whether the rule has complete matching passed typed evidence."""
 
-        return self.validation_status is (
-            InstrumentChannelPairingRuleValidationStatus
-            .SCIENTIFICALLY_VALIDATED
+        return (
+            assess_instrument_channel_pairing_rule_scientific_validation(
+                self
+            ).scientifically_validated
         )
 
     @property
@@ -1299,6 +2109,11 @@ class InstrumentChannelPairingRule:
             "tolerance_provenance": self.tolerance_provenance.value,
             "validation_status": self.validation_status.value,
             "evidence_reference": self.evidence_reference,
+            "validation_evidence": (
+                None
+                if self.validation_evidence is None
+                else self.validation_evidence.to_dict()
+            ),
             "notes": self.notes,
             "scientifically_validated": self.scientifically_validated,
             "observational_channel_identity_explicit": True,
@@ -1338,6 +2153,9 @@ class InstrumentChannelPairingRuleCatalogue:
         InstrumentChannelPairingRuleValidationStatus | str
     )
     evidence_reference: str | None = None
+    validation_evidence: (
+        InstrumentChannelPairingRuleCatalogueValidationEvidence | None
+    ) = None
     notes: str | None = None
     schema_version: str = (
         INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_SCHEMA_VERSION
@@ -1426,6 +2244,20 @@ class InstrumentChannelPairingRuleCatalogue:
                     f"validation status: {self.validation_status!r}."
                 ) from exc
 
+        validation_evidence = self.validation_evidence
+        if (
+            validation_evidence is not None
+            and not isinstance(
+                validation_evidence,
+                InstrumentChannelPairingRuleCatalogueValidationEvidence,
+            )
+        ):
+            raise TypeError(
+                "validation_evidence must be an "
+                "InstrumentChannelPairingRuleCatalogueValidationEvidence "
+                "or None."
+            )
+
         if validation_status is (
             InstrumentChannelPairingRuleValidationStatus
             .SCIENTIFICALLY_VALIDATED
@@ -1433,7 +2265,8 @@ class InstrumentChannelPairingRuleCatalogue:
             if evidence_reference is None:
                 raise ValueError(
                     "A scientifically validated pairing-rule catalogue "
-                    "requires an evidence_reference."
+                    "requires an evidence_reference and typed "
+                    "validation_evidence."
                 )
             unvalidated_rule_ids = tuple(
                 rule.rule_id
@@ -1469,15 +2302,38 @@ class InstrumentChannelPairingRuleCatalogue:
             "evidence_reference",
             evidence_reference,
         )
+        object.__setattr__(
+            self,
+            "validation_evidence",
+            validation_evidence,
+        )
         object.__setattr__(self, "notes", notes)
+
+        validation_report = (
+            assess_instrument_channel_pairing_rule_catalogue_scientific_validation(
+                self
+            )
+        )
+        if (
+            validation_status
+            is InstrumentChannelPairingRuleValidationStatus
+            .SCIENTIFICALLY_VALIDATED
+            and not validation_report.scientifically_validated
+        ):
+            raise ValueError(
+                "Scientifically validated pairing-rule catalogues require "
+                "complete matching passed aggregate validation evidence; "
+                f"reasons={validation_report.reasons!r}."
+            )
 
     @property
     def scientifically_validated(self) -> bool:
-        """Whether the catalogue records scientific validation."""
+        """Whether aggregate and member typed evidence are complete."""
 
-        return self.validation_status is (
-            InstrumentChannelPairingRuleValidationStatus
-            .SCIENTIFICALLY_VALIDATED
+        return (
+            assess_instrument_channel_pairing_rule_catalogue_scientific_validation(
+                self
+            ).scientifically_validated
         )
 
     @property
@@ -1506,6 +2362,11 @@ class InstrumentChannelPairingRuleCatalogue:
             "provenance_reference": self.provenance_reference,
             "validation_status": self.validation_status.value,
             "evidence_reference": self.evidence_reference,
+            "validation_evidence": (
+                None
+                if self.validation_evidence is None
+                else self.validation_evidence.to_dict()
+            ),
             "notes": self.notes,
             "rules": [rule.to_dict() for rule in self.rules],
             "n_rules": len(self.rules),
@@ -1539,6 +2400,7 @@ class InstrumentChannelPairingRuleCatalogue:
             "provenance_reference",
             "validation_status",
             "evidence_reference",
+            "validation_evidence",
             "notes",
             "rules",
             "n_rules",
@@ -1594,6 +2456,13 @@ class InstrumentChannelPairingRuleCatalogue:
                     evidence_reference=(
                         rule_payload["evidence_reference"]
                     ),
+                    validation_evidence=(
+                        None
+                        if rule_payload["validation_evidence"] is None
+                        else InstrumentChannelPairingRuleValidationEvidence.from_dict(
+                            rule_payload["validation_evidence"]
+                        )
+                    ),
                     notes=rule_payload["notes"],
                 )
             except KeyError as exc:
@@ -1617,6 +2486,13 @@ class InstrumentChannelPairingRuleCatalogue:
             rules=tuple(rules),
             validation_status=payload["validation_status"],
             evidence_reference=payload["evidence_reference"],
+            validation_evidence=(
+                None
+                if payload["validation_evidence"] is None
+                else InstrumentChannelPairingRuleCatalogueValidationEvidence.from_dict(
+                    payload["validation_evidence"]
+                )
+            ),
             notes=payload["notes"],
         )
 
@@ -1627,6 +2503,485 @@ class InstrumentChannelPairingRuleCatalogue:
             )
 
         return catalogue
+
+
+
+@dataclass(frozen=True)
+class InstrumentChannelPairingRuleScientificValidationReport:
+    """Deterministic structural assessment of one rule's validation claim."""
+
+    rule_id: str
+    validation_status_declared: bool
+    validation_evidence_present: bool
+    evidence_reference_matches: bool
+    evidence_identity_matches: bool
+    evidence_configuration_matches: bool
+    tolerance_provenance_acceptable: bool
+    validation_evidence_passed: bool
+    scientifically_validated: bool
+    reasons: tuple[str, ...]
+    schema_version: str = (
+        INSTRUMENT_CHANNEL_PAIRING_RULE_SCIENTIFIC_VALIDATION_REPORT_SCHEMA_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if self.schema_version != (
+            INSTRUMENT_CHANNEL_PAIRING_RULE_SCIENTIFIC_VALIDATION_REPORT_SCHEMA_VERSION
+        ):
+            raise ValueError(
+                "Unsupported rule scientific-validation report schema "
+                f"version: {self.schema_version!r}."
+            )
+        object.__setattr__(
+            self,
+            "rule_id",
+            _normalize_scientific_validation_text(
+                self.rule_id,
+                name="rule_id",
+            ),
+        )
+
+        for name in (
+            "validation_status_declared",
+            "validation_evidence_present",
+            "evidence_reference_matches",
+            "evidence_identity_matches",
+            "evidence_configuration_matches",
+            "tolerance_provenance_acceptable",
+            "validation_evidence_passed",
+            "scientifically_validated",
+        ):
+            if not isinstance(getattr(self, name), bool):
+                raise TypeError(f"{name} must be a bool.")
+
+        expected_reasons: list[str] = []
+        if not self.validation_status_declared:
+            expected_reasons.append(
+                "rule_status_not_scientifically_validated"
+            )
+        if not self.validation_evidence_present:
+            expected_reasons.append("rule_validation_evidence_missing")
+        else:
+            if not self.evidence_reference_matches:
+                expected_reasons.append(
+                    "rule_validation_evidence_reference_mismatch"
+                )
+            if not self.evidence_identity_matches:
+                expected_reasons.append(
+                    "rule_validation_evidence_identity_mismatch"
+                )
+            if not self.evidence_configuration_matches:
+                expected_reasons.append(
+                    "rule_validation_evidence_configuration_mismatch"
+                )
+            if not self.validation_evidence_passed:
+                expected_reasons.append("rule_validation_not_passed")
+        if not self.tolerance_provenance_acceptable:
+            expected_reasons.append(
+                "rule_tolerance_provenance_not_scientifically_validated"
+            )
+
+        reasons = tuple(self.reasons)
+        if reasons != tuple(expected_reasons):
+            raise ValueError(
+                "Rule validation reasons must exactly describe structural "
+                "validation failures in deterministic order."
+            )
+        expected_validated = not expected_reasons
+        if self.scientifically_validated != expected_validated:
+            raise ValueError(
+                "scientifically_validated must agree with the complete "
+                "rule validation assessment."
+            )
+        object.__setattr__(self, "reasons", reasons)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a strict JSON-safe structural validation report."""
+
+        return {
+            "schema_version": self.schema_version,
+            "rule_id": self.rule_id,
+            "validation_status_declared": (
+                self.validation_status_declared
+            ),
+            "validation_evidence_present": (
+                self.validation_evidence_present
+            ),
+            "evidence_reference_matches": (
+                self.evidence_reference_matches
+            ),
+            "evidence_identity_matches": self.evidence_identity_matches,
+            "evidence_configuration_matches": (
+                self.evidence_configuration_matches
+            ),
+            "tolerance_provenance_acceptable": (
+                self.tolerance_provenance_acceptable
+            ),
+            "validation_evidence_passed": (
+                self.validation_evidence_passed
+            ),
+            "scientifically_validated": self.scientifically_validated,
+            "reasons": list(self.reasons),
+            "assessment_has_side_effects": False,
+            "scientific_validation_executed": False,
+            "marker": INSTRUMENT_CHANNEL_CALIBRATION_TBD_MARKER,
+        }
+
+
+def assess_instrument_channel_pairing_rule_scientific_validation(
+    rule: InstrumentChannelPairingRule,
+) -> InstrumentChannelPairingRuleScientificValidationReport:
+    """Assess typed evidence completeness without executing validation."""
+
+    if not isinstance(rule, InstrumentChannelPairingRule):
+        raise TypeError(
+            "rule must be an InstrumentChannelPairingRule."
+        )
+
+    evidence = rule.validation_evidence
+    evidence_present = evidence is not None
+    status_declared = rule.validation_status is (
+        InstrumentChannelPairingRuleValidationStatus
+        .SCIENTIFICALLY_VALIDATED
+    )
+    reference_matches = bool(
+        evidence_present
+        and rule.evidence_reference
+        == evidence.validation_result_reference
+    )
+    identity_matches = bool(
+        evidence_present
+        and evidence.identity_key
+        == (
+            rule.rule_id,
+            rule.reference_instrument,
+            rule.reference_channel,
+            rule.channel_instrument,
+            rule.channel,
+            rule.physical_wavelength,
+        )
+    )
+    configuration_matches = bool(
+        evidence_present
+        and evidence.configuration_key
+        == (
+            rule.pairing_method,
+            rule.time_unit,
+            rule.maximum_time_separation,
+            rule.tolerance_provenance,
+        )
+    )
+    provenance_acceptable = rule.tolerance_provenance is not (
+        InstrumentChannelPairingToleranceProvenance.CALLER_SUPPLIED
+    )
+    evidence_passed = bool(evidence_present and evidence.passed)
+
+    reasons: list[str] = []
+    if not status_declared:
+        reasons.append("rule_status_not_scientifically_validated")
+    if not evidence_present:
+        reasons.append("rule_validation_evidence_missing")
+    else:
+        if not reference_matches:
+            reasons.append(
+                "rule_validation_evidence_reference_mismatch"
+            )
+        if not identity_matches:
+            reasons.append(
+                "rule_validation_evidence_identity_mismatch"
+            )
+        if not configuration_matches:
+            reasons.append(
+                "rule_validation_evidence_configuration_mismatch"
+            )
+        if not evidence_passed:
+            reasons.append("rule_validation_not_passed")
+    if not provenance_acceptable:
+        reasons.append(
+            "rule_tolerance_provenance_not_scientifically_validated"
+        )
+
+    return InstrumentChannelPairingRuleScientificValidationReport(
+        rule_id=rule.rule_id,
+        validation_status_declared=status_declared,
+        validation_evidence_present=evidence_present,
+        evidence_reference_matches=reference_matches,
+        evidence_identity_matches=identity_matches,
+        evidence_configuration_matches=configuration_matches,
+        tolerance_provenance_acceptable=provenance_acceptable,
+        validation_evidence_passed=evidence_passed,
+        scientifically_validated=not reasons,
+        reasons=tuple(reasons),
+    )
+
+
+@dataclass(frozen=True)
+class InstrumentChannelPairingRuleCatalogueScientificValidationReport:
+    """Deterministic aggregate structural validation assessment."""
+
+    catalogue_id: str
+    validation_status_declared: bool
+    validation_evidence_present: bool
+    evidence_reference_matches: bool
+    evidence_identity_matches: bool
+    evidence_member_rule_ids_match: bool
+    evidence_member_validation_ids_match: bool
+    validation_evidence_passed: bool
+    all_rules_scientifically_validated: bool
+    unvalidated_rule_ids: tuple[str, ...]
+    scientifically_validated: bool
+    reasons: tuple[str, ...]
+    schema_version: str = (
+        INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_SCIENTIFIC_VALIDATION_REPORT_SCHEMA_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if self.schema_version != (
+            INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_SCIENTIFIC_VALIDATION_REPORT_SCHEMA_VERSION
+        ):
+            raise ValueError(
+                "Unsupported catalogue scientific-validation report schema "
+                f"version: {self.schema_version!r}."
+            )
+        object.__setattr__(
+            self,
+            "catalogue_id",
+            _normalize_scientific_validation_text(
+                self.catalogue_id,
+                name="catalogue_id",
+            ),
+        )
+        unvalidated_rule_ids = tuple(self.unvalidated_rule_ids)
+        if len(set(unvalidated_rule_ids)) != len(unvalidated_rule_ids):
+            raise ValueError("unvalidated_rule_ids must be unique.")
+
+        for name in (
+            "validation_status_declared",
+            "validation_evidence_present",
+            "evidence_reference_matches",
+            "evidence_identity_matches",
+            "evidence_member_rule_ids_match",
+            "evidence_member_validation_ids_match",
+            "validation_evidence_passed",
+            "all_rules_scientifically_validated",
+            "scientifically_validated",
+        ):
+            if not isinstance(getattr(self, name), bool):
+                raise TypeError(f"{name} must be a bool.")
+
+        if self.all_rules_scientifically_validated != (
+            not unvalidated_rule_ids
+        ):
+            raise ValueError(
+                "all_rules_scientifically_validated must agree with "
+                "unvalidated_rule_ids."
+            )
+
+        expected_reasons: list[str] = []
+        if not self.validation_status_declared:
+            expected_reasons.append(
+                "catalogue_status_not_scientifically_validated"
+            )
+        if not self.validation_evidence_present:
+            expected_reasons.append(
+                "catalogue_validation_evidence_missing"
+            )
+        else:
+            if not self.evidence_reference_matches:
+                expected_reasons.append(
+                    "catalogue_validation_evidence_reference_mismatch"
+                )
+            if not self.evidence_identity_matches:
+                expected_reasons.append(
+                    "catalogue_validation_evidence_identity_mismatch"
+                )
+            if not self.evidence_member_rule_ids_match:
+                expected_reasons.append(
+                    "catalogue_validation_member_rule_ids_mismatch"
+                )
+            if not self.evidence_member_validation_ids_match:
+                expected_reasons.append(
+                    "catalogue_validation_member_validation_ids_mismatch"
+                )
+            if not self.validation_evidence_passed:
+                expected_reasons.append(
+                    "catalogue_validation_not_passed"
+                )
+        if not self.all_rules_scientifically_validated:
+            expected_reasons.append(
+                "member_rules_not_all_scientifically_validated"
+            )
+
+        reasons = tuple(self.reasons)
+        if reasons != tuple(expected_reasons):
+            raise ValueError(
+                "Catalogue validation reasons must exactly describe "
+                "structural failures in deterministic order."
+            )
+        expected_validated = not expected_reasons
+        if self.scientifically_validated != expected_validated:
+            raise ValueError(
+                "scientifically_validated must agree with the complete "
+                "catalogue validation assessment."
+            )
+
+        object.__setattr__(
+            self,
+            "unvalidated_rule_ids",
+            unvalidated_rule_ids,
+        )
+        object.__setattr__(self, "reasons", reasons)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a strict JSON-safe aggregate validation report."""
+
+        return {
+            "schema_version": self.schema_version,
+            "catalogue_id": self.catalogue_id,
+            "validation_status_declared": (
+                self.validation_status_declared
+            ),
+            "validation_evidence_present": (
+                self.validation_evidence_present
+            ),
+            "evidence_reference_matches": (
+                self.evidence_reference_matches
+            ),
+            "evidence_identity_matches": self.evidence_identity_matches,
+            "evidence_member_rule_ids_match": (
+                self.evidence_member_rule_ids_match
+            ),
+            "evidence_member_validation_ids_match": (
+                self.evidence_member_validation_ids_match
+            ),
+            "validation_evidence_passed": (
+                self.validation_evidence_passed
+            ),
+            "all_rules_scientifically_validated": (
+                self.all_rules_scientifically_validated
+            ),
+            "unvalidated_rule_ids": list(self.unvalidated_rule_ids),
+            "scientifically_validated": self.scientifically_validated,
+            "reasons": list(self.reasons),
+            "assessment_has_side_effects": False,
+            "scientific_validation_executed": False,
+            "marker": INSTRUMENT_CHANNEL_CALIBRATION_TBD_MARKER,
+        }
+
+
+def assess_instrument_channel_pairing_rule_catalogue_scientific_validation(
+    catalogue: InstrumentChannelPairingRuleCatalogue,
+) -> InstrumentChannelPairingRuleCatalogueScientificValidationReport:
+    """Assess aggregate typed evidence without executing validation."""
+
+    if not isinstance(
+        catalogue,
+        InstrumentChannelPairingRuleCatalogue,
+    ):
+        raise TypeError(
+            "catalogue must be an InstrumentChannelPairingRuleCatalogue."
+        )
+
+    evidence = catalogue.validation_evidence
+    evidence_present = evidence is not None
+    status_declared = catalogue.validation_status is (
+        InstrumentChannelPairingRuleValidationStatus
+        .SCIENTIFICALLY_VALIDATED
+    )
+    reference_matches = bool(
+        evidence_present
+        and catalogue.evidence_reference
+        == evidence.validation_result_reference
+    )
+    identity_matches = bool(
+        evidence_present
+        and (
+            evidence.catalogue_id,
+            evidence.catalogue_version,
+            evidence.catalogue_schema_version,
+        )
+        == (
+            catalogue.catalogue_id,
+            catalogue.catalogue_version,
+            catalogue.schema_version,
+        )
+    )
+
+    member_rule_ids = tuple(rule.rule_id for rule in catalogue.rules)
+    member_validation_ids = tuple(
+        (
+            rule.validation_evidence.validation_id
+            if rule.validation_evidence is not None
+            else ""
+        )
+        for rule in catalogue.rules
+    )
+    member_rule_ids_match = bool(
+        evidence_present
+        and evidence.member_rule_ids == member_rule_ids
+    )
+    member_validation_ids_match = bool(
+        evidence_present
+        and evidence.member_validation_ids == member_validation_ids
+    )
+    evidence_passed = bool(evidence_present and evidence.passed)
+
+    unvalidated_rule_ids = tuple(
+        rule.rule_id
+        for rule in catalogue.rules
+        if not rule.scientifically_validated
+    )
+    all_rules_validated = not unvalidated_rule_ids
+
+    reasons: list[str] = []
+    if not status_declared:
+        reasons.append(
+            "catalogue_status_not_scientifically_validated"
+        )
+    if not evidence_present:
+        reasons.append("catalogue_validation_evidence_missing")
+    else:
+        if not reference_matches:
+            reasons.append(
+                "catalogue_validation_evidence_reference_mismatch"
+            )
+        if not identity_matches:
+            reasons.append(
+                "catalogue_validation_evidence_identity_mismatch"
+            )
+        if not member_rule_ids_match:
+            reasons.append(
+                "catalogue_validation_member_rule_ids_mismatch"
+            )
+        if not member_validation_ids_match:
+            reasons.append(
+                "catalogue_validation_member_validation_ids_mismatch"
+            )
+        if not evidence_passed:
+            reasons.append("catalogue_validation_not_passed")
+    if not all_rules_validated:
+        reasons.append(
+            "member_rules_not_all_scientifically_validated"
+        )
+
+    return (
+        InstrumentChannelPairingRuleCatalogueScientificValidationReport(
+            catalogue_id=catalogue.catalogue_id,
+            validation_status_declared=status_declared,
+            validation_evidence_present=evidence_present,
+            evidence_reference_matches=reference_matches,
+            evidence_identity_matches=identity_matches,
+            evidence_member_rule_ids_match=member_rule_ids_match,
+            evidence_member_validation_ids_match=(
+                member_validation_ids_match
+            ),
+            validation_evidence_passed=evidence_passed,
+            all_rules_scientifically_validated=all_rules_validated,
+            unvalidated_rule_ids=unvalidated_rule_ids,
+            scientifically_validated=not reasons,
+            reasons=tuple(reasons),
+        )
+    )
 
 
 @dataclass(frozen=True)

--- a/tests/test_instrument_channel_pairing_rule_catalogue_contract.py
+++ b/tests/test_instrument_channel_pairing_rule_catalogue_contract.py
@@ -2,21 +2,106 @@
 
 from __future__ import annotations
 
-from dataclasses import FrozenInstanceError
 import json
-from pathlib import Path
 import unittest
+from dataclasses import FrozenInstanceError
+from pathlib import Path
 
 from pgmuvi.instrument_channel_calibration import (
     INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_SCHEMA_VERSION,
     InstrumentChannelPairingMethod,
     InstrumentChannelPairingRule,
     InstrumentChannelPairingRuleCatalogue,
+    InstrumentChannelPairingRuleCatalogueValidationEvidence,
     InstrumentChannelPairingRuleRequest,
+    InstrumentChannelPairingRuleScientificValidationDisposition,
+    InstrumentChannelPairingRuleValidationEvidence,
     InstrumentChannelPairingRuleValidationStatus,
     InstrumentChannelPairingToleranceProvenance,
     resolve_instrument_channel_pairing_rule,
 )
+
+
+def _rule_validation_evidence(values):
+    return InstrumentChannelPairingRuleValidationEvidence(
+        validation_id=f"validation:{values['rule_id']}",
+        validation_version="1",
+        rule_id=values["rule_id"],
+        reference_instrument=values["reference_instrument"],
+        reference_channel=values["reference_channel"],
+        channel_instrument=values["channel_instrument"],
+        channel=values["channel"],
+        physical_wavelength=values["physical_wavelength"],
+        pairing_method=values["pairing_method"],
+        time_unit=values["time_unit"],
+        maximum_time_separation=values["maximum_time_separation"],
+        tolerance_provenance=values["tolerance_provenance"],
+        validation_dataset_reference="dataset:synthetic-contract-fixture",
+        validation_dataset_sha256="a" * 64,
+        validation_protocol_reference="protocol:pairing-validation-v1",
+        validation_result_reference=values["evidence_reference"],
+        reference_channel_justification=(
+            "Reference-channel choice is explicitly justified."
+        ),
+        pairing_method_justification=(
+            "Pairing method is explicitly justified."
+        ),
+        time_tolerance_justification=(
+            "Maximum time separation is explicitly justified."
+        ),
+        applicability_boundaries=(
+            "Applies only to the exact named observational-channel pair.",
+        ),
+        acceptance_criteria=(
+            "All declared deterministic acceptance criteria pass.",
+        ),
+        n_validation_sources=3,
+        n_matched_pairs=30,
+        disposition=(
+            InstrumentChannelPairingRuleScientificValidationDisposition
+            .PASSED
+        ),
+    )
+
+
+
+def _catalogue_validation_evidence(values):
+    rules = tuple(values["rules"])
+    return InstrumentChannelPairingRuleCatalogueValidationEvidence(
+        validation_id=(
+            f"catalogue-validation:{values['catalogue_id']}:"
+            f"{values['catalogue_version']}"
+        ),
+        validation_version="1",
+        catalogue_id=values["catalogue_id"],
+        catalogue_version=values["catalogue_version"],
+        catalogue_schema_version=(
+            INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_SCHEMA_VERSION
+        ),
+        member_rule_ids=tuple(rule.rule_id for rule in rules),
+        member_validation_ids=tuple(
+            (
+                rule.validation_evidence.validation_id
+                if rule.validation_evidence is not None
+                else f"missing:{rule.rule_id}"
+            )
+            for rule in rules
+        ),
+        validation_protocol_reference=(
+            "protocol:catalogue-validation-v1"
+        ),
+        validation_result_reference=values["evidence_reference"],
+        applicability_boundaries=(
+            "Applies only to the exact ordered catalogue membership.",
+        ),
+        acceptance_criteria=(
+            "Every member rule has complete passed typed evidence.",
+        ),
+        disposition=(
+            InstrumentChannelPairingRuleScientificValidationDisposition
+            .PASSED
+        ),
+    )
 
 
 class TestInstrumentChannelPairingRuleCatalogueContract(
@@ -48,6 +133,17 @@ class TestInstrumentChannelPairingRuleCatalogueContract(
             "evidence_reference": "validation:representative-lpv-v1",
         }
         values.update(overrides)
+        if "validation_evidence" not in overrides:
+            if (
+                str(values["validation_status"])
+                == "scientifically_validated"
+                and values["evidence_reference"] is not None
+            ):
+                values["validation_evidence"] = (
+                    _rule_validation_evidence(values)
+                )
+            else:
+                values["validation_evidence"] = None
         return InstrumentChannelPairingRule(**values)
 
     @classmethod
@@ -71,6 +167,34 @@ class TestInstrumentChannelPairingRuleCatalogueContract(
             "evidence_reference": "catalogue:validation-report-v1",
         }
         values.update(overrides)
+        if "validation_evidence" not in overrides:
+            rules = tuple(values["rules"])
+            rule_ids = tuple(
+                getattr(rule, "rule_id", None)
+                for rule in rules
+            )
+            identity_keys = tuple(
+                getattr(rule, "identity_key", None)
+                for rule in rules
+            )
+            if (
+                str(values["validation_status"])
+                == "scientifically_validated"
+                and values["evidence_reference"] is not None
+                and bool(rules)
+                and len(set(rule_ids)) == len(rule_ids)
+                and len(set(identity_keys)) == len(identity_keys)
+                and all(
+                    getattr(rule, "validation_evidence", None)
+                    is not None
+                    for rule in rules
+                )
+            ):
+                values["validation_evidence"] = (
+                    _catalogue_validation_evidence(values)
+                )
+            else:
+                values["validation_evidence"] = None
         return InstrumentChannelPairingRuleCatalogue(**values)
 
     def test_catalogue_is_immutable_json_safe_and_round_trips(self):

--- a/tests/test_instrument_channel_pairing_rule_catalogue_discovery_activation_contract.py
+++ b/tests/test_instrument_channel_pairing_rule_catalogue_discovery_activation_contract.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from dataclasses import FrozenInstanceError, replace
 import json
-from pathlib import Path
 import unittest
+from dataclasses import FrozenInstanceError, replace
+from pathlib import Path
 
 from pgmuvi.instrument_channel_calibration import (
     INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_ACTIVATION_REQUEST_SCHEMA_VERSION,
@@ -18,12 +18,97 @@ from pgmuvi.instrument_channel_calibration import (
     InstrumentChannelPairingRuleCatalogueActivationRequest,
     InstrumentChannelPairingRuleCatalogueDiscoveryRequest,
     InstrumentChannelPairingRuleCatalogueSource,
+    InstrumentChannelPairingRuleCatalogueValidationEvidence,
+    InstrumentChannelPairingRuleScientificValidationDisposition,
+    InstrumentChannelPairingRuleValidationEvidence,
     InstrumentChannelPairingRuleValidationStatus,
     InstrumentChannelPairingToleranceProvenance,
     activate_instrument_channel_pairing_rule_catalogue,
     assess_instrument_channel_pairing_rule_catalogue_compatibility,
     discover_instrument_channel_pairing_rule_catalogue,
 )
+
+
+def _rule_validation_evidence(values):
+    return InstrumentChannelPairingRuleValidationEvidence(
+        validation_id=f"validation:{values['rule_id']}",
+        validation_version="1",
+        rule_id=values["rule_id"],
+        reference_instrument=values["reference_instrument"],
+        reference_channel=values["reference_channel"],
+        channel_instrument=values["channel_instrument"],
+        channel=values["channel"],
+        physical_wavelength=values["physical_wavelength"],
+        pairing_method=values["pairing_method"],
+        time_unit=values["time_unit"],
+        maximum_time_separation=values["maximum_time_separation"],
+        tolerance_provenance=values["tolerance_provenance"],
+        validation_dataset_reference="dataset:synthetic-contract-fixture",
+        validation_dataset_sha256="a" * 64,
+        validation_protocol_reference="protocol:pairing-validation-v1",
+        validation_result_reference=values["evidence_reference"],
+        reference_channel_justification=(
+            "Reference-channel choice is explicitly justified."
+        ),
+        pairing_method_justification=(
+            "Pairing method is explicitly justified."
+        ),
+        time_tolerance_justification=(
+            "Maximum time separation is explicitly justified."
+        ),
+        applicability_boundaries=(
+            "Applies only to the exact named observational-channel pair.",
+        ),
+        acceptance_criteria=(
+            "All declared deterministic acceptance criteria pass.",
+        ),
+        n_validation_sources=3,
+        n_matched_pairs=30,
+        disposition=(
+            InstrumentChannelPairingRuleScientificValidationDisposition
+            .PASSED
+        ),
+    )
+
+
+
+def _catalogue_validation_evidence(values):
+    rules = tuple(values["rules"])
+    return InstrumentChannelPairingRuleCatalogueValidationEvidence(
+        validation_id=(
+            f"catalogue-validation:{values['catalogue_id']}:"
+            f"{values['catalogue_version']}"
+        ),
+        validation_version="1",
+        catalogue_id=values["catalogue_id"],
+        catalogue_version=values["catalogue_version"],
+        catalogue_schema_version=(
+            INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_SCHEMA_VERSION
+        ),
+        member_rule_ids=tuple(rule.rule_id for rule in rules),
+        member_validation_ids=tuple(
+            (
+                rule.validation_evidence.validation_id
+                if rule.validation_evidence is not None
+                else f"missing:{rule.rule_id}"
+            )
+            for rule in rules
+        ),
+        validation_protocol_reference=(
+            "protocol:catalogue-validation-v1"
+        ),
+        validation_result_reference=values["evidence_reference"],
+        applicability_boundaries=(
+            "Applies only to the exact ordered catalogue membership.",
+        ),
+        acceptance_criteria=(
+            "Every member rule has complete passed typed evidence.",
+        ),
+        disposition=(
+            InstrumentChannelPairingRuleScientificValidationDisposition
+            .PASSED
+        ),
+    )
 
 
 class TestPairingRuleCatalogueDiscoveryActivationContract(
@@ -55,6 +140,17 @@ class TestPairingRuleCatalogueDiscoveryActivationContract(
             "evidence_reference": "validation:representative-lpv-v1",
         }
         values.update(overrides)
+        if "validation_evidence" not in overrides:
+            if (
+                str(values["validation_status"])
+                == "scientifically_validated"
+                and values["evidence_reference"] is not None
+            ):
+                values["validation_evidence"] = (
+                    _rule_validation_evidence(values)
+                )
+            else:
+                values["validation_evidence"] = None
         return InstrumentChannelPairingRule(**values)
 
     @classmethod
@@ -71,6 +167,34 @@ class TestPairingRuleCatalogueDiscoveryActivationContract(
             "evidence_reference": "catalogue:validation-report-v1",
         }
         values.update(overrides)
+        if "validation_evidence" not in overrides:
+            rules = tuple(values["rules"])
+            rule_ids = tuple(
+                getattr(rule, "rule_id", None)
+                for rule in rules
+            )
+            identity_keys = tuple(
+                getattr(rule, "identity_key", None)
+                for rule in rules
+            )
+            if (
+                str(values["validation_status"])
+                == "scientifically_validated"
+                and values["evidence_reference"] is not None
+                and bool(rules)
+                and len(set(rule_ids)) == len(rule_ids)
+                and len(set(identity_keys)) == len(identity_keys)
+                and all(
+                    getattr(rule, "validation_evidence", None)
+                    is not None
+                    for rule in rules
+                )
+            ):
+                values["validation_evidence"] = (
+                    _catalogue_validation_evidence(values)
+                )
+            else:
+                values["validation_evidence"] = None
         return InstrumentChannelPairingRuleCatalogue(**values)
 
     @staticmethod

--- a/tests/test_instrument_channel_pairing_rule_catalogue_loading_activation.py
+++ b/tests/test_instrument_channel_pairing_rule_catalogue_loading_activation.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from dataclasses import FrozenInstanceError
 import json
-from pathlib import Path
 import tempfile
 import unittest
+from dataclasses import FrozenInstanceError
+from pathlib import Path
 
 from pgmuvi.instrument_channel_calibration import (
     INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_SCHEMA_VERSION,
@@ -22,11 +22,96 @@ from pgmuvi.instrument_channel_calibration import (
     InstrumentChannelPairingRuleCatalogueSource,
     InstrumentChannelPairingRuleCatalogueSourceAccessError,
     InstrumentChannelPairingRuleCatalogueValidationError,
+    InstrumentChannelPairingRuleCatalogueValidationEvidence,
+    InstrumentChannelPairingRuleScientificValidationDisposition,
+    InstrumentChannelPairingRuleValidationEvidence,
     InstrumentChannelPairingRuleValidationStatus,
     InstrumentChannelPairingToleranceProvenance,
     activate_instrument_channel_pairing_rule_catalogue,
     discover_instrument_channel_pairing_rule_catalogue,
 )
+
+
+def _rule_validation_evidence(values):
+    return InstrumentChannelPairingRuleValidationEvidence(
+        validation_id=f"validation:{values['rule_id']}",
+        validation_version="1",
+        rule_id=values["rule_id"],
+        reference_instrument=values["reference_instrument"],
+        reference_channel=values["reference_channel"],
+        channel_instrument=values["channel_instrument"],
+        channel=values["channel"],
+        physical_wavelength=values["physical_wavelength"],
+        pairing_method=values["pairing_method"],
+        time_unit=values["time_unit"],
+        maximum_time_separation=values["maximum_time_separation"],
+        tolerance_provenance=values["tolerance_provenance"],
+        validation_dataset_reference="dataset:synthetic-contract-fixture",
+        validation_dataset_sha256="a" * 64,
+        validation_protocol_reference="protocol:pairing-validation-v1",
+        validation_result_reference=values["evidence_reference"],
+        reference_channel_justification=(
+            "Reference-channel choice is explicitly justified."
+        ),
+        pairing_method_justification=(
+            "Pairing method is explicitly justified."
+        ),
+        time_tolerance_justification=(
+            "Maximum time separation is explicitly justified."
+        ),
+        applicability_boundaries=(
+            "Applies only to the exact named observational-channel pair.",
+        ),
+        acceptance_criteria=(
+            "All declared deterministic acceptance criteria pass.",
+        ),
+        n_validation_sources=3,
+        n_matched_pairs=30,
+        disposition=(
+            InstrumentChannelPairingRuleScientificValidationDisposition
+            .PASSED
+        ),
+    )
+
+
+
+def _catalogue_validation_evidence(values):
+    rules = tuple(values["rules"])
+    return InstrumentChannelPairingRuleCatalogueValidationEvidence(
+        validation_id=(
+            f"catalogue-validation:{values['catalogue_id']}:"
+            f"{values['catalogue_version']}"
+        ),
+        validation_version="1",
+        catalogue_id=values["catalogue_id"],
+        catalogue_version=values["catalogue_version"],
+        catalogue_schema_version=(
+            INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_SCHEMA_VERSION
+        ),
+        member_rule_ids=tuple(rule.rule_id for rule in rules),
+        member_validation_ids=tuple(
+            (
+                rule.validation_evidence.validation_id
+                if rule.validation_evidence is not None
+                else f"missing:{rule.rule_id}"
+            )
+            for rule in rules
+        ),
+        validation_protocol_reference=(
+            "protocol:catalogue-validation-v1"
+        ),
+        validation_result_reference=values["evidence_reference"],
+        applicability_boundaries=(
+            "Applies only to the exact ordered catalogue membership.",
+        ),
+        acceptance_criteria=(
+            "Every member rule has complete passed typed evidence.",
+        ),
+        disposition=(
+            InstrumentChannelPairingRuleScientificValidationDisposition
+            .PASSED
+        ),
+    )
 
 
 class TestPairingRuleCatalogueLoadingActivation(unittest.TestCase):
@@ -56,6 +141,17 @@ class TestPairingRuleCatalogueLoadingActivation(unittest.TestCase):
             "evidence_reference": "validation:representative-lpv-v1",
         }
         values.update(overrides)
+        if "validation_evidence" not in overrides:
+            if (
+                str(values["validation_status"])
+                == "scientifically_validated"
+                and values["evidence_reference"] is not None
+            ):
+                values["validation_evidence"] = (
+                    _rule_validation_evidence(values)
+                )
+            else:
+                values["validation_evidence"] = None
         return InstrumentChannelPairingRule(**values)
 
     @classmethod
@@ -72,6 +168,34 @@ class TestPairingRuleCatalogueLoadingActivation(unittest.TestCase):
             "evidence_reference": "catalogue:validation-report-v1",
         }
         values.update(overrides)
+        if "validation_evidence" not in overrides:
+            rules = tuple(values["rules"])
+            rule_ids = tuple(
+                getattr(rule, "rule_id", None)
+                for rule in rules
+            )
+            identity_keys = tuple(
+                getattr(rule, "identity_key", None)
+                for rule in rules
+            )
+            if (
+                str(values["validation_status"])
+                == "scientifically_validated"
+                and values["evidence_reference"] is not None
+                and bool(rules)
+                and len(set(rule_ids)) == len(rule_ids)
+                and len(set(identity_keys)) == len(identity_keys)
+                and all(
+                    getattr(rule, "validation_evidence", None)
+                    is not None
+                    for rule in rules
+                )
+            ):
+                values["validation_evidence"] = (
+                    _catalogue_validation_evidence(values)
+                )
+            else:
+                values["validation_evidence"] = None
         return InstrumentChannelPairingRuleCatalogue(**values)
 
     @staticmethod

--- a/tests/test_instrument_channel_pairing_rule_catalogue_scientific_validation_contract.py
+++ b/tests/test_instrument_channel_pairing_rule_catalogue_scientific_validation_contract.py
@@ -1,0 +1,441 @@
+"""Scientific-validation evidence contract tests for pairing catalogues."""
+
+from __future__ import annotations
+
+import json
+import unittest
+from dataclasses import FrozenInstanceError, replace
+from pathlib import Path
+
+from pgmuvi.instrument_channel_calibration import (
+    INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_SCHEMA_VERSION,
+    INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_VALIDATION_EVIDENCE_SCHEMA_VERSION,
+    INSTRUMENT_CHANNEL_PAIRING_RULE_VALIDATION_EVIDENCE_SCHEMA_VERSION,
+    InstrumentChannelPairingMethod,
+    InstrumentChannelPairingRule,
+    InstrumentChannelPairingRuleCatalogue,
+    InstrumentChannelPairingRuleCatalogueValidationEvidence,
+    InstrumentChannelPairingRuleScientificValidationDisposition,
+    InstrumentChannelPairingRuleValidationEvidence,
+    InstrumentChannelPairingRuleValidationStatus,
+    InstrumentChannelPairingToleranceProvenance,
+    assess_instrument_channel_pairing_rule_catalogue_scientific_validation,
+    assess_instrument_channel_pairing_rule_scientific_validation,
+)
+
+
+class TestPairingRuleCatalogueScientificValidationContract(
+    unittest.TestCase
+):
+    @staticmethod
+    def _rule_values(**overrides):
+        values = {
+            "rule_id": "survey-a-to-survey-b-v1",
+            "reference_instrument": "Survey A",
+            "reference_channel": "SurveyA/V",
+            "channel_instrument": "Survey B",
+            "channel": "SurveyB/V",
+            "physical_wavelength": 0.55,
+            "pairing_method": (
+                InstrumentChannelPairingMethod
+                .NEAREST_WITHIN_TOLERANCE
+            ),
+            "time_unit": "day",
+            "maximum_time_separation": 0.25,
+            "tolerance_provenance": (
+                InstrumentChannelPairingToleranceProvenance
+                .EMPIRICAL_VALIDATION
+            ),
+            "validation_status": (
+                InstrumentChannelPairingRuleValidationStatus
+                .SCIENTIFICALLY_VALIDATED
+            ),
+            "evidence_reference": "result:rule-validation-v1",
+        }
+        values.update(overrides)
+        return values
+
+    @classmethod
+    def _rule_evidence(cls, **overrides):
+        values = cls._rule_values()
+        evidence_values = {
+            "validation_id": "rule-validation-v1",
+            "validation_version": "1",
+            "rule_id": values["rule_id"],
+            "reference_instrument": values["reference_instrument"],
+            "reference_channel": values["reference_channel"],
+            "channel_instrument": values["channel_instrument"],
+            "channel": values["channel"],
+            "physical_wavelength": values["physical_wavelength"],
+            "pairing_method": values["pairing_method"],
+            "time_unit": values["time_unit"],
+            "maximum_time_separation": (
+                values["maximum_time_separation"]
+            ),
+            "tolerance_provenance": values["tolerance_provenance"],
+            "validation_dataset_reference": "dataset:validation-v1",
+            "validation_dataset_sha256": "b" * 64,
+            "validation_protocol_reference": "protocol:validation-v1",
+            "validation_result_reference": (
+                values["evidence_reference"]
+            ),
+            "reference_channel_justification": (
+                "Survey A is the explicitly justified reference."
+            ),
+            "pairing_method_justification": (
+                "Nearest matching is justified for this cadence."
+            ),
+            "time_tolerance_justification": (
+                "The tolerance is justified by validation results."
+            ),
+            "applicability_boundaries": (
+                "Only SurveyA/V to SurveyB/V at 0.55.",
+            ),
+            "acceptance_criteria": (
+                "Bias and residual acceptance thresholds pass.",
+            ),
+            "n_validation_sources": 4,
+            "n_matched_pairs": 80,
+            "disposition": (
+                InstrumentChannelPairingRuleScientificValidationDisposition
+                .PASSED
+            ),
+        }
+        evidence_values.update(overrides)
+        return InstrumentChannelPairingRuleValidationEvidence(
+            **evidence_values
+        )
+
+    @classmethod
+    def _validated_rule(cls, **overrides):
+        values = cls._rule_values()
+        values.update(overrides)
+        if "validation_evidence" not in overrides:
+            if values["evidence_reference"] is not None:
+                values["validation_evidence"] = cls._rule_evidence(
+                rule_id=values["rule_id"],
+                reference_instrument=values["reference_instrument"],
+                reference_channel=values["reference_channel"],
+                channel_instrument=values["channel_instrument"],
+                channel=values["channel"],
+                physical_wavelength=values["physical_wavelength"],
+                pairing_method=values["pairing_method"],
+                time_unit=values["time_unit"],
+                maximum_time_separation=(
+                    values["maximum_time_separation"]
+                ),
+                tolerance_provenance=values["tolerance_provenance"],
+                validation_result_reference=(
+                    values["evidence_reference"]
+                ),
+            )
+            else:
+                values["validation_evidence"] = None
+        return InstrumentChannelPairingRule(**values)
+
+    @classmethod
+    def _catalogue_evidence(cls, rules, **overrides):
+        rules = tuple(rules)
+        values = {
+            "validation_id": "catalogue-validation-v1",
+            "validation_version": "1",
+            "catalogue_id": "pgmuvi-pairing-rules",
+            "catalogue_version": "2026.1",
+            "catalogue_schema_version": (
+                INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_SCHEMA_VERSION
+            ),
+            "member_rule_ids": tuple(rule.rule_id for rule in rules),
+            "member_validation_ids": tuple(
+                (
+                    rule.validation_evidence.validation_id
+                    if rule.validation_evidence is not None
+                    else f"missing:{rule.rule_id}"
+                )
+                for rule in rules
+            ),
+            "validation_protocol_reference": (
+                "protocol:catalogue-validation-v1"
+            ),
+            "validation_result_reference": (
+                "result:catalogue-validation-v1"
+            ),
+            "applicability_boundaries": (
+                "Only the exact ordered member-rule set.",
+            ),
+            "acceptance_criteria": (
+                "Every member rule passes its evidence contract.",
+            ),
+            "disposition": (
+                InstrumentChannelPairingRuleScientificValidationDisposition
+                .PASSED
+            ),
+        }
+        values.update(overrides)
+        return InstrumentChannelPairingRuleCatalogueValidationEvidence(
+            **values
+        )
+
+    @classmethod
+    def _validated_catalogue(cls, **overrides):
+        rules = overrides.pop(
+            "rules",
+            (
+                cls._validated_rule(),
+                cls._validated_rule(
+                    rule_id="survey-a-to-survey-c-v1",
+                    channel_instrument="Survey C",
+                    channel="SurveyC/V",
+                    evidence_reference="result:rule-validation-c-v1",
+                    validation_evidence=cls._rule_evidence(
+                        validation_id="rule-validation-c-v1",
+                        rule_id="survey-a-to-survey-c-v1",
+                        channel_instrument="Survey C",
+                        channel="SurveyC/V",
+                        validation_result_reference=(
+                            "result:rule-validation-c-v1"
+                        ),
+                    ),
+                ),
+            ),
+        )
+        values = {
+            "catalogue_id": "pgmuvi-pairing-rules",
+            "catalogue_version": "2026.1",
+            "provenance_reference": "catalogue:design-record-v1",
+            "rules": tuple(rules),
+            "validation_status": (
+                InstrumentChannelPairingRuleValidationStatus
+                .SCIENTIFICALLY_VALIDATED
+            ),
+            "evidence_reference": "result:catalogue-validation-v1",
+        }
+        values.update(overrides)
+        if "validation_evidence" not in overrides:
+            rules = tuple(values["rules"])
+            if (
+                values["evidence_reference"] is not None
+                and bool(rules)
+                and all(
+                    rule.validation_evidence is not None
+                    for rule in rules
+                )
+            ):
+                values["validation_evidence"] = cls._catalogue_evidence(
+                    rules,
+                    catalogue_id=values["catalogue_id"],
+                    catalogue_version=values["catalogue_version"],
+                    validation_result_reference=(
+                        values["evidence_reference"]
+                    ),
+                )
+            else:
+                values["validation_evidence"] = None
+        return InstrumentChannelPairingRuleCatalogue(**values)
+
+    def test_rule_evidence_is_immutable_strict_and_round_trips(self):
+        evidence = self._rule_evidence()
+
+        self.assertEqual(
+            evidence.schema_version,
+            INSTRUMENT_CHANNEL_PAIRING_RULE_VALIDATION_EVIDENCE_SCHEMA_VERSION,
+        )
+        self.assertTrue(evidence.passed)
+
+        payload = evidence.to_dict()
+        json.dumps(payload, allow_nan=False)
+        restored = InstrumentChannelPairingRuleValidationEvidence.from_dict(
+            payload
+        )
+
+        self.assertEqual(restored, evidence)
+        self.assertEqual(restored.to_dict(), payload)
+        self.assertFalse(
+            payload[
+                "scientific_validation_execution_performed_by_pgmuvi"
+            ]
+        )
+        self.assertFalse(payload["populated_builtin_evidence"])
+
+        with self.assertRaises(FrozenInstanceError):
+            evidence.validation_id = "replacement"
+
+    def test_rule_validation_requires_exact_identity_configuration_and_pass(self):
+        rule = self._validated_rule()
+        report = (
+            assess_instrument_channel_pairing_rule_scientific_validation(
+                rule
+            )
+        )
+
+        self.assertTrue(rule.scientifically_validated)
+        self.assertTrue(report.scientifically_validated)
+        self.assertEqual(report.reasons, ())
+        json.dumps(report.to_dict(), allow_nan=False)
+        self.assertFalse(report.to_dict()["scientific_validation_executed"])
+
+        mismatches = (
+            (
+                self._rule_evidence(channel="SurveyX/V"),
+                "identity_mismatch",
+            ),
+            (
+                self._rule_evidence(maximum_time_separation=0.5),
+                "configuration_mismatch",
+            ),
+            (
+                self._rule_evidence(
+                    disposition=(
+                        InstrumentChannelPairingRuleScientificValidationDisposition
+                        .FAILED
+                    )
+                ),
+                "not_passed",
+            ),
+        )
+        for evidence, reason_fragment in mismatches:
+            with self.subTest(reason_fragment=reason_fragment):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    reason_fragment,
+                ):
+                    self._validated_rule(validation_evidence=evidence)
+
+    def test_unvalidated_rule_reports_deterministic_reasons(self):
+        rule = InstrumentChannelPairingRule(
+            **self._rule_values(
+                validation_status=(
+                    InstrumentChannelPairingRuleValidationStatus
+                    .DEFINED_NOT_VALIDATED
+                ),
+                evidence_reference=None,
+                validation_evidence=None,
+            )
+        )
+        report = (
+            assess_instrument_channel_pairing_rule_scientific_validation(
+                rule
+            )
+        )
+
+        self.assertFalse(rule.scientifically_validated)
+        self.assertEqual(
+            report.reasons,
+            (
+                "rule_status_not_scientifically_validated",
+                "rule_validation_evidence_missing",
+            ),
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "reasons must exactly describe",
+        ):
+            replace(report, reasons=("forged",))
+
+    def test_catalogue_evidence_is_immutable_strict_and_round_trips(self):
+        rules = (self._validated_rule(),)
+        evidence = self._catalogue_evidence(rules)
+
+        self.assertEqual(
+            evidence.schema_version,
+            INSTRUMENT_CHANNEL_PAIRING_RULE_CATALOGUE_VALIDATION_EVIDENCE_SCHEMA_VERSION,
+        )
+        payload = evidence.to_dict()
+        json.dumps(payload, allow_nan=False)
+
+        restored = (
+            InstrumentChannelPairingRuleCatalogueValidationEvidence.from_dict(
+                payload
+            )
+        )
+        self.assertEqual(restored, evidence)
+        self.assertEqual(restored.to_dict(), payload)
+
+        with self.assertRaises(FrozenInstanceError):
+            evidence.member_rule_ids = ("replacement",)
+
+    def test_catalogue_validation_binds_exact_ordered_members_and_evidence(self):
+        catalogue = self._validated_catalogue()
+        report = (
+            assess_instrument_channel_pairing_rule_catalogue_scientific_validation(
+                catalogue
+            )
+        )
+
+        self.assertTrue(catalogue.scientifically_validated)
+        self.assertTrue(
+            catalogue.all_rules_scientifically_validated
+        )
+        self.assertTrue(report.scientifically_validated)
+        self.assertEqual(report.reasons, ())
+        self.assertEqual(report.unvalidated_rule_ids, ())
+        json.dumps(report.to_dict(), allow_nan=False)
+
+        reversed_evidence = self._catalogue_evidence(
+            catalogue.rules,
+            member_rule_ids=tuple(
+                reversed(
+                    tuple(rule.rule_id for rule in catalogue.rules)
+                )
+            ),
+        )
+        with self.assertRaisesRegex(
+            ValueError,
+            "member_rule_ids_mismatch",
+        ):
+            self._validated_catalogue(
+                rules=catalogue.rules,
+                validation_evidence=reversed_evidence,
+            )
+
+    def test_catalogue_cannot_upgrade_unvalidated_member_evidence(self):
+        unvalidated = InstrumentChannelPairingRule(
+            **self._rule_values(
+                validation_status=(
+                    InstrumentChannelPairingRuleValidationStatus
+                    .DEFINED_NOT_VALIDATED
+                ),
+                evidence_reference=None,
+                validation_evidence=None,
+            )
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "cannot contain rules that are not scientifically validated",
+        ):
+            self._validated_catalogue(rules=(unvalidated,))
+
+    def test_public_docs_preserve_contract_only_boundary(self):
+        repo = Path(__file__).resolve().parents[1]
+        api_text = (
+            repo
+            / "docs/source/pgmuvi.instrument_channel_calibration.rst"
+        ).read_text(encoding="utf-8")
+        future_text = (
+            repo / "docs/source/future_work.rst"
+        ).read_text(encoding="utf-8")
+
+        for token in (
+            "InstrumentChannelPairingRuleValidationEvidence",
+            "InstrumentChannelPairingRuleCatalogueValidationEvidence",
+            "identity-bound",
+            "configuration-bound",
+            "applicability boundaries",
+            "acceptance criteria",
+            "does not execute scientific validation",
+            "no populated built-in evidence",
+        ):
+            self.assertIn(token, api_text)
+
+        for token in (
+            "typed scientific-validation evidence contract",
+            "populated scientifically validated rule catalogue",
+            "representative calibration validation",
+            "TBD[instrument-channel-calibration]",
+        ):
+            self.assertIn(token, future_text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_instrument_channel_pairing_rule_contract.py
+++ b/tests/test_instrument_channel_pairing_rule_contract.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from dataclasses import FrozenInstanceError
 import json
-from pathlib import Path
 import unittest
+from dataclasses import FrozenInstanceError
+from pathlib import Path
 
 import numpy as np
 
@@ -15,10 +15,54 @@ from pgmuvi.instrument_channel_calibration import (
     InstrumentChannelPairingMethod,
     InstrumentChannelPairingRule,
     InstrumentChannelPairingRuleRequest,
+    InstrumentChannelPairingRuleScientificValidationDisposition,
+    InstrumentChannelPairingRuleValidationEvidence,
     InstrumentChannelPairingRuleValidationStatus,
     InstrumentChannelPairingToleranceProvenance,
     resolve_instrument_channel_pairing_rule,
 )
+
+
+def _rule_validation_evidence(values):
+    return InstrumentChannelPairingRuleValidationEvidence(
+        validation_id=f"validation:{values['rule_id']}",
+        validation_version="1",
+        rule_id=values["rule_id"],
+        reference_instrument=values["reference_instrument"],
+        reference_channel=values["reference_channel"],
+        channel_instrument=values["channel_instrument"],
+        channel=values["channel"],
+        physical_wavelength=values["physical_wavelength"],
+        pairing_method=values["pairing_method"],
+        time_unit=values["time_unit"],
+        maximum_time_separation=values["maximum_time_separation"],
+        tolerance_provenance=values["tolerance_provenance"],
+        validation_dataset_reference="dataset:synthetic-contract-fixture",
+        validation_dataset_sha256="a" * 64,
+        validation_protocol_reference="protocol:pairing-validation-v1",
+        validation_result_reference=values["evidence_reference"],
+        reference_channel_justification=(
+            "Reference-channel choice is explicitly justified."
+        ),
+        pairing_method_justification=(
+            "Pairing method is explicitly justified."
+        ),
+        time_tolerance_justification=(
+            "Maximum time separation is explicitly justified."
+        ),
+        applicability_boundaries=(
+            "Applies only to the exact named observational-channel pair.",
+        ),
+        acceptance_criteria=(
+            "All declared deterministic acceptance criteria pass.",
+        ),
+        n_validation_sources=3,
+        n_matched_pairs=30,
+        disposition=(
+            InstrumentChannelPairingRuleScientificValidationDisposition
+            .PASSED
+        ),
+    )
 
 
 class TestInstrumentChannelPairingRuleContract(unittest.TestCase):
@@ -48,6 +92,17 @@ class TestInstrumentChannelPairingRuleContract(unittest.TestCase):
             "evidence_reference": "validation:representative-lpv-v1",
         }
         values.update(overrides)
+        if "validation_evidence" not in overrides:
+            if (
+                str(values["validation_status"])
+                == "scientifically_validated"
+                and values["evidence_reference"] is not None
+            ):
+                values["validation_evidence"] = (
+                    _rule_validation_evidence(values)
+                )
+            else:
+                values["validation_evidence"] = None
         return InstrumentChannelPairingRule(**values)
 
     def test_exact_rule_is_immutable_and_json_safe(self):


### PR DESCRIPTION
## Summary

Define a strict scientific-validation evidence contract for instrument-specific observational-channel pairing rules and catalogues.

This PR replaces status-plus-free-form-reference validation claims with immutable, typed, identity-bound evidence records and deterministic structural validation reports.

## Rule-level scientific-validation evidence

- Adds an immutable and strictly serializable rule-validation evidence record.
- Binds evidence to the exact:
  - rule identifier;
  - reference instrument and observational channel;
  - target instrument and observational channel;
  - contextual physical wavelength;
  - pairing method;
  - time unit;
  - maximum time separation; and
  - tolerance provenance.
- Records:
  - validation identity and version;
  - immutable dataset reference and SHA-256 digest;
  - validation protocol and result references;
  - justification for reference-channel selection;
  - justification for pairing-method selection;
  - justification for the time tolerance;
  - applicability boundaries;
  - acceptance criteria;
  - validation-source and matched-pair counts; and
  - explicit pass/fail disposition.
- Requires exact evidence-reference, identity, configuration, provenance, and disposition agreement before a rule may report itself as scientifically validated.

## Catalogue-level scientific-validation evidence

- Adds immutable aggregate catalogue-validation evidence.
- Binds aggregate evidence to the exact:
  - catalogue identity;
  - catalogue version;
  - catalogue schema version;
  - ordered member-rule identifiers; and
  - ordered member-validation identifiers.
- Prevents aggregate evidence from upgrading an unvalidated member rule.
- Prevents reuse of evidence for a different catalogue identity, version, schema, membership, or member ordering.
- Derives catalogue validation from both aggregate evidence and complete member-rule validation.

## Deterministic structural reports

Adds side-effect-free public assessment functions for rules and catalogues.

The reports:

- expose deterministic reason codes;
- validate structural evidence completeness and consistency;
- are immutable and JSON-safe;
- cannot be forged with inconsistent booleans and reasons;
- do not execute scientific validation;
- do not reproduce or independently verify a scientific study; and
- do not establish that caller-supplied evidence is scientifically correct.

## Serialization and compatibility

- Bumps the pairing-rule schema to `pgmuvi-instrument-channel-pairing-rule-v2`.
- Bumps the catalogue schema to `pgmuvi-instrument-channel-pairing-rule-catalogue-v2`.
- Adds strict evidence schemas and structural-report schemas.
- Extends strict rule and catalogue serialization/deserialization with typed validation evidence.
- Preserves exact compatibility checks and explicit-path loading/local activation boundaries.

## Explicitly excluded

This PR does **not** add:

- a populated built-in pairing-rule catalogue;
- any claim that a real observational-channel rule has been scientifically validated;
- a validation dataset or real validation result;
- automatic reference-channel selection;
- automatic pairing-method or tolerance selection;
- ambient discovery through environment variables, the current directory, or package resources;
- process-global activation;
- normal fitting-workflow integration;
- automatic calibration;
- representative real-data calibration execution; or
- approximate merging of distinct observational channels sharing one physical wavelength.

`TBD[instrument-channel-calibration]` therefore remains open.

## Validation

- Full repository suite: **2,744 tests passed**
- Ruff package checks: passed
- Ruff changed-test checks: passed
- Documentation TBD-marker audit: passed
- Strict documentation build: passed
- Public export and runtime-contract smoke tests: passed
- Fail-closed scientific-validation audit: passed
- Populated-catalogue audit: passed
- Ambient/global/workflow-integration audit: passed
- `git diff --check`: passed

## Commit

`659a1094740430f741cea7e07b167b29f925b602` — Define scientific validation evidence contract
