### PR TITLE
[Future] Implement maintainer-private multi-source calibration validation

### DIFF
--- a/docs/source/future_work.rst
+++ b/docs/source/future_work.rst
@@ -198,12 +198,12 @@ Wavelength-model extensions
     multi-source decision.  No populated scientifically validated rule catalogue
     exists; catalogue population remains blocked until that decision passes.
 
-    The remaining work is to implement the public data-agnostic multi-source
-    engine, implement the non-distributed private Parquet selection runner,
-    execute the frozen five-source test internally, and commit only a redacted
-    aggregate decision.  A real rule may enter a populated scientifically
-    validated catalogue only after that decision passes.  Normal light-curve
-    workflow integration remains later work.
+    The public data-agnostic multi-source engine and maintainer-only private
+    Parquet selection runner are now implemented.  The remaining work is to run
+    the frozen five-source test on the private catalogue and commit only its
+    redacted aggregate decision.  A real rule may enter a populated
+    scientifically validated catalogue only after that decision passes.
+    Normal light-curve workflow integration remains later work.
 
 **TBD[multi-periodic-wavelength-models]**
     Add a documented and validated multi-periodic workflow beyond the current

--- a/docs/source/pgmuvi.instrument_channel_calibration_validation.rst
+++ b/docs/source/pgmuvi.instrument_channel_calibration_validation.rst
@@ -11,6 +11,11 @@ Instrument-channel calibration validation
    :undoc-members:
    :show-inheritance:
 
+.. automodule:: pgmuvi.instrument_channel_calibration_multisource_execution
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Prospective protocol boundary
 -----------------------------
 
@@ -94,14 +99,21 @@ is repeated until every selected source has been held out once.  Equal matched
 pair counts from each training source prevent one densely sampled light curve
 from dominating the fit.
 
-The public package defines the data-agnostic contract and redacted evidence
-schema.  A **private Parquet** ingestion and selection runner is maintainer
-infrastructure, is not distributed, and does not create public package Parquet
-support.  Raw source identifiers, private light curves, and the detailed
-source-level report remain private.  A public redacted summary may contain
-only protocol and input digests, the selection seed, hashed selected-source
-identities, aggregate held-out metrics, coefficient-stability summaries, and
-the final disposition.
+The public package now implements the data-agnostic array engine as well as the
+contract and redacted evidence schema.  It performs source-balanced
+leave-one-source-out fitting, applies one common calibration to the unseen
+source without refitting, evaluates all frozen temporal folds, and derives the
+aggregate disposition.
+
+A **private Parquet** ingestion and selection runner is available at
+``maintainer_tools/run_private_instrument_channel_multisource_validation.py``.
+It is maintainer-only infrastructure outside the installed package, and the
+private catalogue itself is not distributed.  The public package still has no
+Parquet dependency or end-user Parquet input surface.  Raw source identifiers,
+private light curves, and the detailed source-level report remain private.  A
+public redacted summary may contain only protocol and input digests, the
+selection seed, hashed selected-source identities, aggregate held-out metrics,
+coefficient-stability summaries, and the final disposition.
 
 Maintained execution
 --------------------

--- a/docs/source/pgmuvi.instrument_channel_calibration_validation_execution.rst
+++ b/docs/source/pgmuvi.instrument_channel_calibration_validation_execution.rst
@@ -75,20 +75,53 @@ Parquet catalogue.
 Maintainer-private execution boundary
 -------------------------------------
 
-The next implementation layer will accept already prepared per-source channel
-arrays in memory and execute the frozen maintainer-private multi-source
-contract.  It will not own private catalogue discovery or Parquet ingestion.
-The non-distributed private runner will identify sources containing the exact
-protocol-approved candidate observational-channel pair, apply all pre-fit
-eligibility gates, record the sorted eligible set and random seed, select the
-first five entries from the seeded permutation, and invoke the public
-data-agnostic engine.
+The public data-agnostic execution engine is implemented in
+:mod:`pgmuvi.instrument_channel_calibration_multisource_execution`.  It accepts
+already prepared per-source channel arrays in memory and executes the frozen
+maintainer-private multi-source contract.  It does not discover private files
+or depend on a Parquet library.
 
-The engine will perform source-balanced leave-one-source-out fitting and
-held-out temporal-fold evaluation.  It will return detailed in-memory evidence
-for the private report and a redacted public summary containing no raw source
-identifiers or private paths.  Catalogue population remains a later explicit
-step and is permitted only after a passing redacted decision.
+The maintainer-only adapter
+``maintainer_tools/run_private_instrument_channel_multisource_validation.py``
+reads one private Parquet file through ``pyarrow`` or a pandas-compatible
+Parquet engine, with exactly these required columns:
+
+.. code-block:: text
+
+   object_id
+   time
+   flux
+   flux_error
+   wavelength
+   band
+
+Rows are grouped by ``object_id``.  Every unique identifier is treated as one
+maintainer-asserted independent primary astrophysical source.  The adapter
+retains only the exact protocol-approved candidate observational-channel pair,
+passes every source group to the public engine, and keeps sources lacking the
+pair in the private eligibility audit.
+
+A typical private invocation is:
+
+.. code-block:: console
+
+   python maintainer_tools/run_private_instrument_channel_multisource_validation.py PRIVATE_CATALOGUE.parquet --selection-seed 20260726 --n-sources 5
+
+``--n-sources all`` evaluates every eligible source.  The default outputs are
+written under the ignored ``validation_outputs/`` directory: one detailed
+private report containing raw ``object_id`` values and one redacted summary
+containing only hashed selected-source identities and aggregate evidence.
+
+Eligibility is completed before calibration outcomes are inspected.  The
+engine records the sorted eligible set, applies the seeded permutation, selects
+the requested sources without replacement, fits equal matched-pair counts from
+every training source, and evaluates the unseen source without refitting.  Its
+five temporal-fold metrics are aggregated to one source-level normalized RMSE
+and bias before the frozen cross-source gates are applied.
+
+Catalogue population remains a later explicit step and is permitted only after
+a passing redacted decision.  Running this script does not populate or activate
+a calibration catalogue.
 
 Maintained execution status
 ---------------------------
@@ -110,5 +143,6 @@ five-source protocol.
 
 There is **no catalogue population** from the current execution.  It has not
 established a scientifically validated pairing rule or authorized calibration
-in ordinary light-curve fitting.  The private runner and public
-leave-one-source-out engine remain to be implemented and executed.
+in ordinary light-curve fitting.  The private Parquet runner and public
+leave-one-source-out engine are now implemented, but the frozen private
+multi-source decision has not yet been executed or committed.

--- a/maintainer_tools/run_private_instrument_channel_multisource_validation.py
+++ b/maintainer_tools/run_private_instrument_channel_multisource_validation.py
@@ -1,0 +1,469 @@
+#!/usr/bin/env python3
+"""Run frozen maintainer-private calibration validation on one Parquet file.
+
+This script is intentionally outside the installed ``pgmuvi`` package.  It
+requires ``pyarrow`` only when Parquet input is read.  The private detailed
+report may contain raw ``object_id`` values; the redacted summary does not.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import subprocess
+import sys
+from collections import defaultdict
+from collections.abc import Callable
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from pgmuvi import __version__
+from pgmuvi.instrument_channel_calibration_multisource_execution import (
+    InstrumentChannelCalibrationMultiSourceChannelData,
+    InstrumentChannelCalibrationMultiSourceExecutionResult,
+    InstrumentChannelCalibrationMultiSourceSourceData,
+    execute_instrument_channel_calibration_multisource_validation,
+)
+from pgmuvi.instrument_channel_calibration_multisource_validation import (
+    InstrumentChannelCalibrationMultiSourceValidationProtocol,
+)
+from pgmuvi.instrument_channel_calibration_validation import (
+    InstrumentChannelCalibrationValidationProtocol,
+)
+
+REQUIRED_COLUMNS = (
+    "object_id",
+    "time",
+    "flux",
+    "flux_error",
+    "wavelength",
+    "band",
+)
+DEFAULT_MULTISOURCE_PROTOCOL = (
+    "examples/validation/"
+    "kelt_r3_maintainer_multisource_validation_protocol_v1.json"
+)
+DEFAULT_CANDIDATE_PROTOCOL = (
+    "examples/validation/kelt_r3_pairing_validation_protocol_v1.json"
+)
+DEFAULT_PRIVATE_REPORT = (
+    "validation_outputs/"
+    "private_kelt_r3_multisource_validation_report.json"
+)
+DEFAULT_REDACTED_SUMMARY = (
+    "validation_outputs/"
+    "private_kelt_r3_multisource_validation_summary.json"
+)
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _load_parquet_columns(path: Path) -> dict[str, list[Any]]:
+    try:
+        import pyarrow.parquet as parquet
+    except ImportError:
+        parquet = None
+
+    if parquet is not None:
+        parquet_file = parquet.ParquetFile(path)
+        available = set(parquet_file.schema_arrow.names)
+        missing = sorted(set(REQUIRED_COLUMNS) - available)
+        if missing:
+            raise ValueError(
+                "Private Parquet input is missing required columns: "
+                + ", ".join(missing)
+                + "."
+            )
+        table = parquet_file.read(columns=list(REQUIRED_COLUMNS))
+        return {
+            name: table.column(name).to_pylist()
+            for name in REQUIRED_COLUMNS
+        }
+
+    try:
+        import pandas as pd
+    except ImportError as exc:
+        raise RuntimeError(
+            "The maintainer-only Parquet runner requires pyarrow, or pandas "
+            "with an installed Parquet engine, in the private validation "
+            "environment."
+        ) from exc
+
+    try:
+        frame = pd.read_parquet(path, columns=list(REQUIRED_COLUMNS))
+    except Exception as exc:
+        raise RuntimeError(
+            "Could not read the private Parquet input with pandas. Install "
+            "pyarrow or another pandas-compatible Parquet engine."
+        ) from exc
+    missing = sorted(set(REQUIRED_COLUMNS) - set(frame.columns))
+    if missing:
+        raise ValueError(
+            "Private Parquet input is missing required columns: "
+            + ", ".join(missing)
+            + "."
+        )
+    return {
+        name: frame[name].tolist()
+        for name in REQUIRED_COLUMNS
+    }
+
+
+def _normalize_object_id(value: Any) -> str:
+    if value is None:
+        raise ValueError("object_id values must be non-null.")
+    if isinstance(value, float) and not math.isfinite(value):
+        raise ValueError("object_id values must be finite when numeric.")
+    if isinstance(value, bytes):
+        value = value.decode("utf-8")
+    normalized = str(value).strip()
+    if not normalized:
+        raise ValueError("object_id values must be non-empty.")
+    return normalized
+
+
+def _coerce_float(value: Any) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return math.nan
+
+
+def build_source_data_from_columns(
+    columns: dict[str, list[Any]],
+    *,
+    protocol: InstrumentChannelCalibrationMultiSourceValidationProtocol,
+) -> tuple[
+    tuple[InstrumentChannelCalibrationMultiSourceSourceData, ...],
+    dict[str, int],
+]:
+    """Group one private table by object_id and split the exact channel pair."""
+
+    missing = sorted(set(REQUIRED_COLUMNS) - set(columns))
+    if missing:
+        raise ValueError(
+            "Input columns are missing: " + ", ".join(missing) + "."
+        )
+
+    lengths = {len(columns[name]) for name in REQUIRED_COLUMNS}
+    if len(lengths) != 1:
+        raise ValueError("All input columns must have the same row count.")
+
+    grouped: dict[str, dict[str, list[Any]]] = defaultdict(
+        lambda: {
+            "reference_time": [],
+            "reference_flux": [],
+            "reference_error": [],
+            "reference_wavelength": [],
+            "channel_time": [],
+            "channel_flux": [],
+            "channel_error": [],
+            "channel_wavelength": [],
+        }
+    )
+    ignored_non_candidate_rows = 0
+    for index in range(next(iter(lengths), 0)):
+        source_id = _normalize_object_id(columns["object_id"][index])
+        group = grouped[source_id]
+        band_value = columns["band"][index]
+        if isinstance(band_value, bytes):
+            band_value = band_value.decode("utf-8")
+        band = "" if band_value is None else str(band_value).strip()
+
+        if band == protocol.reference_channel:
+            prefix = "reference"
+        elif band == protocol.channel:
+            prefix = "channel"
+        else:
+            ignored_non_candidate_rows += 1
+            continue
+
+        group[f"{prefix}_time"].append(
+            _coerce_float(columns["time"][index])
+        )
+        group[f"{prefix}_flux"].append(
+            _coerce_float(columns["flux"][index])
+        )
+        group[f"{prefix}_error"].append(
+            _coerce_float(columns["flux_error"][index])
+        )
+        group[f"{prefix}_wavelength"].append(
+            _coerce_float(columns["wavelength"][index])
+        )
+
+    sources = tuple(
+        InstrumentChannelCalibrationMultiSourceSourceData(
+            astrophysical_source_id=source_id,
+            reference=InstrumentChannelCalibrationMultiSourceChannelData(
+                channel=protocol.reference_channel,
+                time=tuple(values["reference_time"]),
+                flux=tuple(values["reference_flux"]),
+                flux_error=tuple(values["reference_error"]),
+                wavelength=tuple(values["reference_wavelength"]),
+            ),
+            channel=InstrumentChannelCalibrationMultiSourceChannelData(
+                channel=protocol.channel,
+                time=tuple(values["channel_time"]),
+                flux=tuple(values["channel_flux"]),
+                flux_error=tuple(values["channel_error"]),
+                wavelength=tuple(values["channel_wavelength"]),
+            ),
+            is_primary_source=True,
+            derivation_parent_source_id=None,
+        )
+        for source_id, values in sorted(grouped.items())
+    )
+    ingestion = {
+        "input_row_count": next(iter(lengths), 0),
+        "grouped_source_count": len(sources),
+        "ignored_non_candidate_channel_row_count": (
+            ignored_non_candidate_rows
+        ),
+    }
+    return sources, ingestion
+
+
+def _git_commit(repository_root: Path) -> str:
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repository_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    commit = result.stdout.strip()
+    if len(commit) != 40:
+        raise RuntimeError("Could not determine a full package Git commit.")
+    return commit
+
+
+def _utc_now() -> str:
+    return (
+        datetime.now(timezone.utc)
+        .replace(microsecond=0)
+        .strftime("%Y-%m-%dT%H:%M:%SZ")
+    )
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(path.name + ".tmp")
+    temporary.write_text(
+        json.dumps(
+            payload,
+            indent=2,
+            sort_keys=True,
+            allow_nan=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    temporary.replace(path)
+
+
+def execute_private_parquet_validation(
+    *,
+    parquet_path: Path,
+    repository_root: Path,
+    multisource_protocol_path: Path,
+    candidate_protocol_path: Path,
+    selection_seed: int,
+    n_sources: int | str,
+    private_report_output: Path,
+    redacted_summary_output: Path,
+    package_version: str | None = None,
+    package_commit: str | None = None,
+    executed_at_utc: str | None = None,
+    parquet_loader: Callable[[Path], dict[str, list[Any]]] = (
+        _load_parquet_columns
+    ),
+) -> InstrumentChannelCalibrationMultiSourceExecutionResult:
+    """Load private Parquet rows and execute the public array-based engine."""
+
+    parquet_path = parquet_path.expanduser().resolve()
+    if not parquet_path.is_file():
+        raise ValueError("parquet_path must identify an existing file.")
+
+    protocol = InstrumentChannelCalibrationMultiSourceValidationProtocol.from_dict(
+        _load_json(multisource_protocol_path)
+    )
+    candidate_protocol = (
+        InstrumentChannelCalibrationValidationProtocol.from_dict(
+            _load_json(candidate_protocol_path)
+        )
+    )
+    columns = parquet_loader(parquet_path)
+    sources, ingestion = build_source_data_from_columns(
+        columns,
+        protocol=protocol,
+    )
+
+    resolved_version = package_version or __version__
+    resolved_commit = package_commit or _git_commit(repository_root)
+    resolved_time = executed_at_utc or _utc_now()
+    input_sha256 = _sha256_file(parquet_path)
+
+    result = execute_instrument_channel_calibration_multisource_validation(
+        sources,
+        protocol=protocol,
+        candidate_protocol=candidate_protocol,
+        private_input_sha256=input_sha256,
+        selection_seed=selection_seed,
+        n_sources=n_sources,
+        package_version=resolved_version,
+        package_commit=resolved_commit,
+        executed_at_utc=resolved_time,
+    )
+
+    private_payload = {
+        "schema_version": (
+            "pgmuvi-maintainer-private-parquet-"
+            "multisource-validation-report-v1"
+        ),
+        "private_input_path": str(parquet_path),
+        "private_input_sha256": input_sha256,
+        "required_columns": list(REQUIRED_COLUMNS),
+        "source_independence_assertion": (
+            "Each unique object_id is treated as one independent primary "
+            "astrophysical source, as asserted by the maintainer."
+        ),
+        "ingestion": ingestion,
+        "multisource_protocol": protocol.to_dict(),
+        "candidate_protocol": candidate_protocol.to_dict(),
+        "execution": result.to_private_dict(),
+    }
+    _write_json(private_report_output, private_payload)
+    _write_json(redacted_summary_output, result.summary.to_dict())
+    return result
+
+
+def _parse_source_count(value: str) -> int | str:
+    normalized = value.strip().lower()
+    if normalized == "all":
+        return "all"
+    try:
+        count = int(normalized)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "--n-sources must be an integer or 'all'."
+        ) from exc
+    if count < 2:
+        raise argparse.ArgumentTypeError("--n-sources must be at least 2.")
+    return count
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run the frozen maintainer-private multi-source calibration "
+            "validation on one Parquet catalogue."
+        )
+    )
+    parser.add_argument("parquet_path", type=Path)
+    parser.add_argument(
+        "--repository-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+    )
+    parser.add_argument(
+        "--multisource-protocol",
+        type=Path,
+        default=Path(DEFAULT_MULTISOURCE_PROTOCOL),
+    )
+    parser.add_argument(
+        "--candidate-protocol",
+        type=Path,
+        default=Path(DEFAULT_CANDIDATE_PROTOCOL),
+    )
+    parser.add_argument(
+        "--selection-seed",
+        type=int,
+        default=20260726,
+    )
+    parser.add_argument(
+        "--n-sources",
+        type=_parse_source_count,
+        default=5,
+    )
+    parser.add_argument(
+        "--private-report-output",
+        type=Path,
+        default=Path(DEFAULT_PRIVATE_REPORT),
+    )
+    parser.add_argument(
+        "--redacted-summary-output",
+        type=Path,
+        default=Path(DEFAULT_REDACTED_SUMMARY),
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    repository_root = args.repository_root.expanduser().resolve()
+
+    def resolve_from_repository(path: Path) -> Path:
+        path = path.expanduser()
+        return path.resolve() if path.is_absolute() else (
+            repository_root / path
+        ).resolve()
+
+    result = execute_private_parquet_validation(
+        parquet_path=args.parquet_path,
+        repository_root=repository_root,
+        multisource_protocol_path=resolve_from_repository(
+            args.multisource_protocol
+        ),
+        candidate_protocol_path=resolve_from_repository(
+            args.candidate_protocol
+        ),
+        selection_seed=args.selection_seed,
+        n_sources=args.n_sources,
+        private_report_output=resolve_from_repository(
+            args.private_report_output
+        ),
+        redacted_summary_output=resolve_from_repository(
+            args.redacted_summary_output
+        ),
+    )
+
+    print("PGMUVI maintainer-private multi-source validation")
+    print(f"disposition: {result.disposition.value}")
+    print(f"eligible sources: {len(result.eligible_source_ids)}")
+    print(f"selected sources: {len(result.selected_source_ids)}")
+    print(
+        "successful holdouts: "
+        f"{result.summary.successful_source_holdout_count}"
+    )
+    print(
+        "median held-out normalized RMSE: "
+        f"{result.summary.median_source_holdout_normalized_rmse}"
+    )
+    print(
+        "worst held-out normalized RMSE: "
+        f"{result.summary.worst_source_holdout_normalized_rmse}"
+    )
+    print(
+        "median held-out normalized bias: "
+        f"{result.summary.median_source_holdout_bias_normalized}"
+    )
+    print(f"private report: {args.private_report_output}")
+    print(f"redacted summary: {args.redacted_summary_output}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pgmuvi/__init__.py
+++ b/pgmuvi/__init__.py
@@ -18,6 +18,8 @@ __all__ = [
     "gps",
     "initialization",
     "instrument_channel_calibration",
+    "instrument_channel_calibration_multisource_execution",
+    "instrument_channel_calibration_multisource_validation",
     "instrument_channel_calibration_validation",
     "instrument_channel_calibration_validation_execution",
     "lightcurve",

--- a/pgmuvi/instrument_channel_calibration_multisource_execution.py
+++ b/pgmuvi/instrument_channel_calibration_multisource_execution.py
@@ -1,0 +1,1092 @@
+"""Execute source-balanced multi-source calibration validation.
+
+The public engine in this module consumes already prepared per-source arrays.
+It performs no file discovery and has no Parquet dependency.  A maintainer-only
+runner may load private data and pass those arrays here.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import random
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from pgmuvi.instrument_channel_calibration import (
+    construct_instrument_channel_pairing,
+    fit_instrument_channel_calibration,
+)
+from pgmuvi.instrument_channel_calibration_multisource_validation import (
+    InstrumentChannelCalibrationMultiSourceValidationDisposition,
+    InstrumentChannelCalibrationMultiSourceValidationProtocol,
+    InstrumentChannelCalibrationMultiSourceValidationSummary,
+)
+from pgmuvi.instrument_channel_calibration_validation import (
+    InstrumentChannelCalibrationValidationProtocol,
+)
+
+__all__ = [
+    "InstrumentChannelCalibrationMultiSourceChannelData",
+    "InstrumentChannelCalibrationMultiSourceEligibilityResult",
+    "InstrumentChannelCalibrationMultiSourceExecutionResult",
+    "InstrumentChannelCalibrationMultiSourceFoldResult",
+    "InstrumentChannelCalibrationMultiSourceHoldoutResult",
+    "InstrumentChannelCalibrationMultiSourceSourceData",
+    "InstrumentChannelCalibrationMultiSourceTrainingSample",
+    "execute_instrument_channel_calibration_multisource_validation",
+]
+
+
+def _text(value: Any, *, name: str) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{name} must be a string.")
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{name} must be non-empty.")
+    return normalized
+
+
+def _float_tuple(value: Any, *, name: str) -> tuple[float, ...]:
+    if isinstance(value, (str, bytes)):
+        raise TypeError(f"{name} must be a one-dimensional numeric sequence.")
+    try:
+        return tuple(float(item) for item in value)
+    except (TypeError, ValueError) as exc:
+        raise TypeError(
+            f"{name} must be a one-dimensional numeric sequence."
+        ) from exc
+
+
+def _source_hash(source_id: str) -> str:
+    return hashlib.sha256(source_id.encode("utf-8")).hexdigest()
+
+
+def _mad(values: Sequence[float]) -> float | None:
+    array = np.asarray(values, dtype=float)
+    if array.size == 0:
+        return None
+    median = float(np.median(array))
+    return float(np.median(np.abs(array - median)))
+
+
+@dataclass(frozen=True)
+class InstrumentChannelCalibrationMultiSourceChannelData:
+    """Rows for one observational channel of one astrophysical source."""
+
+    channel: str
+    time: tuple[float, ...]
+    flux: tuple[float, ...]
+    flux_error: tuple[float, ...]
+    wavelength: tuple[float, ...]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "channel", _text(self.channel, name="channel"))
+        for name in ("time", "flux", "flux_error", "wavelength"):
+            object.__setattr__(
+                self,
+                name,
+                _float_tuple(getattr(self, name), name=name),
+            )
+        lengths = {
+            len(self.time),
+            len(self.flux),
+            len(self.flux_error),
+            len(self.wavelength),
+        }
+        if len(lengths) != 1:
+            raise ValueError("Channel data arrays must have equal length.")
+
+
+@dataclass(frozen=True)
+class InstrumentChannelCalibrationMultiSourceSourceData:
+    """Data-agnostic input for one independent astrophysical source."""
+
+    astrophysical_source_id: str
+    reference: InstrumentChannelCalibrationMultiSourceChannelData
+    channel: InstrumentChannelCalibrationMultiSourceChannelData
+    is_primary_source: bool = True
+    derivation_parent_source_id: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "astrophysical_source_id",
+            _text(
+                self.astrophysical_source_id,
+                name="astrophysical_source_id",
+            ),
+        )
+        if not isinstance(
+            self.reference,
+            InstrumentChannelCalibrationMultiSourceChannelData,
+        ):
+            raise TypeError("reference must be channel data.")
+        if not isinstance(
+            self.channel,
+            InstrumentChannelCalibrationMultiSourceChannelData,
+        ):
+            raise TypeError("channel must be channel data.")
+        if not isinstance(self.is_primary_source, bool):
+            raise TypeError("is_primary_source must be boolean.")
+        parent = self.derivation_parent_source_id
+        if parent is not None:
+            parent = _text(parent, name="derivation_parent_source_id")
+        object.__setattr__(self, "derivation_parent_source_id", parent)
+
+
+@dataclass(frozen=True)
+class InstrumentChannelCalibrationMultiSourceEligibilityResult:
+    """Pre-fit structural and informativeness assessment for one source."""
+
+    astrophysical_source_id: str
+    source_id_sha256: str
+    eligible: bool
+    reasons: tuple[str, ...]
+    n_reference_input_rows: int
+    n_channel_input_rows: int
+    n_reference_usable_rows: int
+    n_channel_usable_rows: int
+    n_matched_pairs: int
+    temporal_fold_pair_counts: tuple[int, ...]
+    temporal_fold_amplitude_to_median_reference_error: tuple[float, ...]
+
+    def to_private_dict(self) -> dict[str, Any]:
+        return {
+            "astrophysical_source_id": self.astrophysical_source_id,
+            "source_id_sha256": self.source_id_sha256,
+            "eligible": self.eligible,
+            "reasons": list(self.reasons),
+            "n_reference_input_rows": self.n_reference_input_rows,
+            "n_channel_input_rows": self.n_channel_input_rows,
+            "n_reference_usable_rows": self.n_reference_usable_rows,
+            "n_channel_usable_rows": self.n_channel_usable_rows,
+            "n_matched_pairs": self.n_matched_pairs,
+            "temporal_fold_pair_counts": list(
+                self.temporal_fold_pair_counts
+            ),
+            "temporal_fold_amplitude_to_median_reference_error": list(
+                self.temporal_fold_amplitude_to_median_reference_error
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class InstrumentChannelCalibrationMultiSourceFoldResult:
+    """Held-out temporal-fold evidence without refitting."""
+
+    fold_index: int
+    n_holdout_pairs: int
+    successful: bool
+    holdout_reference_flux_q05_q95_amplitude: float | None
+    holdout_median_reference_flux_error: float | None
+    holdout_amplitude_to_median_reference_error: float | None
+    holdout_normalized_rmse: float | None
+    holdout_median_bias_normalized: float | None
+    maximum_absolute_time_separation: float | None
+    reasons: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "fold_index": self.fold_index,
+            "n_holdout_pairs": self.n_holdout_pairs,
+            "successful": self.successful,
+            "holdout_reference_flux_q05_q95_amplitude": (
+                self.holdout_reference_flux_q05_q95_amplitude
+            ),
+            "holdout_median_reference_flux_error": (
+                self.holdout_median_reference_flux_error
+            ),
+            "holdout_amplitude_to_median_reference_error": (
+                self.holdout_amplitude_to_median_reference_error
+            ),
+            "holdout_normalized_rmse": self.holdout_normalized_rmse,
+            "holdout_median_bias_normalized": (
+                self.holdout_median_bias_normalized
+            ),
+            "maximum_absolute_time_separation": (
+                self.maximum_absolute_time_separation
+            ),
+            "reasons": list(self.reasons),
+        }
+
+
+@dataclass(frozen=True)
+class InstrumentChannelCalibrationMultiSourceTrainingSample:
+    """Auditable source-balanced subsample used in one held-out fit."""
+
+    astrophysical_source_id: str
+    source_id_sha256: str
+    derived_seed: int
+    n_available_pairs: int
+    selected_pair_positions: tuple[int, ...]
+
+    def to_private_dict(self) -> dict[str, Any]:
+        return {
+            "astrophysical_source_id": self.astrophysical_source_id,
+            "source_id_sha256": self.source_id_sha256,
+            "derived_seed": self.derived_seed,
+            "n_available_pairs": self.n_available_pairs,
+            "selected_pair_positions": list(self.selected_pair_positions),
+        }
+
+
+@dataclass(frozen=True)
+class InstrumentChannelCalibrationMultiSourceHoldoutResult:
+    """One leave-one-source-out transfer test."""
+
+    heldout_astrophysical_source_id: str
+    heldout_source_id_sha256: str
+    training_source_id_sha256s: tuple[str, ...]
+    training_samples: tuple[
+        InstrumentChannelCalibrationMultiSourceTrainingSample,
+        ...,
+    ]
+    matched_pairs_per_training_source: int
+    n_training_pairs: int
+    fitted_offset: float | None
+    fitted_scale: float | None
+    fold_results: tuple[
+        InstrumentChannelCalibrationMultiSourceFoldResult,
+        ...,
+    ]
+    source_holdout_normalized_rmse: float | None
+    source_holdout_bias_normalized: float | None
+    successful: bool
+    reasons: tuple[str, ...]
+
+    def to_private_dict(self) -> dict[str, Any]:
+        return {
+            "heldout_astrophysical_source_id": (
+                self.heldout_astrophysical_source_id
+            ),
+            "heldout_source_id_sha256": self.heldout_source_id_sha256,
+            "training_source_id_sha256s": list(
+                self.training_source_id_sha256s
+            ),
+            "training_samples": [
+                sample.to_private_dict() for sample in self.training_samples
+            ],
+            "matched_pairs_per_training_source": (
+                self.matched_pairs_per_training_source
+            ),
+            "n_training_pairs": self.n_training_pairs,
+            "fitted_offset": self.fitted_offset,
+            "fitted_scale": self.fitted_scale,
+            "fold_results": [
+                result.to_dict() for result in self.fold_results
+            ],
+            "source_holdout_normalized_rmse": (
+                self.source_holdout_normalized_rmse
+            ),
+            "source_holdout_bias_normalized": (
+                self.source_holdout_bias_normalized
+            ),
+            "successful": self.successful,
+            "reasons": list(self.reasons),
+        }
+
+
+@dataclass(frozen=True)
+class InstrumentChannelCalibrationMultiSourceExecutionResult:
+    """Private detailed evidence plus its redacted public summary."""
+
+    selection_seed: int
+    requested_source_count: int | str
+    eligible_source_ids: tuple[str, ...]
+    selected_source_ids: tuple[str, ...]
+    eligibility_results: tuple[
+        InstrumentChannelCalibrationMultiSourceEligibilityResult,
+        ...,
+    ]
+    holdout_results: tuple[
+        InstrumentChannelCalibrationMultiSourceHoldoutResult,
+        ...,
+    ]
+    disposition: InstrumentChannelCalibrationMultiSourceValidationDisposition
+    reasons: tuple[str, ...]
+    summary: InstrumentChannelCalibrationMultiSourceValidationSummary
+
+    def to_private_dict(self) -> dict[str, Any]:
+        return {
+            "selection_seed": self.selection_seed,
+            "requested_source_count": self.requested_source_count,
+            "eligible_source_ids": list(self.eligible_source_ids),
+            "selected_source_ids": list(self.selected_source_ids),
+            "eligibility_results": [
+                result.to_private_dict()
+                for result in self.eligibility_results
+            ],
+            "holdout_results": [
+                result.to_private_dict()
+                for result in self.holdout_results
+            ],
+            "disposition": self.disposition.value,
+            "reasons": list(self.reasons),
+            "redacted_summary": self.summary.to_dict(),
+            "catalogue_population_performed": False,
+        }
+
+
+@dataclass(frozen=True)
+class _PreparedSource:
+    source_id: str
+    source_hash: str
+    reference_flux: np.ndarray
+    channel_flux: np.ndarray
+    reference_error: np.ndarray
+    channel_error: np.ndarray
+    time_separation: np.ndarray
+    fold_positions: tuple[np.ndarray, ...]
+
+
+def _verify_protocol_binding(
+    protocol: InstrumentChannelCalibrationMultiSourceValidationProtocol,
+    candidate_protocol: InstrumentChannelCalibrationValidationProtocol,
+) -> None:
+    comparisons = {
+        "candidate protocol id": (
+            protocol.candidate_protocol_id,
+            candidate_protocol.protocol_id,
+        ),
+        "candidate protocol version": (
+            protocol.candidate_protocol_version,
+            candidate_protocol.protocol_version,
+        ),
+        "candidate protocol digest": (
+            protocol.candidate_protocol_sha256,
+            candidate_protocol.canonical_sha256,
+        ),
+        "rule id": (protocol.rule_id, candidate_protocol.rule_id),
+        "reference channel": (
+            protocol.reference_channel,
+            candidate_protocol.reference_channel,
+        ),
+        "target channel": (protocol.channel, candidate_protocol.channel),
+        "physical wavelength": (
+            protocol.physical_wavelength,
+            candidate_protocol.physical_wavelength,
+        ),
+    }
+    mismatched = [
+        name for name, (left, right) in comparisons.items() if left != right
+    ]
+    if mismatched:
+        raise ValueError(
+            "Multi-source and candidate protocols do not match: "
+            + ", ".join(mismatched)
+            + "."
+        )
+
+
+def _usable_rows(
+    data: InstrumentChannelCalibrationMultiSourceChannelData,
+    *,
+    expected_channel: str,
+    physical_wavelength: float,
+    wavelength_tolerance: float,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    if data.channel != expected_channel:
+        return (
+            np.empty(0, dtype=float),
+            np.empty(0, dtype=float),
+            np.empty(0, dtype=float),
+        )
+
+    time = np.asarray(data.time, dtype=float)
+    flux = np.asarray(data.flux, dtype=float)
+    error = np.asarray(data.flux_error, dtype=float)
+    wavelength = np.asarray(data.wavelength, dtype=float)
+
+    usable = (
+        np.isfinite(time)
+        & np.isfinite(flux)
+        & np.isfinite(error)
+        & np.isfinite(wavelength)
+        & (flux > 0.0)
+        & (error > 0.0)
+        & np.isclose(
+            wavelength,
+            physical_wavelength,
+            rtol=0.0,
+            atol=wavelength_tolerance,
+        )
+    )
+    return time[usable], flux[usable], error[usable]
+
+
+def _construct_partitioned_pairs(
+    reference_times: np.ndarray,
+    channel_times: np.ndarray,
+    *,
+    protocol: InstrumentChannelCalibrationMultiSourceValidationProtocol,
+    candidate_protocol: InstrumentChannelCalibrationValidationProtocol,
+) -> tuple[np.ndarray, np.ndarray]:
+    tolerance = float(candidate_protocol.maximum_time_separation or 0.0)
+    combined = [
+        (float(value), 0, index)
+        for index, value in enumerate(reference_times)
+    ]
+    combined.extend(
+        (float(value), 1, index)
+        for index, value in enumerate(channel_times)
+    )
+    combined.sort(key=lambda item: (item[0], item[1], item[2]))
+
+    components: list[list[tuple[float, int, int]]] = []
+    current: list[tuple[float, int, int]] = []
+    for record in combined:
+        if current and record[0] - current[-1][0] > tolerance:
+            components.append(current)
+            current = []
+        current.append(record)
+    if current:
+        components.append(current)
+
+    reference_positions: list[int] = []
+    channel_positions: list[int] = []
+    for component in components:
+        local_reference = np.asarray(
+            [item[2] for item in component if item[1] == 0],
+            dtype=int,
+        )
+        local_channel = np.asarray(
+            [item[2] for item in component if item[1] == 1],
+            dtype=int,
+        )
+        if local_reference.size == 0 or local_channel.size == 0:
+            continue
+        pairing = construct_instrument_channel_pairing(
+            reference_times[local_reference],
+            channel_times[local_channel],
+            reference_channel=protocol.reference_channel,
+            channel=protocol.channel,
+            wavelength=protocol.physical_wavelength,
+            time_unit=candidate_protocol.time_unit,
+            method=candidate_protocol.pairing_method,
+            maximum_time_separation=(
+                candidate_protocol.maximum_time_separation
+            ),
+            reference_row_indices=local_reference,
+            channel_row_indices=local_channel,
+        )
+        reference_positions.extend(pairing.reference_row_indices)
+        channel_positions.extend(pairing.channel_row_indices)
+
+    if not reference_positions:
+        return np.empty(0, dtype=int), np.empty(0, dtype=int)
+
+    reference_array = np.asarray(reference_positions, dtype=int)
+    channel_array = np.asarray(channel_positions, dtype=int)
+    midpoint = 0.5 * (
+        reference_times[reference_array] + channel_times[channel_array]
+    )
+    ordering = np.lexsort((channel_array, reference_array, midpoint))
+    return reference_array[ordering], channel_array[ordering]
+
+
+def _prepare_source(
+    source: InstrumentChannelCalibrationMultiSourceSourceData,
+    *,
+    protocol: InstrumentChannelCalibrationMultiSourceValidationProtocol,
+    candidate_protocol: InstrumentChannelCalibrationValidationProtocol,
+) -> tuple[
+    InstrumentChannelCalibrationMultiSourceEligibilityResult,
+    _PreparedSource | None,
+]:
+    reasons: list[str] = []
+
+    if not source.is_primary_source:
+        reasons.append("source_not_asserted_primary")
+    if source.derivation_parent_source_id is not None:
+        reasons.append("derived_source_excluded")
+
+    reference_time, reference_flux, reference_error = _usable_rows(
+        source.reference,
+        expected_channel=protocol.reference_channel,
+        physical_wavelength=protocol.physical_wavelength,
+        wavelength_tolerance=(
+            protocol.physical_wavelength_absolute_tolerance
+        ),
+    )
+    channel_time, channel_flux, channel_error = _usable_rows(
+        source.channel,
+        expected_channel=protocol.channel,
+        physical_wavelength=protocol.physical_wavelength,
+        wavelength_tolerance=(
+            protocol.physical_wavelength_absolute_tolerance
+        ),
+    )
+
+    if source.reference.channel != protocol.reference_channel:
+        reasons.append("missing_exact_reference_observational_channel")
+    elif reference_time.size == 0:
+        reasons.append("no_usable_reference_channel_rows")
+
+    if source.channel.channel != protocol.channel:
+        reasons.append("missing_exact_target_observational_channel")
+    elif channel_time.size == 0:
+        reasons.append("no_usable_target_channel_rows")
+
+    reference_positions = np.empty(0, dtype=int)
+    channel_positions = np.empty(0, dtype=int)
+    if reference_time.size and channel_time.size:
+        reference_positions, channel_positions = _construct_partitioned_pairs(
+            reference_time,
+            channel_time,
+            protocol=protocol,
+            candidate_protocol=candidate_protocol,
+        )
+
+    n_pairs = int(reference_positions.size)
+    if n_pairs < protocol.minimum_matched_pairs_per_source:
+        reasons.append("insufficient_matched_pairs")
+
+    fold_counts: tuple[int, ...] = ()
+    fold_ratios: tuple[float, ...] = ()
+    fold_positions: tuple[np.ndarray, ...] = ()
+    if n_pairs:
+        paired_reference_flux = reference_flux[reference_positions]
+        paired_reference_error = reference_error[reference_positions]
+        fold_positions = tuple(
+            np.asarray(item, dtype=int)
+            for item in np.array_split(
+                np.arange(n_pairs, dtype=int),
+                protocol.temporal_fold_count,
+            )
+        )
+        counts: list[int] = []
+        ratios: list[float] = []
+        for index, positions in enumerate(fold_positions):
+            count = int(positions.size)
+            counts.append(count)
+            if count:
+                amplitude = float(
+                    np.quantile(
+                        paired_reference_flux[positions],
+                        0.95,
+                        method="linear",
+                    )
+                    - np.quantile(
+                        paired_reference_flux[positions],
+                        0.05,
+                        method="linear",
+                    )
+                )
+                median_error = float(
+                    np.median(paired_reference_error[positions])
+                )
+                ratio = (
+                    amplitude / median_error
+                    if median_error > 0.0
+                    else math.nan
+                )
+            else:
+                ratio = math.nan
+            ratios.append(float(ratio))
+            if count < protocol.minimum_holdout_pairs_per_fold:
+                reasons.append(f"fold_{index}_insufficient_holdout_pairs")
+            if (
+                not math.isfinite(ratio)
+                or ratio
+                < protocol.minimum_holdout_amplitude_to_median_reference_error
+            ):
+                reasons.append(f"fold_{index}_insufficient_dynamic_range")
+        fold_counts = tuple(counts)
+        fold_ratios = tuple(ratios)
+
+    eligible = not reasons
+    result = InstrumentChannelCalibrationMultiSourceEligibilityResult(
+        astrophysical_source_id=source.astrophysical_source_id,
+        source_id_sha256=_source_hash(source.astrophysical_source_id),
+        eligible=eligible,
+        reasons=tuple(reasons),
+        n_reference_input_rows=len(source.reference.time),
+        n_channel_input_rows=len(source.channel.time),
+        n_reference_usable_rows=int(reference_time.size),
+        n_channel_usable_rows=int(channel_time.size),
+        n_matched_pairs=n_pairs,
+        temporal_fold_pair_counts=fold_counts,
+        temporal_fold_amplitude_to_median_reference_error=fold_ratios,
+    )
+    if not eligible:
+        return result, None
+
+    prepared = _PreparedSource(
+        source_id=source.astrophysical_source_id,
+        source_hash=result.source_id_sha256,
+        reference_flux=reference_flux[reference_positions],
+        channel_flux=channel_flux[channel_positions],
+        reference_error=reference_error[reference_positions],
+        channel_error=channel_error[channel_positions],
+        time_separation=np.abs(
+            reference_time[reference_positions]
+            - channel_time[channel_positions]
+        ),
+        fold_positions=fold_positions,
+    )
+    return result, prepared
+
+
+def _subsample_positions(
+    *,
+    n_pairs: int,
+    sample_size: int,
+    selection_seed: int,
+    heldout_source_hash: str,
+    training_source_hash: str,
+) -> tuple[np.ndarray, int]:
+    material = (
+        f"{selection_seed}|{heldout_source_hash}|{training_source_hash}"
+    ).encode()
+    derived_seed = int.from_bytes(
+        hashlib.sha256(material).digest()[:8],
+        byteorder="big",
+        signed=False,
+    )
+    generator = np.random.default_rng(derived_seed)
+    positions = generator.choice(
+        n_pairs,
+        size=sample_size,
+        replace=False,
+    )
+    return np.sort(np.asarray(positions, dtype=int)), derived_seed
+
+
+def _evaluate_fold(
+    *,
+    fold_index: int,
+    positions: np.ndarray,
+    heldout: _PreparedSource,
+    offset: float,
+    scale: float,
+    protocol: InstrumentChannelCalibrationMultiSourceValidationProtocol,
+) -> InstrumentChannelCalibrationMultiSourceFoldResult:
+    amplitude = float(
+        np.quantile(
+            heldout.reference_flux[positions],
+            0.95,
+            method="linear",
+        )
+        - np.quantile(
+            heldout.reference_flux[positions],
+            0.05,
+            method="linear",
+        )
+    )
+    median_error = float(np.median(heldout.reference_error[positions]))
+    ratio = amplitude / median_error
+    reasons: list[str] = []
+    if positions.size < protocol.minimum_holdout_pairs_per_fold:
+        reasons.append("insufficient_holdout_pairs")
+    if (
+        not math.isfinite(ratio)
+        or ratio
+        < protocol.minimum_holdout_amplitude_to_median_reference_error
+    ):
+        reasons.append("insufficient_dynamic_range")
+
+    prediction = offset + scale * heldout.channel_flux[positions]
+    residual = heldout.reference_flux[positions] - prediction
+    if (
+        amplitude <= 0.0
+        or np.any(~np.isfinite(prediction))
+        or np.any(~np.isfinite(residual))
+    ):
+        reasons.append("nonfinite_or_zero_amplitude_holdout_metrics")
+
+    successful = not reasons
+    return InstrumentChannelCalibrationMultiSourceFoldResult(
+        fold_index=fold_index,
+        n_holdout_pairs=int(positions.size),
+        successful=successful,
+        holdout_reference_flux_q05_q95_amplitude=amplitude,
+        holdout_median_reference_flux_error=median_error,
+        holdout_amplitude_to_median_reference_error=ratio,
+        holdout_normalized_rmse=(
+            float(np.sqrt(np.mean(residual**2)) / amplitude)
+            if successful
+            else None
+        ),
+        holdout_median_bias_normalized=(
+            float(np.median(residual) / amplitude)
+            if successful
+            else None
+        ),
+        maximum_absolute_time_separation=(
+            float(np.max(heldout.time_separation[positions]))
+            if positions.size
+            else None
+        ),
+        reasons=tuple(reasons),
+    )
+
+
+def _execute_holdout(
+    *,
+    heldout: _PreparedSource,
+    training: tuple[_PreparedSource, ...],
+    selection_seed: int,
+    protocol: InstrumentChannelCalibrationMultiSourceValidationProtocol,
+    candidate_protocol: InstrumentChannelCalibrationValidationProtocol,
+) -> InstrumentChannelCalibrationMultiSourceHoldoutResult:
+    pairs_per_source = min(
+        int(source.reference_flux.size) for source in training
+    )
+    reference_blocks: list[np.ndarray] = []
+    channel_blocks: list[np.ndarray] = []
+    reference_error_blocks: list[np.ndarray] = []
+    channel_error_blocks: list[np.ndarray] = []
+    training_samples: list[
+        InstrumentChannelCalibrationMultiSourceTrainingSample
+    ] = []
+
+    for source in training:
+        positions, derived_seed = _subsample_positions(
+            n_pairs=int(source.reference_flux.size),
+            sample_size=pairs_per_source,
+            selection_seed=selection_seed,
+            heldout_source_hash=heldout.source_hash,
+            training_source_hash=source.source_hash,
+        )
+        reference_blocks.append(source.reference_flux[positions])
+        channel_blocks.append(source.channel_flux[positions])
+        reference_error_blocks.append(source.reference_error[positions])
+        channel_error_blocks.append(source.channel_error[positions])
+        training_samples.append(
+            InstrumentChannelCalibrationMultiSourceTrainingSample(
+                astrophysical_source_id=source.source_id,
+                source_id_sha256=source.source_hash,
+                derived_seed=derived_seed,
+                n_available_pairs=int(source.reference_flux.size),
+                selected_pair_positions=tuple(
+                    int(position) for position in positions
+                ),
+            )
+        )
+
+    try:
+        calibration = fit_instrument_channel_calibration(
+            np.concatenate(reference_blocks),
+            np.concatenate(channel_blocks),
+            reference_channel=protocol.reference_channel,
+            channel=protocol.channel,
+            wavelength=protocol.physical_wavelength,
+            reference_error=np.concatenate(reference_error_blocks),
+            channel_error=np.concatenate(channel_error_blocks),
+            sigma_clip=candidate_protocol.sigma_clip,
+            max_iter=candidate_protocol.maximum_fit_iterations,
+            min_pairs=candidate_protocol.minimum_fit_pairs,
+        )
+    except Exception as exc:
+        return InstrumentChannelCalibrationMultiSourceHoldoutResult(
+            heldout_astrophysical_source_id=heldout.source_id,
+            heldout_source_id_sha256=heldout.source_hash,
+            training_source_id_sha256s=tuple(
+                source.source_hash for source in training
+            ),
+            training_samples=tuple(training_samples),
+            matched_pairs_per_training_source=pairs_per_source,
+            n_training_pairs=pairs_per_source * len(training),
+            fitted_offset=None,
+            fitted_scale=None,
+            fold_results=(),
+            source_holdout_normalized_rmse=None,
+            source_holdout_bias_normalized=None,
+            successful=False,
+            reasons=(f"calibration_fit_failed:{type(exc).__name__}:{exc}",),
+        )
+
+    folds = tuple(
+        _evaluate_fold(
+            fold_index=index,
+            positions=positions,
+            heldout=heldout,
+            offset=float(calibration.offset),
+            scale=float(calibration.scale),
+            protocol=protocol,
+        )
+        for index, positions in enumerate(heldout.fold_positions)
+    )
+    successful = all(fold.successful for fold in folds)
+    nrmse_values = [
+        fold.holdout_normalized_rmse
+        for fold in folds
+        if fold.holdout_normalized_rmse is not None
+    ]
+    bias_values = [
+        fold.holdout_median_bias_normalized
+        for fold in folds
+        if fold.holdout_median_bias_normalized is not None
+    ]
+    reasons = (
+        ()
+        if successful
+        else ("one_or_more_heldout_temporal_folds_unsuccessful",)
+    )
+    return InstrumentChannelCalibrationMultiSourceHoldoutResult(
+        heldout_astrophysical_source_id=heldout.source_id,
+        heldout_source_id_sha256=heldout.source_hash,
+        training_source_id_sha256s=tuple(
+            source.source_hash for source in training
+        ),
+        training_samples=tuple(training_samples),
+        matched_pairs_per_training_source=pairs_per_source,
+        n_training_pairs=pairs_per_source * len(training),
+        fitted_offset=float(calibration.offset),
+        fitted_scale=float(calibration.scale),
+        fold_results=folds,
+        source_holdout_normalized_rmse=(
+            float(np.median(nrmse_values)) if successful else None
+        ),
+        source_holdout_bias_normalized=(
+            float(np.median(bias_values)) if successful else None
+        ),
+        successful=successful,
+        reasons=reasons,
+    )
+
+
+def execute_instrument_channel_calibration_multisource_validation(
+    sources: Sequence[InstrumentChannelCalibrationMultiSourceSourceData],
+    *,
+    protocol: InstrumentChannelCalibrationMultiSourceValidationProtocol,
+    candidate_protocol: InstrumentChannelCalibrationValidationProtocol,
+    private_input_sha256: str,
+    selection_seed: int,
+    n_sources: int | str = 5,
+    summary_id: str = "maintainer-private-kelt-r3-multisource-run-v1",
+    summary_version: str = "1.0",
+    package_version: str,
+    package_commit: str,
+    executed_at_utc: str,
+) -> InstrumentChannelCalibrationMultiSourceExecutionResult:
+    """Run the frozen source-balanced leave-one-source-out validation."""
+
+    if not isinstance(
+        protocol,
+        InstrumentChannelCalibrationMultiSourceValidationProtocol,
+    ):
+        raise TypeError("protocol must be a multi-source protocol.")
+    if not isinstance(
+        candidate_protocol,
+        InstrumentChannelCalibrationValidationProtocol,
+    ):
+        raise TypeError("candidate_protocol must be a validation protocol.")
+    _verify_protocol_binding(protocol, candidate_protocol)
+
+    if isinstance(selection_seed, bool) or not isinstance(selection_seed, int):
+        raise TypeError("selection_seed must be an integer.")
+    if selection_seed < 0:
+        raise ValueError("selection_seed must be non-negative.")
+
+    if n_sources != "all":
+        if isinstance(n_sources, bool) or not isinstance(n_sources, int):
+            raise TypeError("n_sources must be an integer or 'all'.")
+        if n_sources < protocol.required_source_count:
+            raise ValueError(
+                "n_sources cannot be smaller than required_source_count."
+            )
+
+    if not isinstance(sources, Sequence):
+        raise TypeError("sources must be a sequence.")
+    normalized_sources = tuple(sources)
+    if any(
+        not isinstance(
+            source,
+            InstrumentChannelCalibrationMultiSourceSourceData,
+        )
+        for source in normalized_sources
+    ):
+        raise TypeError("Every source must be multi-source source data.")
+
+    ids = [source.astrophysical_source_id for source in normalized_sources]
+    if len(ids) != len(set(ids)):
+        raise ValueError("astrophysical_source_id values must be unique.")
+
+    eligibility: list[
+        InstrumentChannelCalibrationMultiSourceEligibilityResult
+    ] = []
+    prepared_by_id: dict[str, _PreparedSource] = {}
+    for source in normalized_sources:
+        result, prepared = _prepare_source(
+            source,
+            protocol=protocol,
+            candidate_protocol=candidate_protocol,
+        )
+        eligibility.append(result)
+        if prepared is not None:
+            prepared_by_id[source.astrophysical_source_id] = prepared
+
+    eligible_ids = sorted(prepared_by_id)
+    permutation = list(eligible_ids)
+    random.Random(selection_seed).shuffle(permutation)
+    requested_count = (
+        len(permutation) if n_sources == "all" else int(n_sources)
+    )
+    selected_ids = tuple(permutation[:requested_count])
+
+    holdouts: tuple[
+        InstrumentChannelCalibrationMultiSourceHoldoutResult,
+        ...,
+    ] = ()
+    reasons: list[str] = []
+    disposition = (
+        InstrumentChannelCalibrationMultiSourceValidationDisposition.INCONCLUSIVE
+    )
+
+    if len(eligible_ids) < protocol.required_source_count:
+        reasons.append("insufficient_private_validation_sample")
+    elif n_sources != "all" and len(eligible_ids) < requested_count:
+        reasons.append("insufficient_requested_source_count")
+    elif len(selected_ids) < protocol.required_source_count:
+        reasons.append("insufficient_selected_source_count")
+    else:
+        selected = tuple(prepared_by_id[item] for item in selected_ids)
+        holdouts = tuple(
+            _execute_holdout(
+                heldout=heldout,
+                training=tuple(
+                    source for source in selected if source is not heldout
+                ),
+                selection_seed=selection_seed,
+                protocol=protocol,
+                candidate_protocol=candidate_protocol,
+            )
+            for heldout in selected
+        )
+        if any(not result.successful for result in holdouts):
+            reasons.append("one_or_more_source_holdouts_unsuccessful")
+        else:
+            source_nrmse = np.asarray(
+                [
+                    result.source_holdout_normalized_rmse
+                    for result in holdouts
+                ],
+                dtype=float,
+            )
+            source_bias = np.asarray(
+                [
+                    result.source_holdout_bias_normalized
+                    for result in holdouts
+                ],
+                dtype=float,
+            )
+            median_nrmse = float(np.median(source_nrmse))
+            worst_nrmse = float(np.max(source_nrmse))
+            median_bias = float(np.median(source_bias))
+            if (
+                median_nrmse
+                > protocol.maximum_median_source_holdout_normalized_rmse
+            ):
+                reasons.append(
+                    "median_source_holdout_normalized_rmse_exceeds_gate"
+                )
+            if (
+                worst_nrmse
+                > protocol.maximum_worst_source_holdout_normalized_rmse
+            ):
+                reasons.append(
+                    "worst_source_holdout_normalized_rmse_exceeds_gate"
+                )
+            if (
+                abs(median_bias)
+                > protocol.maximum_absolute_median_source_holdout_bias_normalized
+            ):
+                reasons.append(
+                    "absolute_median_source_holdout_bias_exceeds_gate"
+                )
+            disposition = (
+                InstrumentChannelCalibrationMultiSourceValidationDisposition.PASSED
+                if not reasons
+                else InstrumentChannelCalibrationMultiSourceValidationDisposition.FAILED
+            )
+
+    successful_holdouts = tuple(
+        result for result in holdouts if result.successful
+    )
+    source_nrmse_values = [
+        result.source_holdout_normalized_rmse
+        for result in successful_holdouts
+        if result.source_holdout_normalized_rmse is not None
+    ]
+    source_bias_values = [
+        result.source_holdout_bias_normalized
+        for result in successful_holdouts
+        if result.source_holdout_bias_normalized is not None
+    ]
+    scales = [
+        result.fitted_scale
+        for result in successful_holdouts
+        if result.fitted_scale is not None
+    ]
+    offsets = [
+        result.fitted_offset
+        for result in successful_holdouts
+        if result.fitted_offset is not None
+    ]
+
+    summary = InstrumentChannelCalibrationMultiSourceValidationSummary(
+        summary_id=summary_id,
+        summary_version=summary_version,
+        protocol_id=protocol.protocol_id,
+        protocol_version=protocol.protocol_version,
+        protocol_sha256=protocol.canonical_sha256,
+        candidate_protocol_id=protocol.candidate_protocol_id,
+        candidate_protocol_version=protocol.candidate_protocol_version,
+        candidate_protocol_sha256=protocol.candidate_protocol_sha256,
+        rule_id=protocol.rule_id,
+        private_input_sha256=private_input_sha256,
+        selection_seed=selection_seed,
+        eligible_source_count=len(eligible_ids),
+        selected_source_id_sha256s=tuple(
+            _source_hash(item) for item in selected_ids
+        ),
+        successful_source_holdout_count=len(successful_holdouts),
+        median_source_holdout_normalized_rmse=(
+            float(np.median(source_nrmse_values))
+            if source_nrmse_values
+            else None
+        ),
+        worst_source_holdout_normalized_rmse=(
+            float(np.max(source_nrmse_values))
+            if source_nrmse_values
+            else None
+        ),
+        median_source_holdout_bias_normalized=(
+            float(np.median(source_bias_values))
+            if source_bias_values
+            else None
+        ),
+        fitted_scale_median=(
+            float(np.median(scales)) if scales else None
+        ),
+        fitted_scale_mad=_mad(scales),
+        fitted_offset_median=(
+            float(np.median(offsets)) if offsets else None
+        ),
+        fitted_offset_mad=_mad(offsets),
+        package_version=package_version,
+        package_commit=package_commit,
+        executed_at_utc=executed_at_utc,
+        disposition=disposition,
+        reasons=tuple(reasons),
+        all_acceptance_criteria_passed=(
+            disposition
+            is InstrumentChannelCalibrationMultiSourceValidationDisposition.PASSED
+        ),
+    )
+    return InstrumentChannelCalibrationMultiSourceExecutionResult(
+        selection_seed=selection_seed,
+        requested_source_count=n_sources,
+        eligible_source_ids=tuple(eligible_ids),
+        selected_source_ids=selected_ids,
+        eligibility_results=tuple(eligibility),
+        holdout_results=holdouts,
+        disposition=disposition,
+        reasons=tuple(reasons),
+        summary=summary,
+    )

--- a/tests/test_instrument_channel_calibration_multisource_execution.py
+++ b/tests/test_instrument_channel_calibration_multisource_execution.py
@@ -1,0 +1,318 @@
+from __future__ import annotations
+
+import json
+import unittest
+from dataclasses import replace
+from pathlib import Path
+
+import numpy as np
+
+from pgmuvi.instrument_channel_calibration_multisource_execution import (
+    InstrumentChannelCalibrationMultiSourceChannelData,
+    InstrumentChannelCalibrationMultiSourceSourceData,
+    execute_instrument_channel_calibration_multisource_validation,
+)
+from pgmuvi.instrument_channel_calibration_multisource_validation import (
+    InstrumentChannelCalibrationMultiSourceValidationDisposition,
+    InstrumentChannelCalibrationMultiSourceValidationProtocol,
+)
+from pgmuvi.instrument_channel_calibration_validation import (
+    InstrumentChannelCalibrationValidationProtocol,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MULTISOURCE_PROTOCOL_PATH = (
+    ROOT
+    / "examples"
+    / "validation"
+    / "kelt_r3_maintainer_multisource_validation_protocol_v1.json"
+)
+CANDIDATE_PROTOCOL_PATH = (
+    ROOT
+    / "examples"
+    / "validation"
+    / "kelt_r3_pairing_validation_protocol_v1.json"
+)
+
+
+class TestInstrumentChannelCalibrationMultiSourceExecution(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.protocol = (
+            InstrumentChannelCalibrationMultiSourceValidationProtocol.from_dict(
+                json.loads(
+                    MULTISOURCE_PROTOCOL_PATH.read_text(encoding="utf-8")
+                )
+            )
+        )
+        cls.candidate = InstrumentChannelCalibrationValidationProtocol.from_dict(
+            json.loads(CANDIDATE_PROTOCOL_PATH.read_text(encoding="utf-8"))
+        )
+
+    def source(
+        self,
+        source_id: str,
+        *,
+        n_pairs: int = 100,
+        offset: float = 0.3,
+        scale: float = 1.2,
+        phase: float = 0.0,
+        reference_channel: str | None = None,
+        target_channel: str | None = None,
+        error: float = 0.01,
+        is_primary: bool = True,
+    ) -> InstrumentChannelCalibrationMultiSourceSourceData:
+        time = np.arange(n_pairs, dtype=float)
+        target = (
+            2.0
+            + 0.5 * np.sin(2.0 * np.pi * time / 20.0 + phase)
+            + 0.1 * np.cos(2.0 * np.pi * time / 7.0)
+        )
+        reference = offset + scale * target
+        uncertainty = np.full(n_pairs, error)
+        wavelength = np.full(n_pairs, self.protocol.physical_wavelength)
+        return InstrumentChannelCalibrationMultiSourceSourceData(
+            astrophysical_source_id=source_id,
+            reference=InstrumentChannelCalibrationMultiSourceChannelData(
+                channel=(
+                    reference_channel or self.protocol.reference_channel
+                ),
+                time=tuple(time),
+                flux=tuple(reference),
+                flux_error=tuple(uncertainty),
+                wavelength=tuple(wavelength),
+            ),
+            channel=InstrumentChannelCalibrationMultiSourceChannelData(
+                channel=target_channel or self.protocol.channel,
+                time=tuple(time + 0.01),
+                flux=tuple(target),
+                flux_error=tuple(uncertainty),
+                wavelength=tuple(wavelength),
+            ),
+            is_primary_source=is_primary,
+        )
+
+    def execute(
+        self,
+        sources: tuple[
+            InstrumentChannelCalibrationMultiSourceSourceData,
+            ...,
+        ],
+        *,
+        seed: int = 20260726,
+        n_sources: int | str = 5,
+    ):
+        return execute_instrument_channel_calibration_multisource_validation(
+            sources,
+            protocol=self.protocol,
+            candidate_protocol=self.candidate,
+            private_input_sha256="a" * 64,
+            selection_seed=seed,
+            n_sources=n_sources,
+            package_version="test",
+            package_commit="b" * 40,
+            executed_at_utc="2026-07-26T00:00:00Z",
+        )
+
+    def test_five_transferable_sources_pass(self) -> None:
+        sources = tuple(
+            self.source(
+                f"source-{index}",
+                n_pairs=100 + 5 * index,
+                phase=0.1 * index,
+            )
+            for index in range(5)
+        )
+        result = self.execute(sources)
+
+        self.assertIs(
+            result.disposition,
+            InstrumentChannelCalibrationMultiSourceValidationDisposition.PASSED,
+        )
+        self.assertEqual(result.summary.successful_source_holdout_count, 5)
+        self.assertEqual(len(result.holdout_results), 5)
+        self.assertLess(
+            result.summary.worst_source_holdout_normalized_rmse,
+            0.01,
+        )
+        self.assertFalse(
+            result.summary.to_dict()["raw_source_identifiers_included"]
+        )
+        private = result.to_private_dict()
+        self.assertIn("source-0", json.dumps(private))
+        self.assertNotIn(
+            "source-0",
+            json.dumps(result.summary.to_dict()),
+        )
+
+    def test_selection_is_seeded_and_reproducible(self) -> None:
+        sources = tuple(
+            self.source(f"source-{index}", phase=0.05 * index)
+            for index in range(8)
+        )
+        first = self.execute(sources, seed=314159)
+        second = self.execute(tuple(reversed(sources)), seed=314159)
+        third = self.execute(sources, seed=271828)
+
+        self.assertEqual(first.selected_source_ids, second.selected_source_ids)
+        self.assertNotEqual(first.selected_source_ids, third.selected_source_ids)
+        self.assertEqual(
+            first.summary.selected_source_id_sha256s,
+            second.summary.selected_source_id_sha256s,
+        )
+
+    def test_eligibility_is_decided_before_fit(self) -> None:
+        sources = (
+            *(self.source(f"good-{index}") for index in range(5)),
+            self.source("too-short", n_pairs=99),
+            self.source(
+                "wrong-reference",
+                reference_channel="OTHER/reference",
+            ),
+            self.source("derived", is_primary=False),
+        )
+        result = self.execute(sources)
+        by_id = {
+            item.astrophysical_source_id: item
+            for item in result.eligibility_results
+        }
+
+        self.assertFalse(by_id["too-short"].eligible)
+        self.assertIn(
+            "insufficient_matched_pairs",
+            by_id["too-short"].reasons,
+        )
+        self.assertFalse(by_id["wrong-reference"].eligible)
+        self.assertIn(
+            "missing_exact_reference_observational_channel",
+            by_id["wrong-reference"].reasons,
+        )
+        self.assertFalse(by_id["derived"].eligible)
+        self.assertIn("source_not_asserted_primary", by_id["derived"].reasons)
+        self.assertNotIn("too-short", result.selected_source_ids)
+
+    def test_training_is_source_balanced(self) -> None:
+        sources = tuple(
+            self.source(
+                f"source-{index}",
+                n_pairs=(180 if index == 0 else 100 + index),
+            )
+            for index in range(5)
+        )
+        result = self.execute(sources)
+
+        for holdout in result.holdout_results:
+            training_counts = [
+                next(
+                    item.n_matched_pairs
+                    for item in result.eligibility_results
+                    if item.source_id_sha256 == source_hash
+                )
+                for source_hash in holdout.training_source_id_sha256s
+            ]
+            self.assertEqual(
+                holdout.matched_pairs_per_training_source,
+                min(training_counts),
+            )
+            self.assertEqual(
+                holdout.n_training_pairs,
+                holdout.matched_pairs_per_training_source * 4,
+            )
+            self.assertEqual(len(holdout.training_samples), 4)
+            for sample in holdout.training_samples:
+                self.assertEqual(
+                    len(sample.selected_pair_positions),
+                    holdout.matched_pairs_per_training_source,
+                )
+                self.assertEqual(
+                    tuple(sorted(sample.selected_pair_positions)),
+                    sample.selected_pair_positions,
+                )
+                self.assertGreaterEqual(sample.derived_seed, 0)
+            self.assertEqual(len(holdout.fold_results), 5)
+
+    def test_nontransferable_source_fails_frozen_gates(self) -> None:
+        sources = tuple(
+            self.source(
+                f"source-{index}",
+                offset=(3.0 if index == 4 else 0.3),
+                scale=(0.5 if index == 4 else 1.2),
+                phase=0.1 * index,
+            )
+            for index in range(5)
+        )
+        result = self.execute(sources)
+
+        self.assertIs(
+            result.disposition,
+            InstrumentChannelCalibrationMultiSourceValidationDisposition.FAILED,
+        )
+        self.assertTrue(result.reasons)
+        self.assertGreater(
+            result.summary.worst_source_holdout_normalized_rmse,
+            self.protocol.maximum_worst_source_holdout_normalized_rmse,
+        )
+
+    def test_four_eligible_sources_are_inconclusive(self) -> None:
+        result = self.execute(
+            tuple(self.source(f"source-{index}") for index in range(4))
+        )
+
+        self.assertIs(
+            result.disposition,
+            InstrumentChannelCalibrationMultiSourceValidationDisposition.
+            INCONCLUSIVE,
+        )
+        self.assertEqual(
+            result.reasons,
+            ("insufficient_private_validation_sample",),
+        )
+        self.assertEqual(result.holdout_results, ())
+        self.assertEqual(result.summary.successful_source_holdout_count, 0)
+
+    def test_protocol_digest_mismatch_is_rejected(self) -> None:
+        mismatched = replace(
+            self.protocol,
+            candidate_protocol_sha256="0" * 64,
+        )
+        with self.assertRaisesRegex(ValueError, "candidate protocol digest"):
+            execute_instrument_channel_calibration_multisource_validation(
+                tuple(self.source(f"source-{index}") for index in range(5)),
+                protocol=mismatched,
+                candidate_protocol=self.candidate,
+                private_input_sha256="a" * 64,
+                selection_seed=1,
+                package_version="test",
+                package_commit="b" * 40,
+                executed_at_utc="2026-07-26T00:00:00Z",
+            )
+
+    def test_requested_count_larger_than_eligible_is_inconclusive(self) -> None:
+        result = self.execute(
+            tuple(self.source(f"source-{index}") for index in range(6)),
+            n_sources=7,
+        )
+        self.assertIs(
+            result.disposition,
+            InstrumentChannelCalibrationMultiSourceValidationDisposition.
+            INCONCLUSIVE,
+        )
+        self.assertEqual(
+            result.reasons,
+            ("insufficient_requested_source_count",),
+        )
+        self.assertEqual(result.holdout_results, ())
+
+    def test_all_eligible_sources_can_be_evaluated(self) -> None:
+        sources = tuple(
+            self.source(f"source-{index}", phase=0.03 * index)
+            for index in range(7)
+        )
+        result = self.execute(sources, n_sources="all")
+        self.assertEqual(len(result.selected_source_ids), 7)
+        self.assertEqual(len(result.holdout_results), 7)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_private_instrument_channel_calibration_parquet_runner.py
+++ b/tests/test_private_instrument_channel_calibration_parquet_runner.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+from pgmuvi.instrument_channel_calibration_multisource_validation import (
+    InstrumentChannelCalibrationMultiSourceValidationProtocol,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNNER_PATH = (
+    ROOT
+    / "maintainer_tools"
+    / "run_private_instrument_channel_multisource_validation.py"
+)
+MULTISOURCE_PROTOCOL_PATH = (
+    ROOT
+    / "examples"
+    / "validation"
+    / "kelt_r3_maintainer_multisource_validation_protocol_v1.json"
+)
+CANDIDATE_PROTOCOL_PATH = (
+    ROOT
+    / "examples"
+    / "validation"
+    / "kelt_r3_pairing_validation_protocol_v1.json"
+)
+
+
+def _load_runner():
+    spec = importlib.util.spec_from_file_location(
+        "pgmuvi_private_parquet_runner",
+        RUNNER_PATH,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Could not load the private Parquet runner.")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestPrivateInstrumentChannelCalibrationParquetRunner(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.runner = _load_runner()
+        cls.protocol = (
+            InstrumentChannelCalibrationMultiSourceValidationProtocol.from_dict(
+                json.loads(
+                    MULTISOURCE_PROTOCOL_PATH.read_text(encoding="utf-8")
+                )
+            )
+        )
+
+    def columns(
+        self,
+        *,
+        n_sources: int = 5,
+        n_pairs: int = 100,
+    ) -> dict[str, list[object]]:
+        result = {
+            name: []
+            for name in self.runner.REQUIRED_COLUMNS
+        }
+        for source_index in range(n_sources):
+            time = np.arange(n_pairs, dtype=float)
+            target = (
+                2.0
+                + 0.5 * np.sin(2.0 * np.pi * time / 20.0)
+                + 0.1 * np.cos(2.0 * np.pi * time / 7.0)
+            )
+            reference = 0.3 + 1.2 * target
+            for index in range(n_pairs):
+                for band, row_time, flux in (
+                    (
+                        self.protocol.reference_channel,
+                        time[index],
+                        reference[index],
+                    ),
+                    (
+                        self.protocol.channel,
+                        time[index] + 0.01,
+                        target[index],
+                    ),
+                ):
+                    result["object_id"].append(f"object-{source_index}")
+                    result["time"].append(float(row_time))
+                    result["flux"].append(float(flux))
+                    result["flux_error"].append(0.01)
+                    result["wavelength"].append(
+                        self.protocol.physical_wavelength
+                    )
+                    result["band"].append(band)
+            result["object_id"].append(f"object-{source_index}")
+            result["time"].append(0.0)
+            result["flux"].append(1.0)
+            result["flux_error"].append(0.1)
+            result["wavelength"].append(1.25)
+            result["band"].append("OTHER/J")
+        return result
+
+    def test_required_columns_match_private_catalogue_contract(self) -> None:
+        self.assertEqual(
+            self.runner.REQUIRED_COLUMNS,
+            (
+                "object_id",
+                "time",
+                "flux",
+                "flux_error",
+                "wavelength",
+                "band",
+            ),
+        )
+
+    def test_columns_group_by_object_id_and_exact_channels(self) -> None:
+        columns = self.columns()
+        sources, ingestion = self.runner.build_source_data_from_columns(
+            columns,
+            protocol=self.protocol,
+        )
+
+        self.assertEqual(len(sources), 5)
+        self.assertEqual(
+            tuple(source.astrophysical_source_id for source in sources),
+            tuple(f"object-{index}" for index in range(5)),
+        )
+        self.assertEqual(len(sources[0].reference.time), 100)
+        self.assertEqual(len(sources[0].channel.time), 100)
+        self.assertEqual(
+            ingestion["ignored_non_candidate_channel_row_count"],
+            5,
+        )
+
+    def test_sources_without_candidate_pair_remain_auditable(self) -> None:
+        columns = self.columns()
+        columns["object_id"].append("unmatched-object")
+        columns["time"].append(1.0)
+        columns["flux"].append(2.0)
+        columns["flux_error"].append(0.1)
+        columns["wavelength"].append(2.2)
+        columns["band"].append("OTHER/K")
+
+        sources, _ = self.runner.build_source_data_from_columns(
+            columns,
+            protocol=self.protocol,
+        )
+        by_id = {
+            source.astrophysical_source_id: source
+            for source in sources
+        }
+        self.assertIn("unmatched-object", by_id)
+        self.assertEqual(by_id["unmatched-object"].reference.time, ())
+        self.assertEqual(by_id["unmatched-object"].channel.time, ())
+
+    def test_private_runner_writes_detailed_and_redacted_outputs(self) -> None:
+        columns = self.columns()
+        with tempfile.TemporaryDirectory() as directory:
+            workspace = Path(directory)
+            parquet_path = workspace / "private.parquet"
+            parquet_path.write_bytes(b"private-parquet-placeholder")
+            private_output = workspace / "private.json"
+            summary_output = workspace / "summary.json"
+
+            result = self.runner.execute_private_parquet_validation(
+                parquet_path=parquet_path,
+                repository_root=ROOT,
+                multisource_protocol_path=MULTISOURCE_PROTOCOL_PATH,
+                candidate_protocol_path=CANDIDATE_PROTOCOL_PATH,
+                selection_seed=20260726,
+                n_sources=5,
+                private_report_output=private_output,
+                redacted_summary_output=summary_output,
+                package_version="test",
+                package_commit="b" * 40,
+                executed_at_utc="2026-07-26T00:00:00Z",
+                parquet_loader=lambda _: columns,
+            )
+
+            self.assertEqual(result.disposition.value, "passed")
+            private = json.loads(private_output.read_text(encoding="utf-8"))
+            summary = json.loads(summary_output.read_text(encoding="utf-8"))
+
+        self.assertIn("object-0", json.dumps(private))
+        self.assertNotIn("object-0", json.dumps(summary))
+        self.assertEqual(summary["disposition"], "passed")
+        self.assertFalse(summary["catalogue_population_performed"])
+        self.assertIn("source_independence_assertion", private)
+
+    def test_missing_column_is_rejected_before_grouping(self) -> None:
+        columns = self.columns()
+        del columns["flux_error"]
+        with self.assertRaisesRegex(ValueError, "flux_error"):
+            self.runner.build_source_data_from_columns(
+                columns,
+                protocol=self.protocol,
+            )
+
+    def test_runner_is_outside_installed_package(self) -> None:
+        pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+        self.assertIn(
+            'packages = ["pgmuvi", "pgmuvi.preprocess"]',
+            pyproject,
+        )
+        self.assertNotIn('"pyarrow"', pyproject)
+        self.assertTrue(RUNNER_PATH.is_file())
+        self.assertFalse(
+            (ROOT / "pgmuvi" / RUNNER_PATH.name).exists()
+        )
+
+    def test_documentation_contains_runnable_private_command(self) -> None:
+        execution = (
+            ROOT
+            / "docs"
+            / "source"
+            / "pgmuvi.instrument_channel_calibration_validation_execution.rst"
+        ).read_text(encoding="utf-8")
+        for token in (
+            "object_id",
+            "flux_error",
+            "PRIVATE_CATALOGUE.parquet",
+            "--selection-seed 20260726",
+            "--n-sources 5",
+            "--n-sources all",
+            "validation_outputs/",
+        ):
+            with self.subTest(token=token):
+                self.assertIn(token, execution)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- PGMUVI-DEFERRED-FUTURE-WORK:START -->
> [!IMPORTANT]
> **Deferred future work — do not merge into the current fitting-pipeline release line.**
>
> This pull request is retained as an auditable prototype. Future integration is tracked by issue #268: https://github.com/ICSM/pgmuvi/issues/268
>
> When resumed, the useful code must be ported onto a fresh branch from the latest active PGMUVI base, reconciled with the generic duplicate-physical-wavelength multiplet APIs, fully retested, and submitted as a new integration pull request. The historical branch will not be rebased or force-pushed.
<!-- PGMUVI-DEFERRED-FUTURE-WORK:END -->

## Summary

Implement the runnable maintainer-private multi-source calibration-validation path defined by PR170.

This pull request:

- adds a public, data-agnostic source-balanced leave-one-source-out execution engine;
- adds a maintainer-only Parquet runner outside the installed package;
- accepts one Parquet catalogue with columns:
  `object_id`, `time`, `flux`, `flux_error`, `wavelength`, and `band`;
- groups independent astrophysical sources by `object_id`;
- requires the exact frozen observational-channel pair at the frozen physical wavelength;
- filters non-finite and non-positive flux and flux-error rows before eligibility;
- determines eligibility before source selection and calibration outcomes;
- supports reproducible seeded selection of five sources or all eligible sources;
- balances training sources with equal matched-pair counts;
- fits a common calibration on the other sources and evaluates each held-out source without refitting;
- retains five temporal folds inside each held-out source;
- applies the preregistered pair-count, dynamic-range, RMSE, and bias gates;
- writes a private detailed report and a redacted aggregate report;
- records the private-input checksum, protocol digest, package commit, execution timestamp, selection seed, hashed source identities, and exact balanced sampling audit.

The private runner remains outside the installed/end-user package surface. No private catalogue or source-level private result is committed.

## Maintainer command

```zsh
python maintainer_tools/run_private_instrument_channel_multisource_validation.py \
    PRIVATE_CATALOGUE.parquet \
    --selection-seed 20260726 \
    --n-sources 5
```

Use `--n-sources all` to evaluate all eligible sources.

## Validation

- Package Ruff: passed
- New runner/test Ruff: passed
- New multi-source execution tests: 9 passed
- Private Parquet runner tests: 7 passed
- PR170 multi-source contract tests: 10 passed
- Existing calibration-validation execution tests: 9 passed
- Existing calibration-validation contract tests: 16 passed
- Instrument-channel documentation tests: 5 passed
- Documentation future-work tests: 5 passed
- Repository reference-integrity tests: 7 passed
- Complete unit-test suite: 2,843 passed
- Strict Sphinx documentation build: passed
- `git diff --check`: passed

## Boundaries

- This PR does not include private observational data.
- This PR does not populate the calibration catalogue.
- Catalogue population remains conditional on a successful maintainer-private execution.
- No merge is requested or performed by the automation used to create this PR.
