### PR TITLE
Add dataset-agnostic calibration validation execution

### DIFF
--- a/docs/source/future_work.rst
+++ b/docs/source/future_work.rst
@@ -183,11 +183,16 @@ Wavelength-model extensions
     was inconclusive and only one independent astrophysical source was
     available.
     No real rule is therefore claimed as scientifically validated, and no
-    populated scientifically validated rule catalogue exists.  Obtaining
-    scientifically adequate fold evidence for the anchor source and completing
-    representative calibration validation on additional independent
-    astrophysical sources remain future work, together with normal light-curve
-    workflow integration.
+    populated scientifically validated rule catalogue exists.  A strict,
+    protocol-bound dataset-manifest execution path now supports repository-
+    contained additional independent primary sources while preserving dataset
+    identity, lineage, digest, observational-channel, and frozen-protocol
+    constraints.  No eligible second KELT source is currently distributed, and
+    the anchor still contains one low-dynamic-range fold.  Obtaining
+    scientifically adequate anchor evidence and the remaining representative calibration validation
+    with genuinely independent external scientific data therefore remain future
+    work, together with catalogue population and normal
+    light-curve workflow integration.
 
 **TBD[multi-periodic-wavelength-models]**
     Add a documented and validated multi-periodic workflow beyond the current

--- a/docs/source/pgmuvi.instrument_channel_calibration_validation.rst
+++ b/docs/source/pgmuvi.instrument_channel_calibration_validation.rst
@@ -71,9 +71,11 @@ Maintained execution
 The numerical execution path is implemented separately in
 :mod:`pgmuvi.instrument_channel_calibration_validation_execution`.
 It verifies that every dataset reference resolves within the repository and
-that the exact dataset SHA-256 matches the frozen protocol before pairing or
-fitting begins.  Fold construction, fitting, held-out metrics, and assessment
-remain deterministic for fixed code and data.
+that each exact dataset SHA-256 matches its immutable identity before pairing
+or fitting begins.  The anchor-only runner remains available, and a strict
+protocol-bound dataset manifest can supply additional independent primary
+sources without altering the frozen protocol.  Fold construction, fitting,
+held-out metrics, and assessment remain deterministic for fixed code and data.
 
 Executing a protocol is not catalogue population.  The maintained runner
 records evidence and the assessor derives ``passed``, ``failed``, or

--- a/docs/source/pgmuvi.instrument_channel_calibration_validation_execution.rst
+++ b/docs/source/pgmuvi.instrument_channel_calibration_validation_execution.rst
@@ -19,6 +19,57 @@ Dataset references must resolve inside the repository.  The executor does not
 search sibling directories, populate the scientifically validated pairing-rule
 catalogue, or activate instrument-channel calibration in normal fitting.
 
+Additional independent sources
+------------------------------
+
+The anchor-only API remains available.  For additional independent sources,
+the maintained runner accepts a strict dataset manifest through
+``--dataset-manifest``.  The manifest is a repository-relative JSON record
+bound to the exact protocol identity
+and canonical SHA-256 digest.  It contains only additional primary datasets;
+the executor always evaluates the frozen anchor itself and then evaluates each
+manifest dataset under the unchanged pairing, fitting, fold, normalization,
+and acceptance configuration.
+
+Each manifest dataset must provide a distinct astrophysical-source identity,
+a unique dataset identity, a repository-relative CSV reference, and its exact
+SHA-256 digest.  Derived, filtered, copied, resampled, or otherwise transformed
+versions of the anchor are rejected as additional independent evidence.
+Every CSV must contain ``time``, ``flux``, ``flux_error``, ``wavelength``, and
+``band`` columns.  Eligible flux and uncertainty values must be finite and
+strictly positive; the two exact KELT observational-channel identities must
+remain distinct at the frozen physical wavelength.
+
+A manifest has this shape; bracketed values are placeholders, not distributed
+datasets or validation evidence:
+
+.. code-block:: json
+
+   {
+     "schema_version": "pgmuvi-instrument-channel-calibration-validation-dataset-manifest-v1",
+     "protocol_id": "kelt-osn-r3-pairing-validation-v1",
+     "protocol_version": "1.0",
+     "protocol_sha256": "[canonical frozen protocol SHA-256]",
+     "datasets": [
+       {
+         "schema_version": "pgmuvi-instrument-channel-calibration-validation-dataset-v1",
+         "dataset_id": "[independent-dataset-id]",
+         "astrophysical_source_id": "[independent-source-id]",
+         "dataset_reference": "examples/data/[independent-source].csv",
+         "dataset_sha256": "[dataset SHA-256]",
+         "derivation_parent_dataset_id": null,
+         "is_derived": false
+       }
+     ]
+   }
+
+When ``--dataset-manifest`` is used, explicit non-default
+``--result-output`` and ``--report-output`` paths are required so the committed
+representative artifacts cannot be overwritten accidentally.  The resulting
+assessment combines the anchor and all additional source results.  This
+infrastructure does not assert that any supplied source is scientifically
+adequate and cannot turn an inconclusive anchor result into passing evidence.
+
 Maintained execution status
 ---------------------------
 
@@ -31,6 +82,10 @@ repository-contained anchor dataset.  The maintained artifacts are:
 
 The committed report disposition is ``inconclusive``.  Its reasons are
 ``source_results_inconclusive`` and
-``insufficient_independent_astrophysical_sources``.  The execution performed
-no catalogue population and does not establish a scientifically validated
-pairing rule or authorize calibration in ordinary light-curve fitting.
+``insufficient_independent_astrophysical_sources``.  The anchor contains one
+low-dynamic-range fold, and the repository contains no second eligible
+independent KELT source.  The dataset-manifest execution surface is therefore
+ready for future supplied data, but no current evidence passes the frozen
+protocol.  The execution performed no catalogue population and does not
+establish a scientifically validated pairing rule or authorize calibration in
+ordinary light-curve fitting.

--- a/pgmuvi/instrument_channel_calibration_validation.py
+++ b/pgmuvi/instrument_channel_calibration_validation.py
@@ -23,6 +23,9 @@ from pgmuvi.instrument_channel_calibration import (
 INSTRUMENT_CHANNEL_CALIBRATION_VALIDATION_DATASET_SCHEMA_VERSION = (
     "pgmuvi-instrument-channel-calibration-validation-dataset-v1"
 )
+INSTRUMENT_CHANNEL_CALIBRATION_VALIDATION_DATASET_MANIFEST_SCHEMA_VERSION = (
+    "pgmuvi-instrument-channel-calibration-validation-dataset-manifest-v1"
+)
 INSTRUMENT_CHANNEL_CALIBRATION_VALIDATION_ACCEPTANCE_CRITERIA_SCHEMA_VERSION = (
     "pgmuvi-instrument-channel-calibration-validation-acceptance-criteria-v1"
 )
@@ -44,6 +47,7 @@ INSTRUMENT_CHANNEL_CALIBRATION_VALIDATION_REPORT_SCHEMA_VERSION = (
 
 __all__ = [
     "INSTRUMENT_CHANNEL_CALIBRATION_VALIDATION_ACCEPTANCE_CRITERIA_SCHEMA_VERSION",
+    "INSTRUMENT_CHANNEL_CALIBRATION_VALIDATION_DATASET_MANIFEST_SCHEMA_VERSION",
     "INSTRUMENT_CHANNEL_CALIBRATION_VALIDATION_DATASET_SCHEMA_VERSION",
     "INSTRUMENT_CHANNEL_CALIBRATION_VALIDATION_FOLD_RESULT_SCHEMA_VERSION",
     "INSTRUMENT_CHANNEL_CALIBRATION_VALIDATION_PROTOCOL_SCHEMA_VERSION",
@@ -52,6 +56,7 @@ __all__ = [
     "INSTRUMENT_CHANNEL_CALIBRATION_VALIDATION_SOURCE_RESULT_SCHEMA_VERSION",
     "InstrumentChannelCalibrationValidationAcceptanceCriteria",
     "InstrumentChannelCalibrationValidationDataset",
+    "InstrumentChannelCalibrationValidationDatasetManifest",
     "InstrumentChannelCalibrationValidationDisposition",
     "InstrumentChannelCalibrationValidationFoldResult",
     "InstrumentChannelCalibrationValidationProtocol",
@@ -280,6 +285,143 @@ class InstrumentChannelCalibrationValidationDataset:
                 "strict contract representation."
             )
         return dataset
+
+
+
+@dataclass(frozen=True)
+class InstrumentChannelCalibrationValidationDatasetManifest:
+    """Strict additional-source datasets bound to one frozen protocol."""
+
+    protocol_id: str
+    protocol_version: str
+    protocol_sha256: str
+    datasets: tuple[InstrumentChannelCalibrationValidationDataset, ...]
+    schema_version: str = (
+        INSTRUMENT_CHANNEL_CALIBRATION_VALIDATION_DATASET_MANIFEST_SCHEMA_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if self.schema_version != (
+            INSTRUMENT_CHANNEL_CALIBRATION_VALIDATION_DATASET_MANIFEST_SCHEMA_VERSION
+        ):
+            raise ValueError(
+                "Unsupported calibration-validation dataset-manifest schema "
+                f"version: {self.schema_version!r}."
+            )
+        object.__setattr__(
+            self,
+            "protocol_id",
+            _normalize_text(self.protocol_id, name="protocol_id"),
+        )
+        object.__setattr__(
+            self,
+            "protocol_version",
+            _normalize_text(
+                self.protocol_version,
+                name="protocol_version",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "protocol_sha256",
+            _normalize_sha256(
+                self.protocol_sha256,
+                name="protocol_sha256",
+            ),
+        )
+
+        datasets = self.datasets
+        if isinstance(datasets, (str, bytes)):
+            raise TypeError("datasets must be a sequence of validation datasets.")
+        normalized = tuple(datasets)
+        if not normalized:
+            raise ValueError(
+                "datasets must contain at least one additional dataset."
+            )
+        if any(
+            not isinstance(
+                dataset,
+                InstrumentChannelCalibrationValidationDataset,
+            )
+            for dataset in normalized
+        ):
+            raise TypeError(
+                "datasets must contain only "
+                "InstrumentChannelCalibrationValidationDataset records."
+            )
+        if any(dataset.is_derived for dataset in normalized):
+            raise ValueError(
+                "Additional validation datasets must be primary, not derived."
+            )
+
+        dataset_ids = tuple(dataset.dataset_id for dataset in normalized)
+        if len(set(dataset_ids)) != len(dataset_ids):
+            raise ValueError(
+                "Additional validation datasets must use unique dataset_id values."
+            )
+
+        source_ids = tuple(
+            dataset.astrophysical_source_id for dataset in normalized
+        )
+        if len(set(source_ids)) != len(source_ids):
+            raise ValueError(
+                "Additional validation datasets must represent distinct "
+                "astrophysical sources."
+            )
+
+        object.__setattr__(self, "datasets", normalized)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the strict JSON-safe manifest representation."""
+
+        return {
+            "schema_version": self.schema_version,
+            "protocol_id": self.protocol_id,
+            "protocol_version": self.protocol_version,
+            "protocol_sha256": self.protocol_sha256,
+            "datasets": [dataset.to_dict() for dataset in self.datasets],
+        }
+
+    @classmethod
+    def from_dict(
+        cls,
+        payload: Any,
+    ) -> InstrumentChannelCalibrationValidationDatasetManifest:
+        """Construct an additional-source manifest from strict JSON data."""
+
+        if not isinstance(payload, dict):
+            raise TypeError(
+                "Calibration-validation dataset manifest must be a dictionary."
+            )
+        expected_keys = {
+            "schema_version",
+            "protocol_id",
+            "protocol_version",
+            "protocol_sha256",
+            "datasets",
+        }
+        if set(payload) != expected_keys:
+            raise ValueError(
+                "Calibration-validation dataset-manifest payload must contain "
+                "exactly the contract fields."
+            )
+
+        manifest = cls(
+            schema_version=payload["schema_version"],
+            protocol_id=payload["protocol_id"],
+            protocol_version=payload["protocol_version"],
+            protocol_sha256=payload["protocol_sha256"],
+            datasets=tuple(
+                InstrumentChannelCalibrationValidationDataset.from_dict(item)
+                for item in payload["datasets"]
+            ),
+        )
+        if manifest.to_dict() != payload:
+            raise ValueError(
+                "Calibration-validation dataset-manifest payload does not "
+                "match the strict contract representation."
+            )
+        return manifest
 
 
 @dataclass(frozen=True)

--- a/pgmuvi/instrument_channel_calibration_validation_execution.py
+++ b/pgmuvi/instrument_channel_calibration_validation_execution.py
@@ -24,6 +24,8 @@ from pgmuvi.instrument_channel_calibration import (
     fit_instrument_channel_calibration,
 )
 from pgmuvi.instrument_channel_calibration_validation import (
+    InstrumentChannelCalibrationValidationDataset,
+    InstrumentChannelCalibrationValidationDatasetManifest,
     InstrumentChannelCalibrationValidationFoldResult,
     InstrumentChannelCalibrationValidationProtocol,
     InstrumentChannelCalibrationValidationReport,
@@ -51,6 +53,7 @@ __all__ = [
     "DEFAULT_INSTRUMENT_CHANNEL_CALIBRATION_VALIDATION_REPORT_REFERENCE",
     "DEFAULT_INSTRUMENT_CHANNEL_CALIBRATION_VALIDATION_RESULT_ID",
     "DEFAULT_INSTRUMENT_CHANNEL_CALIBRATION_VALIDATION_RESULT_REFERENCE",
+    "execute_instrument_channel_calibration_validation_dataset_manifest",
     "execute_instrument_channel_calibration_validation_protocol",
     "write_instrument_channel_calibration_validation_artifacts",
 ]
@@ -102,20 +105,36 @@ def _load_protocol(
     return InstrumentChannelCalibrationValidationProtocol.from_dict(payload)
 
 
-def _load_anchor_channel_rows(
+def _load_dataset_manifest(
+    repository_root: Path,
+    manifest_reference: str,
+) -> InstrumentChannelCalibrationValidationDatasetManifest:
+    path = _repository_path(
+        repository_root,
+        manifest_reference,
+        name="dataset_manifest_reference",
+    )
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return InstrumentChannelCalibrationValidationDatasetManifest.from_dict(
+        payload
+    )
+
+
+def _load_dataset_channel_rows(
     repository_root: Path,
     protocol: InstrumentChannelCalibrationValidationProtocol,
+    dataset: InstrumentChannelCalibrationValidationDataset,
 ) -> tuple[np.ndarray, np.ndarray]:
     dataset_path = _repository_path(
         repository_root,
-        protocol.anchor_dataset.dataset_reference,
-        name="anchor_dataset.dataset_reference",
+        dataset.dataset_reference,
+        name="dataset.dataset_reference",
     )
 
     actual_sha256 = _file_sha256(dataset_path)
-    if actual_sha256 != protocol.anchor_dataset.dataset_sha256:
+    if actual_sha256 != dataset.dataset_sha256:
         raise ValueError(
-            "Anchor dataset SHA-256 does not match the frozen protocol."
+            "Validation dataset SHA-256 does not match its manifest identity."
         )
 
     reference_rows: list[tuple[float, float, float]] = []
@@ -135,7 +154,7 @@ def _load_anchor_channel_rows(
         }
         if not required.issubset(reader.fieldnames or ()):
             raise ValueError(
-                "Anchor dataset must contain time, flux, flux_error, "
+                "Validation dataset must contain time, flux, flux_error, "
                 "wavelength, and band columns."
             )
 
@@ -172,16 +191,27 @@ def _load_anchor_channel_rows(
 
     if not reference_rows:
         raise ValueError(
-            "Anchor dataset contains no usable reference-channel rows."
+            "Validation dataset contains no usable reference-channel rows."
         )
     if not channel_rows:
         raise ValueError(
-            "Anchor dataset contains no usable target-channel rows."
+            "Validation dataset contains no usable target-channel rows."
         )
 
     return (
         np.asarray(reference_rows, dtype=float),
         np.asarray(channel_rows, dtype=float),
+    )
+
+
+def _load_anchor_channel_rows(
+    repository_root: Path,
+    protocol: InstrumentChannelCalibrationValidationProtocol,
+) -> tuple[np.ndarray, np.ndarray]:
+    return _load_dataset_channel_rows(
+        repository_root,
+        protocol,
+        protocol.anchor_dataset,
     )
 
 
@@ -361,28 +391,13 @@ def _execute_fold(
         )
 
 
-def execute_instrument_channel_calibration_validation_protocol(
+def _validate_execution_request(
     *,
     repository_root: str | Path,
-    protocol_reference: str = (
-        DEFAULT_INSTRUMENT_CHANNEL_CALIBRATION_VALIDATION_PROTOCOL_REFERENCE
-    ),
-    result_id: str = (
-        DEFAULT_INSTRUMENT_CHANNEL_CALIBRATION_VALIDATION_RESULT_ID
-    ),
-    result_version: str = "1.0",
-    execution_reference: str = (
-        DEFAULT_INSTRUMENT_CHANNEL_CALIBRATION_VALIDATION_RESULT_REFERENCE
-    ),
     package_version: str,
     package_commit: str,
     executed_at_utc: str,
-) -> tuple[
-    InstrumentChannelCalibrationValidationResult,
-    InstrumentChannelCalibrationValidationReport,
-]:
-    """Execute one frozen protocol against its repository-contained anchor."""
-
+) -> tuple[Path, str]:
     root = Path(repository_root).resolve()
     if not root.is_dir():
         raise ValueError("repository_root must identify an existing directory.")
@@ -400,11 +415,19 @@ def execute_instrument_channel_calibration_validation_protocol(
         raise ValueError(
             "executed_at_utc must use YYYY-MM-DDTHH:MM:SSZ."
         )
+    return root, package_version.strip()
 
-    protocol = _load_protocol(root, protocol_reference)
-    reference_rows, channel_rows = _load_anchor_channel_rows(
-        root,
+
+def _execute_validation_dataset(
+    *,
+    repository_root: Path,
+    protocol: InstrumentChannelCalibrationValidationProtocol,
+    dataset: InstrumentChannelCalibrationValidationDataset,
+) -> InstrumentChannelCalibrationValidationSourceResult:
+    reference_rows, channel_rows = _load_dataset_channel_rows(
+        repository_root,
         protocol,
+        dataset,
     )
 
     reference_positions, channel_positions = (
@@ -452,12 +475,31 @@ def execute_instrument_channel_calibration_validation_protocol(
             "one_or_more_temporal_folds_unsuccessful",
         )
 
-    source_result = InstrumentChannelCalibrationValidationSourceResult(
-        dataset=protocol.anchor_dataset,
+    return InstrumentChannelCalibrationValidationSourceResult(
+        dataset=dataset,
         n_matched_pairs=n_pairs,
         fold_results=fold_results,
         failure_reasons=source_failure_reasons,
     )
+
+
+def _build_validation_result(
+    *,
+    protocol: InstrumentChannelCalibrationValidationProtocol,
+    source_results: tuple[
+        InstrumentChannelCalibrationValidationSourceResult,
+        ...,
+    ],
+    result_id: str,
+    result_version: str,
+    execution_reference: str,
+    package_version: str,
+    package_commit: str,
+    executed_at_utc: str,
+) -> tuple[
+    InstrumentChannelCalibrationValidationResult,
+    InstrumentChannelCalibrationValidationReport,
+]:
     result = InstrumentChannelCalibrationValidationResult(
         result_id=result_id,
         result_version=result_version,
@@ -466,10 +508,10 @@ def execute_instrument_channel_calibration_validation_protocol(
         protocol_sha256=protocol.canonical_sha256,
         rule_id=protocol.rule_id,
         execution_reference=execution_reference,
-        package_version=package_version.strip(),
+        package_version=package_version,
         package_commit=package_commit,
         executed_at_utc=executed_at_utc,
-        source_results=(source_result,),
+        source_results=source_results,
         execution_completed=True,
     )
 
@@ -480,6 +522,144 @@ def execute_instrument_channel_calibration_validation_protocol(
         result,
     )
     return result, report
+
+
+def execute_instrument_channel_calibration_validation_protocol(
+    *,
+    repository_root: str | Path,
+    protocol_reference: str = (
+        DEFAULT_INSTRUMENT_CHANNEL_CALIBRATION_VALIDATION_PROTOCOL_REFERENCE
+    ),
+    result_id: str = (
+        DEFAULT_INSTRUMENT_CHANNEL_CALIBRATION_VALIDATION_RESULT_ID
+    ),
+    result_version: str = "1.0",
+    execution_reference: str = (
+        DEFAULT_INSTRUMENT_CHANNEL_CALIBRATION_VALIDATION_RESULT_REFERENCE
+    ),
+    package_version: str,
+    package_commit: str,
+    executed_at_utc: str,
+) -> tuple[
+    InstrumentChannelCalibrationValidationResult,
+    InstrumentChannelCalibrationValidationReport,
+]:
+    """Execute one frozen protocol against its repository-contained anchor."""
+
+    root, normalized_version = _validate_execution_request(
+        repository_root=repository_root,
+        package_version=package_version,
+        package_commit=package_commit,
+        executed_at_utc=executed_at_utc,
+    )
+    protocol = _load_protocol(root, protocol_reference)
+    source_result = _execute_validation_dataset(
+        repository_root=root,
+        protocol=protocol,
+        dataset=protocol.anchor_dataset,
+    )
+    return _build_validation_result(
+        protocol=protocol,
+        source_results=(source_result,),
+        result_id=result_id,
+        result_version=result_version,
+        execution_reference=execution_reference,
+        package_version=normalized_version,
+        package_commit=package_commit,
+        executed_at_utc=executed_at_utc,
+    )
+
+
+def execute_instrument_channel_calibration_validation_dataset_manifest(
+    *,
+    repository_root: str | Path,
+    dataset_manifest_reference: str,
+    protocol_reference: str = (
+        DEFAULT_INSTRUMENT_CHANNEL_CALIBRATION_VALIDATION_PROTOCOL_REFERENCE
+    ),
+    result_id: str = (
+        DEFAULT_INSTRUMENT_CHANNEL_CALIBRATION_VALIDATION_RESULT_ID
+    ),
+    result_version: str = "1.0",
+    execution_reference: str = (
+        DEFAULT_INSTRUMENT_CHANNEL_CALIBRATION_VALIDATION_RESULT_REFERENCE
+    ),
+    package_version: str,
+    package_commit: str,
+    executed_at_utc: str,
+) -> tuple[
+    InstrumentChannelCalibrationValidationResult,
+    InstrumentChannelCalibrationValidationReport,
+]:
+    """Execute the anchor plus strict additional independent datasets."""
+
+    root, normalized_version = _validate_execution_request(
+        repository_root=repository_root,
+        package_version=package_version,
+        package_commit=package_commit,
+        executed_at_utc=executed_at_utc,
+    )
+    protocol = _load_protocol(root, protocol_reference)
+    manifest = _load_dataset_manifest(
+        root,
+        dataset_manifest_reference,
+    )
+
+    if (
+        manifest.protocol_id != protocol.protocol_id
+        or manifest.protocol_version != protocol.protocol_version
+    ):
+        raise ValueError(
+            "Dataset manifest protocol identity does not match the "
+            "frozen protocol."
+        )
+    if manifest.protocol_sha256 != protocol.canonical_sha256:
+        raise ValueError(
+            "Dataset manifest protocol digest does not match the "
+            "frozen protocol."
+        )
+
+    anchor = protocol.anchor_dataset
+    for dataset in manifest.datasets:
+        if dataset.dataset_id == anchor.dataset_id:
+            raise ValueError(
+                "Additional dataset_id must differ from the anchor dataset."
+            )
+        if (
+            dataset.astrophysical_source_id
+            == anchor.astrophysical_source_id
+        ):
+            raise ValueError(
+                "Additional datasets must represent astrophysical sources "
+                "independent of the anchor source."
+            )
+
+    source_results = (
+        _execute_validation_dataset(
+            repository_root=root,
+            protocol=protocol,
+            dataset=anchor,
+        ),
+        *(
+            _execute_validation_dataset(
+                repository_root=root,
+                protocol=protocol,
+                dataset=dataset,
+            )
+            for dataset in manifest.datasets
+        ),
+    )
+
+    return _build_validation_result(
+        protocol=protocol,
+        source_results=source_results,
+        result_id=result_id,
+        result_version=result_version,
+        execution_reference=execution_reference,
+        package_version=normalized_version,
+        package_commit=package_commit,
+        executed_at_utc=executed_at_utc,
+    )
 
 
 def write_instrument_channel_calibration_validation_artifacts(

--- a/scripts/run_instrument_channel_calibration_validation.py
+++ b/scripts/run_instrument_channel_calibration_validation.py
@@ -13,6 +13,7 @@ from pgmuvi.instrument_channel_calibration_validation_execution import (
     DEFAULT_INSTRUMENT_CHANNEL_CALIBRATION_VALIDATION_PROTOCOL_REFERENCE,
     DEFAULT_INSTRUMENT_CHANNEL_CALIBRATION_VALIDATION_REPORT_REFERENCE,
     DEFAULT_INSTRUMENT_CHANNEL_CALIBRATION_VALIDATION_RESULT_REFERENCE,
+    execute_instrument_channel_calibration_validation_dataset_manifest,
     execute_instrument_channel_calibration_validation_protocol,
     write_instrument_channel_calibration_validation_artifacts,
 )
@@ -48,6 +49,14 @@ def main() -> int:
         "--protocol",
         default=(
             DEFAULT_INSTRUMENT_CHANNEL_CALIBRATION_VALIDATION_PROTOCOL_REFERENCE
+        ),
+    )
+    parser.add_argument(
+        "--dataset-manifest",
+        default=None,
+        help=(
+            "Repository-relative strict manifest of additional independent "
+            "validation datasets."
         ),
     )
     parser.add_argument(
@@ -87,16 +96,40 @@ def main() -> int:
         .replace("+00:00", "Z")
     )
 
-    result, report = (
-        execute_instrument_channel_calibration_validation_protocol(
-            repository_root=root,
-            protocol_reference=arguments.protocol,
-            execution_reference=arguments.result_output,
-            package_version=package_version,
-            package_commit=package_commit,
-            executed_at_utc=executed_at,
+    if arguments.dataset_manifest is None:
+        result, report = (
+            execute_instrument_channel_calibration_validation_protocol(
+                repository_root=root,
+                protocol_reference=arguments.protocol,
+                execution_reference=arguments.result_output,
+                package_version=package_version,
+                package_commit=package_commit,
+                executed_at_utc=executed_at,
+            )
         )
-    )
+    else:
+        if (
+            arguments.result_output
+            == DEFAULT_INSTRUMENT_CHANNEL_CALIBRATION_VALIDATION_RESULT_REFERENCE
+            or arguments.report_output
+            == DEFAULT_INSTRUMENT_CHANNEL_CALIBRATION_VALIDATION_REPORT_REFERENCE
+        ):
+            parser.error(
+                "--dataset-manifest requires explicit --result-output and "
+                "--report-output paths so committed representative artifacts "
+                "cannot be overwritten accidentally."
+            )
+        result, report = (
+            execute_instrument_channel_calibration_validation_dataset_manifest(
+                repository_root=root,
+                dataset_manifest_reference=arguments.dataset_manifest,
+                protocol_reference=arguments.protocol,
+                execution_reference=arguments.result_output,
+                package_version=package_version,
+                package_commit=package_commit,
+                executed_at_utc=executed_at,
+            )
+        )
 
     result_path = (root / arguments.result_output).resolve()
     report_path = (root / arguments.report_output).resolve()
@@ -107,16 +140,19 @@ def main() -> int:
         report_path=report_path,
     )
 
-    source = result.source_results[0]
     print(
         f"result={result_path.relative_to(root)} "
         f"report={report_path.relative_to(root)}"
     )
-    print(
-        f"pairs={source.n_matched_pairs} "
-        f"folds={source.n_temporal_folds} "
-        f"successful_folds={source.n_successful_temporal_folds}"
-    )
+    print(f"sources={len(result.source_results)}")
+    for source in result.source_results:
+        print(
+            f"source={source.dataset.astrophysical_source_id} "
+            f"dataset={source.dataset.dataset_id} "
+            f"pairs={source.n_matched_pairs} "
+            f"folds={source.n_temporal_folds} "
+            f"successful_folds={source.n_successful_temporal_folds}"
+        )
     print(
         f"disposition={report.disposition.value} "
         f"independent_sources="

--- a/tests/test_docs_instrument_channel_calibration.py
+++ b/tests/test_docs_instrument_channel_calibration.py
@@ -373,10 +373,14 @@ class TestInstrumentChannelCalibrationDocumentation(unittest.TestCase):
             "no catalogue population",
             execution.lower(),
         )
+        self.assertIn("dataset manifest", execution.lower())
+        self.assertIn("additional independent", execution.lower())
+        self.assertIn("low-dynamic-range fold", execution)
         self.assertIn(
             "not claimed as scientifically validated",
             validation,
         )
+        self.assertIn("protocol-bound dataset manifest", validation)
         self.assertIn(
             "TBD[instrument-channel-calibration]",
             future,

--- a/tests/test_instrument_channel_calibration_validation_execution.py
+++ b/tests/test_instrument_channel_calibration_validation_execution.py
@@ -18,10 +18,13 @@ from pgmuvi.instrument_channel_calibration import (
     fit_instrument_channel_calibration,
 )
 from pgmuvi.instrument_channel_calibration_validation import (
+    InstrumentChannelCalibrationValidationDataset,
+    InstrumentChannelCalibrationValidationDatasetManifest,
     InstrumentChannelCalibrationValidationProtocol,
 )
 from pgmuvi.instrument_channel_calibration_validation_execution import (
     _construct_partitioned_pair_positions,
+    execute_instrument_channel_calibration_validation_dataset_manifest,
     execute_instrument_channel_calibration_validation_protocol,
 )
 
@@ -271,6 +274,260 @@ class TestInstrumentChannelCalibrationValidationExecution(
                     repository_root=root,
                     protocol_reference=protocol_reference,
                     execution_reference="examples/validation/result.json",
+                    package_version="test",
+                    package_commit="1" * 40,
+                    executed_at_utc="2026-08-01T00:00:00Z",
+                )
+
+
+    def _additional_dataset_manifest(
+        self,
+        root: Path,
+        protocol_reference: str,
+        *,
+        astrophysical_source_id: str = "independent-synthetic-source",
+    ) -> tuple[str, Path]:
+        protocol_payload = json.loads(
+            (root / protocol_reference).read_text(encoding="utf-8")
+        )
+        protocol = (
+            InstrumentChannelCalibrationValidationProtocol.from_dict(
+                protocol_payload
+            )
+        )
+
+        data_reference = "examples/data/independent_validation.csv"
+        data_path = root / data_reference
+        channel_flux = np.asarray(
+            [
+                1.2
+                + 0.0025 * index
+                + 0.18 * math.sin(index / 6.0)
+                for index in range(120)
+            ],
+            dtype=float,
+        )
+
+        with data_path.open(
+            "w",
+            newline="",
+            encoding="utf-8",
+        ) as handle:
+            writer = csv.writer(handle)
+            writer.writerow(
+                ["time", "flux", "flux_error", "wavelength", "band"]
+            )
+            for index, target_flux in enumerate(channel_flux):
+                reference_flux = 0.02 + 0.68 * target_flux
+                writer.writerow(
+                    [
+                        float(index) + 0.2,
+                        reference_flux,
+                        0.001,
+                        protocol.physical_wavelength,
+                        protocol.reference_channel,
+                    ]
+                )
+                writer.writerow(
+                    [
+                        float(index) + 0.21,
+                        target_flux,
+                        0.001,
+                        protocol.physical_wavelength,
+                        protocol.channel,
+                    ]
+                )
+
+        dataset = InstrumentChannelCalibrationValidationDataset(
+            dataset_id="independent-synthetic-full-v1",
+            astrophysical_source_id=astrophysical_source_id,
+            dataset_reference=data_reference,
+            dataset_sha256=hashlib.sha256(
+                data_path.read_bytes()
+            ).hexdigest(),
+        )
+        manifest = InstrumentChannelCalibrationValidationDatasetManifest(
+            protocol_id=protocol.protocol_id,
+            protocol_version=protocol.protocol_version,
+            protocol_sha256=protocol.canonical_sha256,
+            datasets=(dataset,),
+        )
+
+        manifest_reference = "examples/validation/dataset_manifest.json"
+        manifest_path = root / manifest_reference
+        manifest_path.write_text(
+            json.dumps(
+                manifest.to_dict(),
+                indent=2,
+                sort_keys=True,
+                allow_nan=False,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        return manifest_reference, data_path
+
+    def test_dataset_manifest_contract_is_strict_and_primary_only(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            protocol_reference, _ = self._repository_fixture(root)
+            manifest_reference, _ = self._additional_dataset_manifest(
+                root,
+                protocol_reference,
+            )
+            payload = json.loads(
+                (root / manifest_reference).read_text(encoding="utf-8")
+            )
+            manifest = (
+                InstrumentChannelCalibrationValidationDatasetManifest.from_dict(
+                    payload
+                )
+            )
+            self.assertEqual(manifest.to_dict(), payload)
+            self.assertEqual(
+                len(manifest.datasets),
+                1,
+            )
+
+            tampered = dict(payload)
+            tampered["unexpected"] = True
+            with self.assertRaisesRegex(ValueError, "exactly"):
+                InstrumentChannelCalibrationValidationDatasetManifest.from_dict(
+                    tampered
+                )
+
+            derived = InstrumentChannelCalibrationValidationDataset(
+                dataset_id="derived-v1",
+                astrophysical_source_id="derived-source",
+                dataset_reference="examples/data/derived.csv",
+                dataset_sha256="a" * 64,
+                derivation_parent_dataset_id="parent-v1",
+            )
+            with self.assertRaisesRegex(ValueError, "primary"):
+                InstrumentChannelCalibrationValidationDatasetManifest(
+                    protocol_id=manifest.protocol_id,
+                    protocol_version=manifest.protocol_version,
+                    protocol_sha256=manifest.protocol_sha256,
+                    datasets=(derived,),
+                )
+
+    def test_manifest_executes_anchor_and_independent_source(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            protocol_reference, _ = self._repository_fixture(root)
+            manifest_reference, _ = self._additional_dataset_manifest(
+                root,
+                protocol_reference,
+            )
+
+            result, report = (
+                execute_instrument_channel_calibration_validation_dataset_manifest(
+                    repository_root=root,
+                    protocol_reference=protocol_reference,
+                    dataset_manifest_reference=manifest_reference,
+                    execution_reference="examples/validation/combined.json",
+                    package_version="test",
+                    package_commit="1" * 40,
+                    executed_at_utc="2026-08-01T00:00:00Z",
+                )
+            )
+
+            self.assertEqual(len(result.source_results), 2)
+            self.assertEqual(
+                tuple(
+                    source.dataset.astrophysical_source_id
+                    for source in result.source_results
+                ),
+                (
+                    "synthetic-source",
+                    "independent-synthetic-source",
+                ),
+            )
+            self.assertEqual(
+                tuple(
+                    source.n_matched_pairs
+                    for source in result.source_results
+                ),
+                (120, 120),
+            )
+            self.assertEqual(report.disposition.value, "passed")
+            self.assertEqual(
+                report.independent_astrophysical_source_count,
+                2,
+            )
+            self.assertFalse(
+                result.to_dict()["catalogue_population_performed"]
+            )
+
+    def test_manifest_rejects_anchor_source_identity(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            protocol_reference, _ = self._repository_fixture(root)
+            manifest_reference, _ = self._additional_dataset_manifest(
+                root,
+                protocol_reference,
+                astrophysical_source_id="synthetic-source",
+            )
+
+            with self.assertRaisesRegex(ValueError, "independent"):
+                execute_instrument_channel_calibration_validation_dataset_manifest(
+                    repository_root=root,
+                    protocol_reference=protocol_reference,
+                    dataset_manifest_reference=manifest_reference,
+                    execution_reference="examples/validation/combined.json",
+                    package_version="test",
+                    package_commit="1" * 40,
+                    executed_at_utc="2026-08-01T00:00:00Z",
+                )
+
+    def test_manifest_rejects_protocol_digest_mismatch(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            protocol_reference, _ = self._repository_fixture(root)
+            manifest_reference, _ = self._additional_dataset_manifest(
+                root,
+                protocol_reference,
+            )
+            manifest_path = root / manifest_reference
+            payload = json.loads(
+                manifest_path.read_text(encoding="utf-8")
+            )
+            payload["protocol_sha256"] = "0" * 64
+            manifest_path.write_text(
+                json.dumps(payload, indent=2) + "\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ValueError, "digest"):
+                execute_instrument_channel_calibration_validation_dataset_manifest(
+                    repository_root=root,
+                    protocol_reference=protocol_reference,
+                    dataset_manifest_reference=manifest_reference,
+                    execution_reference="examples/validation/combined.json",
+                    package_version="test",
+                    package_commit="1" * 40,
+                    executed_at_utc="2026-08-01T00:00:00Z",
+                )
+
+    def test_manifest_dataset_digest_mismatch_is_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            protocol_reference, _ = self._repository_fixture(root)
+            manifest_reference, data_path = self._additional_dataset_manifest(
+                root,
+                protocol_reference,
+            )
+            data_path.write_text(
+                data_path.read_text(encoding="utf-8") + "\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ValueError, "SHA-256"):
+                execute_instrument_channel_calibration_validation_dataset_manifest(
+                    repository_root=root,
+                    protocol_reference=protocol_reference,
+                    dataset_manifest_reference=manifest_reference,
+                    execution_reference="examples/validation/combined.json",
                     package_version="test",
                     package_commit="1" * 40,
                     executed_at_utc="2026-08-01T00:00:00Z",

--- a/tests/test_run_instrument_channel_calibration_validation_script.py
+++ b/tests/test_run_instrument_channel_calibration_validation_script.py
@@ -1,0 +1,33 @@
+"""CLI coverage for maintained calibration-validation execution."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/run_instrument_channel_calibration_validation.py"
+
+
+class TestRunInstrumentChannelCalibrationValidationScript(
+    unittest.TestCase
+):
+    def test_help_exposes_dataset_manifest_surface(self):
+        completed = subprocess.run(
+            [sys.executable, str(SCRIPT), "--help"],
+            cwd=ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stdout)
+        self.assertIn("--dataset-manifest", completed.stdout)
+        self.assertIn("--result-output", completed.stdout)
+        self.assertIn("--report-output", completed.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a strict JSON-safe dataset-manifest contract for additional calibration-validation datasets
- execute the frozen representative protocol against its anchor plus caller-supplied independent primary sources
- verify exact protocol identity, canonical protocol digest, dataset identity, repository-relative references, and dataset SHA-256 values
- reject derived datasets and additional datasets that reuse the anchor dataset or astrophysical-source identity
- preserve one immutable source result per astrophysical source and assess the combined evidence deterministically
- add a maintained `--dataset-manifest` CLI surface while protecting the committed representative result and report from accidental overwrite
- document the execution surface and its scientific limitations

## Scientific boundary

This PR adds execution infrastructure only.

It does **not**:

- alter the prospectively frozen calibration-validation protocol
- alter its pairing, fitting, fold, normalization, or acceptance criteria
- add or distribute another real astrophysical dataset
- claim that calibration has been scientifically validated
- populate a scientifically validated pairing-rule catalogue
- activate calibration in ordinary light-curve fitting

The existing anchor evidence remains inconclusive because one temporal fold has insufficient dynamic range. The repository still contains only one eligible independent KELT astrophysical source.

Synthetic fixtures added in this PR test contract and execution mechanics only; they do not count as scientific validation evidence.

## Validation

- `python3 -m unittest discover -s tests`
  - 2,774 tests passed
- `python3 -m ruff check ./pgmuvi`
  - passed
- Ruff checks for the changed script and test files
  - passed
- `python3 scripts/audit_docs_tbd_markers.py`
  - passed; 13 registered markers
- `make -C docs html-strict`
  - passed
- `git diff --check`
  - passed

## Data policy

No new real dataset is included. The only real public dataset used remains:

- `examples/data/10131+3049.csv`

Additional real validation datasets must be supplied later as genuine independent primary-source data through the strict repository-relative manifest surface.