### PR TITLE
Remove repository-external and broken file references

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -105,7 +105,7 @@ ruff check -v --output-format=full --show-fixes pgmuvi/
 ```
 
 **Ruff configuration** is in `pyproject.toml` under `[tool.ruff]`:
-- **Excluded from linting**: `tests/` directory and `pgmuvi/test_script.py`
+- **Excluded from linting**: `tests/` directory
 - **Line length**: 88 characters (Black-compatible; E501 is *not* ignored)
 - **Enabled rule sets**: A, B, E, F, ISC, UP, RUF, W
 - **Explicitly ignored**: UP004, B007, ISC001 (ISC001 conflicts with the formatter)
@@ -301,7 +301,7 @@ Core dependencies (from `pyproject.toml`):
 - **setup.py**: Minimal setup.py exists only for backward compatibility with older pip versions
 - **Testing Framework**: Uses stdlib `unittest` with tox — **not pytest**
 - **Documentation**: Built with Sphinx and hosted on ReadTheDocs
-- **Excluding Tests from Lint**: `tests/` and `pgmuvi/test_script.py` are excluded from Ruff
+- **Excluding Tests from Lint**: `tests/` is excluded from Ruff
 - **Notebooks**: Ruff also lints Jupyter notebooks (`*.ipynb`) in addition to `.py` files
 
 ## Validation Steps

--- a/docs/source/howto/wavelength_advisory_batch.rst
+++ b/docs/source/howto/wavelength_advisory_batch.rst
@@ -135,8 +135,7 @@ The same script also accepts a source-list file:
 .. code-block:: bash
 
    cat > sources.txt <<'EOF'
-   10131+3049=10131+3049.csv
-   07454-7112=07454-7112.csv
+   10131+3049=examples/data/10131+3049.csv
    EOF
 
    PYTHONPATH=. python3 examples/run_wavelength_advisory_batch.py \
@@ -157,8 +156,10 @@ The equivalent Python entry point is:
 
    report = LC.run_period_independent_wavelength_advisory_workflow_batch(
        [
-           {"source_id": "10131+3049", "csv_path": "10131+3049.csv"},
-           {"source_id": "07454-7112", "csv_path": "07454-7112.csv"},
+           {
+               "source_id": "10131+3049",
+               "csv_path": "examples/data/10131+3049.csv",
+           },
        ],
        from_csv_kwargs={
            "check_sampling": True,

--- a/docs/source/notebooks/pgmuvi_tutorial.ipynb
+++ b/docs/source/notebooks/pgmuvi_tutorial.ipynb
@@ -115,7 +115,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "c:\\Users\\peter\\anaconda3\\envs\\pgmuvi_dev\\Lib\\site-packages\\tqdm\\auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
       "  from .autonotebook import tqdm as notebook_tqdm\n"
      ]
     }
@@ -203,7 +203,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "c:\\Users\\peter\\anaconda3\\envs\\pgmuvi_dev\\Lib\\site-packages\\gpytorch\\likelihoods\\noise_models.py:148: NumericalWarning: Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 0.0001.\n",
+      "gpytorch/likelihoods/noise_models.py:148: NumericalWarning: Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 0.0001.\n",
       "  warnings.warn(\n"
      ]
     },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ include-package-data = false
 [tool.setuptools_scm]
 
 [tool.ruff]
-exclude = ["tests", "pgmuvi/test_script.py"]
+exclude = ["tests"]
 # include notebooks!
 include = ["*.py", "*.pyi", "**/pyproject.toml", "*.ipynb"]
 

--- a/tests/test_repository_reference_hygiene.py
+++ b/tests/test_repository_reference_hygiene.py
@@ -1,0 +1,79 @@
+"""Regression checks for repository-local reference hygiene."""
+
+from __future__ import annotations
+
+import json
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MACHINE_LOCAL_PATH = re.compile(
+    r"(/Users/|/Volumes/|/home/|[A-Za-z]:\\Users\\|file://)"
+)
+
+
+class TestRepositoryReferenceHygiene(unittest.TestCase):
+    def test_removed_test_script_is_not_referenced(self):
+        text = "\n".join(
+            [
+                (ROOT / ".github/copilot-instructions.md").read_text(
+                    encoding="utf-8"
+                ),
+                (ROOT / "pyproject.toml").read_text(encoding="utf-8"),
+            ]
+        )
+        self.assertNotIn("pgmuvi/test_script.py", text)
+        self.assertFalse((ROOT / "pgmuvi/test_script.py").exists())
+
+    def test_batch_docs_use_existing_public_source(self):
+        text = (
+            ROOT / "docs/source/howto/wavelength_advisory_batch.rst"
+        ).read_text(encoding="utf-8")
+        self.assertNotIn("07454-7112.csv", text)
+        self.assertIn("examples/data/10131+3049.csv", text)
+        self.assertTrue(
+            (ROOT / "examples/data/10131+3049.csv").is_file()
+        )
+
+    def test_notebook_outputs_have_no_machine_local_paths(self):
+        violations = []
+
+        for path in sorted(
+            (ROOT / "docs/source/notebooks").glob("*.ipynb")
+        ):
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            relative = path.relative_to(ROOT).as_posix()
+
+            sections = [
+                ("metadata", payload.get("metadata", {})),
+            ]
+
+            for cell_index, cell in enumerate(payload.get("cells", [])):
+                sections.append(
+                    (
+                        f"cell[{cell_index}].metadata",
+                        cell.get("metadata", {}),
+                    )
+                )
+                for output_index, output in enumerate(
+                    cell.get("outputs", [])
+                ):
+                    sections.append(
+                        (
+                            f"cell[{cell_index}].outputs[{output_index}]",
+                            output,
+                        )
+                    )
+
+            for location, content in sections:
+                serialized = json.dumps(content, ensure_ascii=False)
+                if MACHINE_LOCAL_PATH.search(serialized):
+                    violations.append(f"{relative}:{location}")
+
+        self.assertEqual(violations, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- remove stale Ruff references to the nonexistent `pgmuvi/test_script.py`
- replace broken `07454-7112.csv` documentation examples with the tracked representative source at `examples/data/10131+3049.csv`
- remove machine-local Windows environment prefixes from saved public-notebook warning output
- add repository-reference hygiene regression tests

## Validation

- `python3 -m unittest discover -s tests -v`
  - 2,767 tests passed
- `python3 -m ruff check ./pgmuvi tests/test_repository_reference_hygiene.py`
- `make -C docs html-strict`
- committed diff passes `git diff --check`
- no stale production references remain
- no machine-local paths remain in saved notebook metadata or outputs

## Scope

This PR performs repository-reference hygiene only. It does not change fitting behavior, scientific conclusions, calibration validation status, catalogue contents, or workflow activation.

No merge has been performed.
