### PR TITLE
Implement generic duplicate-wavelength multiplet handling

### DIFF
--- a/docs/source/howto/loading_data.rst
+++ b/docs/source/howto/loading_data.rst
@@ -146,73 +146,98 @@ Duplicate physical wavelengths during fitting
 ---------------------------------------------
 
 A numeric physical wavelength may be represented by more than one
-observational channel, for example two detector/data-stream identifiers from
-the same survey.  Ordinary GP inputs cannot silently treat those channels as
-interchangeable.  Before any model or likelihood is constructed,
-:meth:`~pgmuvi.lightcurve.Lightcurve.fit` therefore resolves each duplicated
-physical-wavelength group.
+observational channel.  Such a group is a shared-wavelength **multiplet**:
+two channels form a pair, three form a triplet, and larger groups are handled
+in the same way.  Ordinary GP inputs use only ``(time, physical wavelength)``
+and therefore cannot silently decide which uncalibrated observational channel
+should represent a multiplet.
 
-The default policy retains the first observational channel encountered in the
-original aligned input row order captured before constructor sampling,
-subsampling, or transformation.  It emits a :class:`UserWarning` that names
-the selected channel, every ignored channel, and the corresponding row counts::
+Inspect all multiplets before fitting::
 
-    lc.fit(model="2DWavelengthDependent")
+    multiplets = lc.duplicate_physical_wavelength_multiplets()
+    for multiplet in multiplets:
+        print(
+            multiplet["physical_wavelength"],
+            multiplet["multiplet_size"],
+            multiplet["observational_channels"],
+            multiplet["row_counts"],
+        )
 
-Select a different channel explicitly when exactly one physical wavelength is
-duplicated::
+When at least one multiplet exists, :meth:`~pgmuvi.lightcurve.Lightcurve.fit`
+refuses to construct the GP training input until the caller chooses explicitly.
+The default ``duplicate_wavelength_policy="error"`` leaves every input row
+unchanged and reports every detected pair, triplet, or larger multiplet.
+
+To retain the first observational channel in the original aligned input order
+for every multiplet, request that behavior explicitly::
+
+    lc.fit(
+        model="2DWavelengthDependent",
+        duplicate_wavelength_policy="first",
+    )
+
+To choose one channel for a single multiplet::
 
     lc.fit(
         model="2DWavelengthDependent",
         duplicate_wavelength_policy="select",
-        duplicate_wavelength_selection="KELT/OSN_Johnson.Cousins_R3_1",
+        duplicate_wavelength_selection="survey_a/channel_beta",
     )
 
-For several duplicated physical wavelengths, provide one channel per physical
-wavelength::
+For several multiplets, provide exactly one selected observational channel for
+every duplicated physical wavelength.  The mapping is generic and may mix
+pairs, triplets, and larger groups::
 
     lc.fit(
         model="2DWavelengthDependent",
         duplicate_wavelength_policy="select",
         duplicate_wavelength_selection={
-            0.6561154962791801: "KELT/OSN_Johnson.Cousins_R3_1",
-            1.25: "SURVEY/FILTER_CHANNEL",
+            0.65: "survey_a/channel_beta",
+            1.25: "instrument_c/stream_3",
         },
     )
 
-The ``"all"`` policy is reserved for a scientifically validated
-instrument-channel calibration strategy.  It currently raises
+Every unselected channel in each multiplet is excluded before model or
+likelihood construction.  The selected rows, ignored rows, multiplet sizes,
+and channel identities are recorded in
+``lc.duplicate_wavelength_channel_resolution`` and in fit-history provenance.
+
+The ``"all"`` policy remains reserved for a scientifically validated
+instrument-channel calibration strategy.  It raises
 :class:`NotImplementedError` before fitting rather than pooling uncalibrated
-channels.  Resolution is recorded in ``lc.duplicate_wavelength_channel_resolution``
-and in fit-history provenance.  Direct :meth:`~pgmuvi.lightcurve.Lightcurve.fit`
-calls preserve the package's established in-place fit contract: the fitted
-object stores the observations actually used by its model.
+channels at an identical GP coordinate.
 
-To preserve one loaded source while fitting alternative channels, create
-independent resolved copies first::
+To preserve one loaded source while comparing alternative explicit choices,
+create independent resolved copies::
 
-    source = Lightcurve.from_csv(
-        "examples/data/10131+3049.csv",
-        max_samples=None,
-        max_samples_per_band=None,
-    )
-    r3_0 = source.copy_with_duplicate_wavelength_channels()
-    r3_1 = source.copy_with_duplicate_wavelength_channels(
+    source = Lightcurve.from_csv("multiwavelength_source.csv", max_samples=None)
+
+    option_a = source.copy_with_duplicate_wavelength_channels(
         policy="select",
-        selection="KELT/OSN_Johnson.Cousins_R3_1",
+        selection={
+            0.65: "survey_a/channel_alpha",
+            1.25: "instrument_c/stream_1",
+        },
+    )
+    option_b = source.copy_with_duplicate_wavelength_channels(
+        policy="select",
+        selection={
+            0.65: "survey_a/channel_beta",
+            1.25: "instrument_c/stream_3",
+        },
     )
 
-    r3_0.fit(model="2DWavelengthDependent")
-    r3_1.fit(model="2DWavelengthDependent")
+    option_a.fit(model="2DWavelengthDependent")
+    option_b.fit(model="2DWavelengthDependent")
 
 ``source`` remains unchanged; each returned copy owns independent data and
-transform objects and records its own channel-resolution provenance.
+transform objects and records its own multiplet-resolution provenance.
 
 When constructor-time ``max_samples_per_band`` is enabled, per-row
-observational-channel labels are used as the grouping key.  Thus two channels
-at one physical wavelength are subsampled independently before the fit policy
-selects one.  Numeric physical wavelength is used only when channel labels are
-unavailable.
+observational-channel labels are used as the grouping key.  Channels at one
+physical wavelength are subsampled independently before the explicit fit
+policy selects one.  Numeric physical wavelength is used only when channel
+labels are unavailable.
 
 Observational-channel labels and mixed-channel input
 ------------------------------------------------------

--- a/docs/source/howto/multiband.rst
+++ b/docs/source/howto/multiband.rst
@@ -86,27 +86,43 @@ The fitting workflow is the same as in 1D::
 
     lc.fit(model="2D")
 
-When several observational channels share one physical wavelength, the default
-fit policy retains the first channel encountered in the original aligned input
-row order captured before constructor subsampling and warns which channels were
-ignored.  This makes the bundled
-``examples/data/10131+3049.csv`` source fit-able without silently pooling its
-two KELT data streams.  To choose the other channel explicitly::
+When several observational channels share one physical wavelength, they form
+a shared-wavelength multiplet.  Pairs, triplets, and larger groups are detected
+from the input itself; no instrument or channel name is hard-coded.  The default
+fit policy is ``"error"`` so the package never chooses a representative channel
+silently.
+
+Inspect the detected structure first::
+
+    print(lc.duplicate_physical_wavelength_multiplets())
+
+Then choose the GP training input explicitly.  To use the first channel in each
+multiplet::
+
+    lc.fit(
+        model="2D",
+        duplicate_wavelength_policy="first",
+    )
+
+To choose one channel per multiplet::
 
     lc.fit(
         model="2D",
         duplicate_wavelength_policy="select",
-        duplicate_wavelength_selection="KELT/OSN_Johnson.Cousins_R3_1",
+        duplicate_wavelength_selection={
+            0.65: "survey_a/channel_beta",
+            1.25: "instrument_c/stream_3",
+        },
     )
 
-The explicit ``"all"`` policy is unavailable until a scientifically validated
-instrument-channel calibration strategy exists; requesting it raises
-an explicit unsupported-policy exception before model construction.
+The explicit ``"all"`` policy remains unavailable until a scientifically
+validated calibration strategy exists; requesting it raises before model
+construction rather than pooling uncalibrated channels at the same GP input
+coordinate.
 
-For side-by-side fits of the two KELT channels without modifying the loaded
-source, use
-:meth:`~pgmuvi.lightcurve.Lightcurve.copy_with_duplicate_wavelength_channels`
-to create one independent fit target per choice.
+Use :meth:`~pgmuvi.lightcurve.Lightcurve.copy_with_duplicate_wavelength_channels`
+to construct independent fit targets for alternative explicit selections
+without mutating the loaded source.
 
 For heterogeneous channel sampling (for example, one observational channel has
 far more observations than the others), consider using the legacy best-band

--- a/docs/source/notebooks/tutorial_wavelength_constraints.ipynb
+++ b/docs/source/notebooks/tutorial_wavelength_constraints.ipynb
@@ -17,7 +17,7 @@
    "source": [
     "## Execution policy and scientific scope\n",
     "\n",
-    "Restart the kernel and use **Run All**. The required path sets `RUN_REQUIRED_FITS = True` and fits both `2DWavelengthDependent` and the constant-mean `2DSeparable` control. The bounded sample is deterministic and preserves every observational channel and every physical wavelength. Optional expensive extensions remain disabled.\n",
+    "Restart the kernel and use **Run All**. The required path sets `RUN_REQUIRED_FITS = True` and fits both `2DWavelengthDependent` and the constant-mean `2DSeparable` control. The bounded sample is deterministic and initially preserves every observational channel and every physical wavelength. Before each GP fit, the notebook explicitly selects the R3_0 observational channel from the one shared-wavelength multiplet; no implicit first-channel rule is used. Optional expensive extensions remain disabled.\n",
     "\n",
     "This is a numerical and workflow demonstration, not automatic model selection or a claim that the inferred wavelength dependence is uniquely physical. Instrument-channel calibration remains `TBD[instrument-channel-calibration]`: two observational channels at one physical wavelength retain distinct identities, but this tutorial does not cross-calibrate them.\n"
    ]
@@ -57,6 +57,9 @@
     "RUN_OPTIONAL_EXPENSIVE_EXTENSIONS = False\n",
     "MAX_SAMPLES_PER_OBSERVATIONAL_CHANNEL = 15\n",
     "REQUIRED_TRAINING_ITERATIONS = 30\n",
+    "DUPLICATE_WAVELENGTH_SELECTION = {\n",
+    "    0.6561154962791801: \"KELT/OSN_Johnson.Cousins_R3_0\",\n",
+    "}\n",
     "\n",
     "np.random.seed(SEED)\n",
     "torch.manual_seed(SEED)\n",
@@ -274,6 +277,8 @@
     "    \"lr\": 0.03,\n",
     "    \"learn_additional_noise\": True,\n",
     "    \"use_parameter_workflow\": True,\n",
+    "    \"duplicate_wavelength_policy\": \"select\",\n",
+    "    \"duplicate_wavelength_selection\": DUPLICATE_WAVELENGTH_SELECTION,\n",
     "    \"verbose\": False,\n",
     "}\n",
     "\n",

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -3622,11 +3622,24 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             groups.append(
                 {
                     "physical_wavelength": float(wavelength),
+                    "multiplet_size": len(channel_order),
                     "observational_channels": channel_order,
                     "row_counts": row_counts,
                 }
             )
         return groups
+
+    def duplicate_physical_wavelength_multiplets(self) -> list[dict]:
+        """Return a public, independent report of shared-wavelength multiplets.
+
+        Each returned record describes one physical wavelength represented by
+        two or more distinct observational channels. Pairs, triplets, and
+        larger multiplets are represented uniformly. Mutating the returned
+        report does not alter the light curve.
+        """
+        return copy.deepcopy(
+            self._duplicate_physical_wavelength_channel_groups()
+        )
 
     @staticmethod
     def _normalize_duplicate_wavelength_selection(
@@ -3855,7 +3868,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
     def copy_with_duplicate_wavelength_channels(
         self,
         *,
-        policy="first",
+        policy="error",
         selection=None,
     ) -> "Lightcurve":
         """Return an independent light curve with duplicate channels resolved.
@@ -3868,9 +3881,11 @@ class Lightcurve(InputHelpers, gpytorch.Module):
 
         Parameters
         ----------
-        policy : {"first", "select", "all"}, optional
+        policy : {"error", "first", "select", "all"}, optional
             Duplicate-channel policy forwarded to
-            :meth:`_apply_duplicate_wavelength_channel_policy`.
+            :meth:`_apply_duplicate_wavelength_channel_policy`. ``"error"``
+            is the default and requires the caller to choose explicitly when
+            any shared-wavelength multiplet is present.
         selection : str or dict, optional
             Explicit observational-channel selection used with ``"select"``.
 
@@ -3924,7 +3939,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
     def _apply_duplicate_wavelength_channel_policy(
         self,
         *,
-        policy="first",
+        policy="error",
         selection=None,
     ) -> dict:
         """Resolve duplicated physical-wavelength channels before fitting.
@@ -3934,7 +3949,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         by the resulting model, matching existing constructor-time filtering
         and subsampling semantics.
         """
-        allowed = {"first", "select", "all"}
+        allowed = {"error", "first", "select", "all"}
         if not isinstance(policy, str):
             raise TypeError(
                 "duplicate_wavelength_policy must be one of "
@@ -3974,6 +3989,33 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 return copy.deepcopy(existing_resolution)
             self.duplicate_wavelength_channel_resolution = provenance
             return provenance
+
+        if policy == "error":
+            if selection is not None:
+                raise ValueError(
+                    "duplicate_wavelength_selection is only valid with "
+                    "duplicate_wavelength_policy='select'."
+                )
+            descriptions = "; ".join(
+                (
+                    f"{group['physical_wavelength']:g} "
+                    f"({group['multiplet_size']}-channel multiplet): "
+                    + ", ".join(group["observational_channels"])
+                )
+                for group in groups
+            )
+            raise ValueError(
+                "Multiple observational channels share one or more physical "
+                f"wavelengths. Detected multiplets: {descriptions}. "
+                "Choose the GP training input explicitly with "
+                "duplicate_wavelength_policy='first' or "
+                "duplicate_wavelength_policy='select' together with "
+                "duplicate_wavelength_selection. Inspect the complete "
+                "structure with "
+                "duplicate_physical_wavelength_multiplets(). "
+                "duplicate_wavelength_policy='all' remains unavailable "
+                "without a scientifically validated calibration strategy."
+            )
 
         if self.band is None or len(self.band) != len(self._xdata_raw):
             raise ValueError(
@@ -10989,7 +11031,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
     def fit(
         self,
         *args,
-        duplicate_wavelength_policy="first",
+        duplicate_wavelength_policy="error",
         duplicate_wavelength_selection=None,
         **kwargs,
     ):
@@ -10997,15 +11039,17 @@ class Lightcurve(InputHelpers, gpytorch.Module):
 
         Parameters
         ----------
-        duplicate_wavelength_policy : {"first", "select", "all"}, optional
+        duplicate_wavelength_policy : {"error", "first", "select", "all"}, optional
             Policy for physical wavelengths represented by more than one
-            observational channel. ``"first"`` (default) retains the first
-            channel encountered in the original aligned input row order,
-            captured before constructor sampling, subsampling, or
-            transformation, and warns about every ignored channel.
-            ``"select"`` requires ``duplicate_wavelength_selection``.
-            ``"all"`` is reserved for validated instrument-channel
-            calibration and currently raises :class:`NotImplementedError`.
+            observational channel. ``"error"`` (default) refuses to construct
+            a GP training input until the caller chooses explicitly.
+            ``"first"`` retains the first channel encountered in the original
+            aligned input row order, captured before constructor sampling,
+            subsampling, or transformation, and warns about every ignored
+            channel. ``"select"`` requires
+            ``duplicate_wavelength_selection``. ``"all"`` is reserved for
+            validated instrument-channel calibration and currently raises
+            :class:`NotImplementedError`.
         duplicate_wavelength_selection : str or dict, optional
             Explicit channel selection used with policy ``"select"``. A
             single string is accepted only when exactly one physical

--- a/tests/test_consensus_duplicate_wavelength_scope.py
+++ b/tests/test_consensus_duplicate_wavelength_scope.py
@@ -287,7 +287,7 @@ class TestConsensusDuplicateWavelengthScope(unittest.TestCase):
             "_fit_core",
             new=fake_fit_core,
         ):
-            lc.fit()
+            lc.fit(duplicate_wavelength_policy="first")
 
         self.assertEqual(
             observations["channels"],
@@ -475,7 +475,10 @@ class TestConsensusDuplicateWavelengthScope(unittest.TestCase):
                 UserWarning,
                 "Selected .*R3_0",
             ):
-                result = lc.fit(fit_strategy="consensus")
+                result = lc.fit(
+                    fit_strategy="consensus",
+                    duplicate_wavelength_policy="first",
+                )
 
         self.assertEqual(result, {"status": "mock-fit-complete"})
         self.assertIn(KELT_R3_0, observed["consensus_channels"])
@@ -564,7 +567,10 @@ class TestConsensusDuplicateWavelengthScope(unittest.TestCase):
             new=fake_fit_core,
         ):
             with self.assertWarns(UserWarning):
-                lc.fit(fit_strategy="consensus")
+                lc.fit(
+                    fit_strategy="consensus",
+                    duplicate_wavelength_policy="first",
+                )
             lc.fit()
 
         self.assertIsNotNone(observed_contexts[0])
@@ -592,7 +598,10 @@ class TestConsensusDuplicateWavelengthScope(unittest.TestCase):
                     RuntimeError,
                     "synthetic consensus failure",
                 ):
-                    lc.fit(fit_strategy="consensus")
+                    lc.fit(
+                        fit_strategy="consensus",
+                        duplicate_wavelength_policy="first",
+                    )
 
         self.assertTrue(lc.assert_active_source_for_test)
         self.assertFalse(

--- a/tests/test_docs_wavelength_constraint_notebook.py
+++ b/tests/test_docs_wavelength_constraint_notebook.py
@@ -68,6 +68,8 @@ class TestWavelengthConstraintNotebook(unittest.TestCase):
             'model="2DSeparable"',
             "primary_lightcurve.fit(",
             "control_lightcurve.fit(",
+            'duplicate_wavelength_policy": "select"',
+            "DUPLICATE_WAVELENGTH_SELECTION",
             "primary_lightcurve.plot(",
             "training_point_prediction_summary",
             "summarize_observational_channel_residuals",

--- a/tests/test_duplicate_wavelength_channel_policy.py
+++ b/tests/test_duplicate_wavelength_channel_policy.py
@@ -44,6 +44,39 @@ def _make_duplicate_group_lightcurve(two_groups: bool = False) -> Lightcurve:
     )
 
 
+def _make_pair_and_triplet_lightcurve() -> Lightcurve:
+    """Return arbitrary channel names with one pair and one triplet."""
+    times = torch.arange(18, dtype=torch.get_default_dtype())
+    wavelengths = torch.tensor(
+        [1.0] * 2
+        + [1.0] * 3
+        + [2.0] * 2
+        + [2.0] * 2
+        + [2.0] * 4
+        + [3.0] * 5,
+        dtype=torch.get_default_dtype(),
+    )
+    bands = np.asarray(
+        ["survey_a/channel_alpha"] * 2
+        + ["survey_b/channel_beta"] * 3
+        + ["instrument_c/stream_1"] * 2
+        + ["instrument_d/stream_2"] * 2
+        + ["instrument_e/stream_3"] * 4
+        + ["unique/channel"] * 5,
+        dtype=np.str_,
+    )
+    xdata = torch.stack((times, wavelengths), dim=1)
+    ydata = 1.0 + torch.sin(times / 3.0)
+    yerr = torch.full_like(ydata, 0.1)
+    return Lightcurve(
+        xdata,
+        ydata,
+        yerr=yerr,
+        band=bands,
+        max_samples=None,
+    )
+
+
 class TestDuplicateWavelengthDiscovery(unittest.TestCase):
     def test_detects_channels_in_first_row_order(self):
         lc = _make_duplicate_group_lightcurve()
@@ -61,15 +94,79 @@ class TestDuplicateWavelengthDiscovery(unittest.TestCase):
             [],
         )
 
+    def test_public_report_detects_pair_and_triplet_generically(self):
+        lc = _make_pair_and_triplet_lightcurve()
+        multiplets = lc.duplicate_physical_wavelength_multiplets()
+
+        self.assertEqual(len(multiplets), 2)
+        self.assertEqual(multiplets[0]["physical_wavelength"], 1.0)
+        self.assertEqual(multiplets[0]["multiplet_size"], 2)
+        self.assertEqual(
+            multiplets[0]["observational_channels"],
+            ["survey_a/channel_alpha", "survey_b/channel_beta"],
+        )
+        self.assertEqual(
+            multiplets[0]["row_counts"],
+            {
+                "survey_a/channel_alpha": 2,
+                "survey_b/channel_beta": 3,
+            },
+        )
+
+        self.assertEqual(multiplets[1]["physical_wavelength"], 2.0)
+        self.assertEqual(multiplets[1]["multiplet_size"], 3)
+        self.assertEqual(
+            multiplets[1]["observational_channels"],
+            [
+                "instrument_c/stream_1",
+                "instrument_d/stream_2",
+                "instrument_e/stream_3",
+            ],
+        )
+        self.assertEqual(
+            multiplets[1]["row_counts"],
+            {
+                "instrument_c/stream_1": 2,
+                "instrument_d/stream_2": 2,
+                "instrument_e/stream_3": 4,
+            },
+        )
+
+        multiplets[0]["observational_channels"].append("mutated")
+        self.assertNotIn(
+            "mutated",
+            lc.duplicate_physical_wavelength_multiplets()[0][
+                "observational_channels"
+            ],
+        )
+
 
 class TestDuplicateWavelengthPolicy(unittest.TestCase):
-    def test_default_first_retains_first_channel_and_warns(self):
+    def test_default_requires_explicit_policy_and_preserves_data(self):
+        lc = _make_duplicate_group_lightcurve()
+        original_x = lc.xdata.clone()
+        original_y = lc.ydata.clone()
+        original_band = lc.band.copy()
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "Choose the GP training input explicitly",
+        ):
+            lc._apply_duplicate_wavelength_channel_policy()
+
+        torch.testing.assert_close(lc.xdata, original_x)
+        torch.testing.assert_close(lc.ydata, original_y)
+        np.testing.assert_array_equal(lc.band, original_band)
+
+    def test_explicit_first_retains_first_channel_and_warns(self):
         lc = _make_duplicate_group_lightcurve()
         with self.assertWarnsRegex(
             UserWarning,
             "Selected A .* ignored B \\(2 rows\\)",
         ):
-            provenance = lc._apply_duplicate_wavelength_channel_policy()
+            provenance = lc._apply_duplicate_wavelength_channel_policy(
+                policy="first",
+            )
         self.assertEqual(len(lc.xdata), 10)
         self.assertNotIn("B", set(lc.band.tolist()))
         self.assertIn("A", set(lc.band.tolist()))
@@ -101,6 +198,39 @@ class TestDuplicateWavelengthPolicy(unittest.TestCase):
                 selection={1.0: "B", 2.0: "D"},
             )
         self.assertEqual(set(lc.band.tolist()), {"B", "D"})
+
+    def test_select_mapping_resolves_pair_and_triplet_before_fit(self):
+        lc = _make_pair_and_triplet_lightcurve()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            provenance = lc._apply_duplicate_wavelength_channel_policy(
+                policy="select",
+                selection={
+                    1.0: "survey_b/channel_beta",
+                    2.0: "instrument_e/stream_3",
+                },
+            )
+
+        self.assertEqual(
+            set(lc.band.tolist()),
+            {
+                "survey_b/channel_beta",
+                "instrument_e/stream_3",
+                "unique/channel",
+            },
+        )
+        self.assertEqual(len(lc.xdata), 12)
+        self.assertEqual(
+            [
+                row["selected_observational_channel"]
+                for row in provenance["groups"]
+            ],
+            ["survey_b/channel_beta", "instrument_e/stream_3"],
+        )
+        self.assertEqual(
+            [row["selected_row_count"] for row in provenance["groups"]],
+            [3, 4],
+        )
 
     def test_string_is_rejected_for_multiple_groups(self):
         lc = _make_duplicate_group_lightcurve(two_groups=True)
@@ -209,7 +339,9 @@ class TestDuplicateWavelengthConstructorSubsampling(unittest.TestCase):
         self.assertEqual(groups[0]["observational_channels"], ["B", "A"])
 
         with self.assertWarnsRegex(UserWarning, "Selected B"):
-            provenance = lc._apply_duplicate_wavelength_channel_policy()
+            provenance = lc._apply_duplicate_wavelength_channel_policy(
+                policy="first",
+            )
 
         self.assertEqual(
             provenance["groups"][0]["selected_observational_channel"],
@@ -254,7 +386,9 @@ class TestDuplicateWavelengthNonMutatingCopy(unittest.TestCase):
         original_band = source.band.copy()
 
         with self.assertWarnsRegex(UserWarning, "Selected A"):
-            resolved = source.copy_with_duplicate_wavelength_channels()
+            resolved = source.copy_with_duplicate_wavelength_channels(
+                policy="first",
+            )
 
         self.assertIsNot(resolved, source)
         torch.testing.assert_close(source.xdata, original_x)
@@ -268,7 +402,9 @@ class TestDuplicateWavelengthNonMutatingCopy(unittest.TestCase):
         source = _make_duplicate_group_lightcurve()
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            first = source.copy_with_duplicate_wavelength_channels()
+            first = source.copy_with_duplicate_wavelength_channels(
+                policy="first",
+            )
             second = source.copy_with_duplicate_wavelength_channels(
                 policy="select",
                 selection="B",
@@ -326,12 +462,29 @@ class TestDuplicateWavelengthFitIntegration(unittest.TestCase):
             result = lc.fit(**fit_kwargs)
         return result, fit_core
 
-    def test_fit_default_resolves_before_core(self):
+    def test_fit_default_requires_explicit_policy_and_never_calls_core(self):
+        lc = _make_duplicate_group_lightcurve()
+        with mock.patch.object(
+            Lightcurve,
+            "_fit_core",
+            autospec=True,
+        ) as fit_core:
+            with self.assertRaisesRegex(
+                ValueError,
+                "Choose the GP training input explicitly",
+            ):
+                lc.fit(model="2D")
+        fit_core.assert_not_called()
+        self.assertEqual(len(lc.xdata), 12)
+        self.assertIn("B", set(lc.band.tolist()))
+
+    def test_fit_explicit_first_resolves_before_core(self):
         lc = _make_duplicate_group_lightcurve()
         with self.assertWarnsRegex(UserWarning, "ignored B"):
             result, fit_core = self._fit_without_training(
                 lc,
                 model="2D",
+                duplicate_wavelength_policy="first",
             )
         self.assertEqual(result, "fit-result")
         self.assertEqual(len(lc.xdata), 10)
@@ -369,7 +522,11 @@ class TestDuplicateWavelengthFitIntegration(unittest.TestCase):
         lc = _make_duplicate_group_lightcurve()
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            self._fit_without_training(lc, model="2D")
+            self._fit_without_training(
+                lc,
+                model="2D",
+                duplicate_wavelength_policy="first",
+            )
         self.assertEqual(len(lc.fit_history), 1)
         notes = lc.fit_history[0]["notes"]
         resolution = notes["duplicate_wavelength_channel_resolution"]
@@ -397,7 +554,9 @@ class TestRepresentativeDatasetDuplicateWavelengthPolicy(unittest.TestCase):
         )
 
         with self.assertWarnsRegex(UserWarning, "Selected .*R3_0"):
-            provenance = lc._apply_duplicate_wavelength_channel_policy()
+            provenance = lc._apply_duplicate_wavelength_channel_policy(
+                policy="first",
+            )
 
         channels = set(lc.band.tolist())
         self.assertIn(KELT_R3_0, channels)
@@ -408,7 +567,26 @@ class TestRepresentativeDatasetDuplicateWavelengthPolicy(unittest.TestCase):
             {KELT_R3_1: 3636},
         )
 
-    def test_representative_dataset_default_fit_reaches_core(self):
+    def test_representative_dataset_default_fit_requires_user_choice(self):
+        lc = Lightcurve.from_csv(REPRESENTATIVE_CSV, max_samples=None)
+
+        with mock.patch.object(
+            Lightcurve,
+            "_fit_core",
+            autospec=True,
+        ) as fit_core:
+            with self.assertRaisesRegex(
+                ValueError,
+                "Choose the GP training input explicitly",
+            ):
+                lc.fit(model="2D")
+
+        fit_core.assert_not_called()
+        self.assertEqual(len(lc.xdata), 10815)
+        self.assertIn(KELT_R3_0, set(lc.band.tolist()))
+        self.assertIn(KELT_R3_1, set(lc.band.tolist()))
+
+    def test_representative_dataset_explicit_first_reaches_core(self):
         lc = Lightcurve.from_csv(REPRESENTATIVE_CSV, max_samples=None)
 
         with mock.patch.object(
@@ -418,7 +596,10 @@ class TestRepresentativeDatasetDuplicateWavelengthPolicy(unittest.TestCase):
             return_value="fit-result",
         ) as fit_core:
             with self.assertWarnsRegex(UserWarning, "Selected .*R3_0"):
-                result = lc.fit(model="2D")
+                result = lc.fit(
+                    model="2D",
+                    duplicate_wavelength_policy="first",
+                )
 
         self.assertEqual(result, "fit-result")
         fit_core.assert_called_once()


### PR DESCRIPTION
## Summary

Implement generic, user-controlled handling of every group of observational channels that shares one physical wavelength.

The implementation is instrument-agnostic: pairs, triplets, and larger multiplets are discovered from the aligned physical-wavelength and observational-channel arrays rather than from KELT-specific names.

## Behavior

- Add the public `Lightcurve.duplicate_physical_wavelength_multiplets()` report.
- Report physical wavelength, multiplet size, ordered observational-channel identities, and row counts.
- Change the fitting default to `duplicate_wavelength_policy="error"` so GP training input is never chosen silently.
- Retain explicit `duplicate_wavelength_policy="first"` for callers that deliberately want input-order selection.
- Require `duplicate_wavelength_policy="select"` to resolve every detected multiplet.
- Support a channel string only when exactly one multiplet exists; require a physical-wavelength-to-channel mapping when several multiplets exist.
- Preserve the full multi-channel source for period consensus while restricting only the downstream GP training input.
- Keep uncalibrated `"all"` pooling unavailable and fail before model construction.
- Record the exact resolution and ignored rows in fitting provenance.
- Update the maintained representative notebook to choose KELT R3_0 explicitly rather than relying on row order.

## Generalization evidence

Tests exercise:

- no duplicate physical wavelengths;
- one arbitrary pair;
- one arbitrary triplet;
- a mixed pair-plus-triplet source;
- arbitrary instrument and observational-channel names;
- explicit `first` and `select` behavior;
- missing, extra, ambiguous, and invalid selections;
- non-mutating resolved copies;
- exact rows reaching `_fit_core`;
- consensus retaining all observational-channel votes;
- the bundled `examples/data/10131+3049.csv` representative source.

The real KELT pair remains only a representative dataset check and does not define the feature.

## Validation

- Focused duplicate-multiplet policy tests: 28 passed.
- Consensus duplicate-scope tests: 12 passed.
- Wavelength-constraint notebook contract tests: 7 passed.
- Full `unittest discover` suite: 2,822 passed.
- `ruff check ./pgmuvi`: passed.
- `make -C docs html-strict`: passed.
- `git diff --check`: passed.

## Boundaries

This PR does not calibrate, average, or pool observational channels. Calibration discovery and population validation remain deferred future work in draft PRs #265 and #266, tracked by issues #267 and #268.

This PR is based directly on the PR169 repository-reference-integrity line and does not include the deferred PR170/PR171 stack.
