### PR TITLE
Audit and enforce repository reference integrity

### DIFF
--- a/docs/source/howto/consensus_fitting.rst
+++ b/docs/source/howto/consensus_fitting.rst
@@ -472,9 +472,10 @@ Notebook tutorial
 -----------------
 
 The maintained :doc:`../notebooks/pgmuvi_tutorial_2d` notebook provides an
-interactive baseline ``2D`` consensus workflow with deterministic data, an
-explicit no-training default, structured failure handling, and LPV-relevant
-follow-up configurations.  The runnable script remains the preferred reference
+executed end-to-end ``2DWavelengthDependent`` consensus workflow with
+deterministic data.  Its default path performs a required fit, verifies fit
+history and recovered period, and calls ``Lightcurve.plot()`` to render fitted
+predictions before presenting explicit follow-up configurations.  The runnable script remains the preferred reference
 for command-line execution and artifact export.
 
 Relationship to wavelength advisory

--- a/docs/source/howto/multiband.rst
+++ b/docs/source/howto/multiband.rst
@@ -206,7 +206,8 @@ periods, or contact the ``pgmuvi`` developers to discuss extensions.
 -----------
 
 The maintained :doc:`../notebooks/pgmuvi_tutorial_2d` notebook builds a
-deterministic three-band light curve, prepares the baseline ``2D`` consensus
-workflow, handles ``ConsensusFitError``, and records LPV-relevant follow-up
-configurations.  Detailed controls remain documented in
+deterministic three-band light curve and performs a required
+``2DWavelengthDependent`` consensus fit.  It verifies successful training and
+period recovery, then calls ``Lightcurve.plot()`` to render fitted predictions
+before recording LPV-relevant follow-up configurations.  Detailed controls remain documented in
 :doc:`consensus_fitting`.

--- a/tests/test_repository_reference_integrity.py
+++ b/tests/test_repository_reference_integrity.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import unittest
+from pathlib import Path
+from urllib.parse import unquote
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS_SOURCE = ROOT / "docs" / "source"
+
+DOC_ROLE = re.compile(r":doc:`(?:[^`<]*<)?([^`>]+)>?`")
+MARKDOWN_LINK = re.compile(r"!?\[[^\]]*\]\(([^)]+)\)")
+LOCAL_ACTION_USE = re.compile(
+    r"^\s*uses:\s*(\./[^\s#]+)",
+    re.MULTILINE,
+)
+MACHINE_LOCAL_REFERENCE = re.compile(
+    r"(?:"
+    r"/Users/"
+    r"|/Volumes/"
+    r"|/home/[A-Za-z0-9_.-]+/"
+    r"|file:///"
+    r"|[A-Za-z]:\\Users\\"
+    r")"
+)
+
+FORBIDDEN_PUBLIC_DATASET = "07454-7112.csv"
+PUBLIC_PREFIXES = (
+    ".github/",
+    "docs/",
+    "examples/",
+    "paper/",
+    "pgmuvi/",
+)
+PUBLIC_ROOT_FILES = {
+    "CITATION.cff",
+    "README.md",
+    "paper.md",
+    "pyproject.toml",
+}
+
+
+def _tracked_files() -> list[Path]:
+    result = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+    )
+    return [
+        ROOT / item.decode("utf-8")
+        for item in result.stdout.split(b"\0")
+        if item
+    ]
+
+
+def _strip_html_comments(text: str) -> str:
+    return re.sub(r"<!--.*?-->", "", text, flags=re.DOTALL)
+
+
+def _clean_target(raw_target: str) -> str:
+    target = unquote(raw_target.strip())
+    if target.startswith("<") and ">" in target:
+        target = target[1 : target.index(">")]
+    elif " " in target:
+        target = target.split(" ", 1)[0]
+    target = target.strip().strip("<>")
+    target = target.split("#", 1)[0]
+    target = target.split("?", 1)[0]
+    return target.strip()
+
+
+def _skip_target(target: str) -> bool:
+    lowered = target.lower()
+    return (
+        not target
+        or target.startswith("#")
+        or target.startswith("|")
+        or lowered.startswith("http://")
+        or lowered.startswith("https://")
+        or lowered.startswith("mailto:")
+        or lowered.startswith("data:")
+        or lowered.startswith("javascript:")
+        or "://" in target
+        or "{" in target
+        or "}" in target
+        or "*" in target
+        or ("[" in target and "]" in target)
+    )
+
+
+def _inside(candidate: Path, parent: Path) -> bool:
+    try:
+        candidate.resolve(strict=False).relative_to(parent.resolve())
+    except ValueError:
+        return False
+    return True
+
+
+def _document_candidates(source_file: Path, target: str) -> list[Path]:
+    if target.startswith("/"):
+        candidate = DOCS_SOURCE / target.lstrip("/")
+    else:
+        candidate = source_file.parent / target
+    if candidate.suffix:
+        return [candidate]
+    return [
+        candidate.with_suffix(".rst"),
+        candidate.with_suffix(".ipynb"),
+        candidate.with_suffix(".md"),
+    ]
+
+
+class TestRepositoryReferenceIntegrity(unittest.TestCase):
+    def test_all_sphinx_doc_targets_exist(self) -> None:
+        failures: list[str] = []
+        for source_file in sorted(DOCS_SOURCE.rglob("*.rst")):
+            text = source_file.read_text(encoding="utf-8")
+            for match in DOC_ROLE.finditer(text):
+                target = _clean_target(match.group(1))
+                if _skip_target(target):
+                    continue
+                candidates = _document_candidates(source_file, target)
+                if any(
+                    _inside(candidate, DOCS_SOURCE)
+                    and candidate.is_file()
+                    for candidate in candidates
+                ):
+                    continue
+                line_number = text.count("\n", 0, match.start(1)) + 1
+                failures.append(
+                    f"{source_file.relative_to(ROOT)}:"
+                    f"{line_number}: {target}"
+                )
+        self.assertEqual(
+            failures,
+            [],
+            "Unresolved :doc: targets:\n" + "\n".join(failures),
+        )
+
+    def test_local_markdown_links_exist(self) -> None:
+        failures: list[str] = []
+        for source_file in [
+            path
+            for path in _tracked_files()
+            if path.suffix.lower() == ".md"
+        ]:
+            text = _strip_html_comments(
+                source_file.read_text(
+                    encoding="utf-8",
+                    errors="replace",
+                )
+            )
+            for match in MARKDOWN_LINK.finditer(text):
+                target = _clean_target(match.group(1))
+                if _skip_target(target):
+                    continue
+                candidate = (source_file.parent / target).resolve(
+                    strict=False
+                )
+                if _inside(candidate, ROOT) and candidate.exists():
+                    continue
+                line_number = text.count("\n", 0, match.start(1)) + 1
+                failures.append(
+                    f"{source_file.relative_to(ROOT)}:"
+                    f"{line_number}: {target}"
+                )
+        self.assertEqual(
+            failures,
+            [],
+            "Broken local Markdown links:\n" + "\n".join(failures),
+        )
+
+    def test_local_github_actions_exist(self) -> None:
+        failures: list[str] = []
+        workflow_files = [
+            *ROOT.glob(".github/workflows/*.yml"),
+            *ROOT.glob(".github/workflows/*.yaml"),
+        ]
+        for source_file in sorted(workflow_files):
+            text = source_file.read_text(encoding="utf-8")
+            for match in LOCAL_ACTION_USE.finditer(text):
+                target = match.group(1)
+                candidate = ROOT / target.removeprefix("./")
+                if candidate.exists():
+                    continue
+                line_number = text.count("\n", 0, match.start(1)) + 1
+                failures.append(
+                    f"{source_file.relative_to(ROOT)}:"
+                    f"{line_number}: {target}"
+                )
+        self.assertEqual(
+            failures,
+            [],
+            "Missing local GitHub actions:\n" + "\n".join(failures),
+        )
+
+    def test_public_files_have_no_machine_paths(self) -> None:
+        failures: list[str] = []
+        for source_file in _tracked_files():
+            relative = str(source_file.relative_to(ROOT))
+            is_public = (
+                relative in PUBLIC_ROOT_FILES
+                or relative.startswith(PUBLIC_PREFIXES)
+            )
+            if not is_public or relative.startswith("tests/"):
+                continue
+            data = source_file.read_bytes()
+            if b"\0" in data:
+                continue
+            text = data.decode("utf-8", errors="replace")
+            for match in MACHINE_LOCAL_REFERENCE.finditer(text):
+                line_number = text.count("\n", 0, match.start()) + 1
+                failures.append(
+                    f"{relative}:{line_number}: {match.group(0)}"
+                )
+        self.assertEqual(
+            failures,
+            [],
+            "Machine-local paths in public files:\n"
+            + "\n".join(failures),
+        )
+
+    def test_forbidden_dataset_is_absent_from_public_files(self) -> None:
+        failures: list[str] = []
+        for source_file in _tracked_files():
+            relative = str(source_file.relative_to(ROOT))
+            is_public = (
+                relative in PUBLIC_ROOT_FILES
+                or relative.startswith(PUBLIC_PREFIXES)
+            )
+            if not is_public or relative.startswith("tests/"):
+                continue
+            data = source_file.read_bytes()
+            if b"\0" in data:
+                continue
+            text = data.decode("utf-8", errors="replace")
+            if FORBIDDEN_PUBLIC_DATASET in text:
+                failures.append(relative)
+        self.assertEqual(
+            failures,
+            [],
+            "Forbidden dataset references:\n" + "\n".join(failures),
+        )
+
+    def test_2d_guides_match_executed_workflow(self) -> None:
+        consensus = (
+            DOCS_SOURCE / "howto" / "consensus_fitting.rst"
+        ).read_text(encoding="utf-8")
+        multiband = (
+            DOCS_SOURCE / "howto" / "multiband.rst"
+        ).read_text(encoding="utf-8")
+        for text in (consensus, multiband):
+            self.assertIn("2DWavelengthDependent", text)
+            self.assertIn("Lightcurve.plot()", text)
+        self.assertNotIn(
+            "explicit no-training default",
+            consensus,
+        )
+        self.assertNotIn(
+            "prepares the baseline ``2D``",
+            multiband,
+        )
+
+    def test_notebook_json_is_parseable(self) -> None:
+        for notebook_file in sorted(DOCS_SOURCE.rglob("*.ipynb")):
+            with self.subTest(
+                notebook=str(notebook_file.relative_to(ROOT))
+            ):
+                json.loads(
+                    notebook_file.read_text(encoding="utf-8")
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- audit all Git-tracked repository content for machine-local or repository-external path references
- distinguish valid Sphinx notebook targets, explicit placeholders, negative assertions, and temporary test fixtures from real defects
- verify that the apparent `figure.png` failures are commented paper-template examples
- verify that the removed model-selection notebook path is an intentional negative regression assertion
- correct stale guides that still described the PR168 2-D notebook as preparation-only
- add durable tests for Sphinx document targets, RST file directives, local Markdown links, local GitHub Actions, notebook JSON, machine-local paths, and the forbidden unbundled dataset

## Audit result

The initial broad scan classified 112 findings:

- 30 scanner false positives
- 76 valid or intentional references
- 4 commented paper-template examples
- 2 duplicate detections of one intentional negative-test reference

No repository-external file or sibling directory was opened.

## Validation

- new repository-reference integrity tests: 7 passed
- existing repository-reference hygiene tests: 3 passed
- PR168 2-D notebook contract tests: 8 passed
- complete suite: 2,817 tests passed
- Ruff: passed
- strict documentation build: passed
- `git diff --check`: passed

This pull request is stacked on PR168. No merge is requested or performed.
