### PR TITLE
Reconcile representative calibration validation status

### DIFF
--- a/docs/source/future_work.rst
+++ b/docs/source/future_work.rst
@@ -175,12 +175,19 @@ Wavelength-model extensions
     failures.  Derived datasets do not count as independent sources, and prior
     exploratory runs are explicitly ineligible as validation evidence.
 
-    This does not close ``TBD[instrument-channel-calibration]``.  The protocol has
-    not been executed, no real rule is claimed as scientifically validated, and no
-    populated scientifically validated rule catalogue exists.  Prospective
-    representative calibration validation on the anchor source and additional
-    independent astrophysical sources remains future work, together with normal
-    light-curve workflow integration.
+    This does not close ``TBD[instrument-channel-calibration]``.  The frozen
+    protocol has now been executed on the repository-contained anchor dataset.
+    The committed report is ``inconclusive`` with the recorded reasons
+    ``source_results_inconclusive`` and
+    ``insufficient_independent_astrophysical_sources``: source-level evidence
+    was inconclusive and only one independent astrophysical source was
+    available.
+    No real rule is therefore claimed as scientifically validated, and no
+    populated scientifically validated rule catalogue exists.  Obtaining
+    scientifically adequate fold evidence for the anchor source and completing
+    representative calibration validation on additional independent
+    astrophysical sources remain future work, together with normal light-curve
+    workflow integration.
 
 **TBD[multi-periodic-wavelength-models]**
     Add a documented and validated multi-periodic workflow beyond the current

--- a/docs/source/pgmuvi.instrument_channel_calibration.rst
+++ b/docs/source/pgmuvi.instrument_channel_calibration.rst
@@ -417,8 +417,8 @@ the compatibility field.  A manually constructed calibration may participate
 when it carries valid available coefficient covariance; fit provenance is not
 required merely because the coefficients were supplied manually.
 
-Prospective representative validation protocol
-----------------------------------------------
+Representative validation protocol and execution status
+-------------------------------------------------------
 
 The contract in
 :mod:`pgmuvi.instrument_channel_calibration_validation` defines a
@@ -441,9 +441,16 @@ evidence that exceeds a quantitative gate is a calibration failure.
 
 Source independence is keyed to astrophysical source identity; derived
 datasets do not count as independent sources.  Prior exploratory runs are
-ineligible as validation evidence.  The contract does not execute the
-protocol, does not create a scientifically validated rule, and does not
-populate a pairing-rule catalogue.
+ineligible as validation evidence.  The protocol contract itself does not
+execute the protocol, create a scientifically validated rule, or populate a
+pairing-rule catalogue.
+
+The maintained executor has subsequently run the frozen protocol against the
+committed anchor dataset.  The resulting report is ``inconclusive`` with the
+recorded reasons ``source_results_inconclusive`` and
+``insufficient_independent_astrophysical_sources``.  This execution therefore
+does not establish a scientifically validated KELT pairing rule, populate a
+catalogue, or authorize activation in ordinary fitting.
 
 ``TBD[instrument-channel-calibration]`` remains open
 ----------------------------------------------------

--- a/docs/source/pgmuvi.instrument_channel_calibration_validation.rst
+++ b/docs/source/pgmuvi.instrument_channel_calibration_validation.rst
@@ -55,11 +55,15 @@ identity, a protocol-digest mismatch, a missing anchor dataset, incomplete
 source or fold evidence, duplicate primary datasets, or too few independent
 astrophysical sources all fail closed as ``inconclusive``.
 
-``TBD[instrument-channel-calibration]`` remains open.  A following PR must
-execute the committed protocol on the anchor source and additional independent
-astrophysical sources.  This contract
-does not populate a pairing-rule catalogue and makes no claim that the KELT
-candidate rule is scientifically validated.
+``TBD[instrument-channel-calibration]`` remains open.  The committed
+protocol has now been executed on the repository-contained anchor dataset.
+The committed report is ``inconclusive`` with reasons
+``source_results_inconclusive`` and
+``insufficient_independent_astrophysical_sources``.  Additional scientifically
+adequate source evidence and validation on independent astrophysical sources
+are still required.  The maintained execution
+does not populate a pairing-rule catalogue, and the KELT candidate rule is
+not claimed as scientifically validated.
 
 Maintained execution
 --------------------

--- a/docs/source/pgmuvi.instrument_channel_calibration_validation_execution.rst
+++ b/docs/source/pgmuvi.instrument_channel_calibration_validation_execution.rst
@@ -18,3 +18,19 @@ and delegates the final disposition to the validation assessor.
 Dataset references must resolve inside the repository.  The executor does not
 search sibling directories, populate the scientifically validated pairing-rule
 catalogue, or activate instrument-channel calibration in normal fitting.
+
+Maintained execution status
+---------------------------
+
+The frozen KELT ``R3_0``/``R3_1`` protocol has been executed against the
+repository-contained anchor dataset.  The maintained artifacts are:
+
+* ``examples/validation/kelt_r3_pairing_validation_protocol_v1.json``;
+* ``examples/validation/kelt_r3_pairing_validation_result_v1.json``; and
+* ``examples/validation/kelt_r3_pairing_validation_report_v1.json``.
+
+The committed report disposition is ``inconclusive``.  Its reasons are
+``source_results_inconclusive`` and
+``insufficient_independent_astrophysical_sources``.  The execution performed
+no catalogue population and does not establish a scientifically validated
+pairing rule or authorize calibration in ordinary light-curve fitting.

--- a/tests/test_docs_instrument_channel_calibration.py
+++ b/tests/test_docs_instrument_channel_calibration.py
@@ -12,6 +12,11 @@ DOCS = Path("docs/source")
 API = DOCS / "api.rst"
 PAGE = DOCS / "pgmuvi.instrument_channel_calibration.rst"
 FUTURE = DOCS / "future_work.rst"
+VALIDATION = DOCS / "pgmuvi.instrument_channel_calibration_validation.rst"
+EXECUTION = (
+    DOCS
+    / "pgmuvi.instrument_channel_calibration_validation_execution.rst"
+)
 ESTIMATION = DOCS / "pgmuvi.wavelength_estimation.rst"
 MULTIBAND = DOCS / "howto/multiband.rst"
 
@@ -333,6 +338,52 @@ class TestInstrumentChannelCalibrationDocumentation(unittest.TestCase):
         self.assertNotIn(
             "uncertainty estimation and propagation",
             text,
+        )
+
+    def test_representative_validation_status_matches_committed_evidence(
+        self,
+    ):
+        future = " ".join(FUTURE.read_text(encoding="utf-8").split())
+        page = " ".join(PAGE.read_text(encoding="utf-8").split())
+        validation = " ".join(
+            VALIDATION.read_text(encoding="utf-8").split()
+        )
+        execution = " ".join(
+            EXECUTION.read_text(encoding="utf-8").split()
+        )
+
+        for text in (future, page, validation, execution):
+            self.assertIn("inconclusive", text)
+
+        for text in (future, page, validation, execution):
+            self.assertIn("source_results_inconclusive", text)
+            self.assertIn(
+                "insufficient_independent_astrophysical_sources",
+                text,
+            )
+
+        self.assertNotIn("protocol has not been executed", future)
+        self.assertNotIn("A following PR must execute", validation)
+
+        self.assertIn(
+            "kelt_r3_pairing_validation_report_v1.json",
+            execution,
+        )
+        self.assertIn(
+            "no catalogue population",
+            execution.lower(),
+        )
+        self.assertIn(
+            "not claimed as scientifically validated",
+            validation,
+        )
+        self.assertIn(
+            "TBD[instrument-channel-calibration]",
+            future,
+        )
+        self.assertIn(
+            "TBD[instrument-channel-calibration]",
+            validation,
         )
 
     def test_estimation_and_multiband_guides_reference_contract(self):


### PR DESCRIPTION
## Summary

- reconcile the maintained documentation with the completed representative instrument-channel calibration validation execution
- record the committed report disposition as `inconclusive`
- preserve the exact committed-report reasons:
  - `source_results_inconclusive`
  - `insufficient_independent_astrophysical_sources`
- keep `TBD[instrument-channel-calibration]` open
- add documentation regression coverage preventing stale pre-execution language from returning

## Scientific status

The frozen KELT `R3_0`/`R3_1` protocol has been executed against the repository-contained anchor dataset.

The committed report remains `inconclusive` because:

- source-level evidence was inconclusive; and
- only one independent astrophysical source was available.

This PR does **not**:

- claim that a pairing rule is scientifically validated;
- populate a scientifically validated pairing-rule catalogue;
- activate calibration in ordinary light-curve fitting; or
- close `TBD[instrument-channel-calibration]`.

Scientifically adequate anchor-source fold evidence and validation across additional independent astrophysical sources remain future work.

## Files changed

- `docs/source/future_work.rst`
- `docs/source/pgmuvi.instrument_channel_calibration.rst`
- `docs/source/pgmuvi.instrument_channel_calibration_validation.rst`
- `docs/source/pgmuvi.instrument_channel_calibration_validation_execution.rst`
- `tests/test_docs_instrument_channel_calibration.py`

## Validation

- `python3 -m unittest discover -s tests`
  - 2,768 tests passed
- `python3 -m ruff check ./pgmuvi tests/test_docs_instrument_channel_calibration.py`
- `python3 scripts/audit_docs_tbd_markers.py`
- `make -C docs html-strict`
- `git diff --check`
- committed evidence/documentation status contract check
- stale pre-execution wording scan
