### PR TITLE
Enable learned additional noise by default

### DIFF
--- a/docs/source/howto/consensus_fitting.rst
+++ b/docs/source/howto/consensus_fitting.rst
@@ -226,10 +226,13 @@ Learned additional noise and uncertainty units
 
 With per-point uncertainties, the default automatic likelihood treats stored
 ``yerr`` values as standard deviations because ``variance=False`` by default.
-The values are squared before being supplied to the fixed-noise likelihood.
+The values are squared before being supplied as fixed per-observation variances,
+and PGMUVI now learns one additional homoscedastic variance by default.  The
+additional term starts near 10% of the median supplied variance so it begins as
+a perturbation rather than replacing the reported uncertainties.
 
-Set ``learn_additional_noise=True`` when the quoted uncertainties may not account
-for all scatter:
+The explicit ``learn_additional_noise=True`` spelling remains available and can
+make the statistical choice visible in a saved workflow:
 
 .. code-block:: python
 
@@ -243,11 +246,13 @@ for all scatter:
    )
 
 This adds one learned homoscedastic variance term on top of the supplied
-per-observation variances.  It does not replace the reported errors.  Do not set
-``variance=True`` unless the stored uncertainty column already contains
-variances rather than standard deviations.  With a ``ytransform``, standard
-deviations use the fitted scale once and variances use its square; location
-shifts are never applied to either quantity.
+per-observation variances.  It does not replace the reported errors.  Pass
+``learn_additional_noise=False`` or ``likelihood="fixed"`` to recover the legacy
+fixed-noise-only behaviour explicitly.  Do not set ``variance=True`` unless the
+stored uncertainty column already contains variances rather than standard
+deviations.  With a ``ytransform``, standard deviations use the fitted scale
+once and variances use its square; location shifts are never applied to either
+quantity.
 
 Initialization, constraints, and numerical stability
 -----------------------------------------------------

--- a/pgmuvi/lightcurve.py
+++ b/pgmuvi/lightcurve.py
@@ -7154,7 +7154,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         self,
         likelihood=None,
         variance=False,
-        learn_additional_noise=False,
+        learn_additional_noise=None,
         **kwargs,
     ):
         """Set the likelihood function for the model
@@ -7174,15 +7174,13 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             uncertainties are available, a standard
             :class:`gpytorch.likelihoods.GaussianLikelihood` is used.
 
-            If a string, it must be ``'learn'``. This is a backwards-
-            compatible alias for setting ``learn_additional_noise=True`` while
-            otherwise using the automatically selected likelihood. With
-            per-point uncertainties, this creates a
-            :class:`gpytorch.likelihoods.FixedNoiseGaussianLikelihood` with a
-            learned homoscedastic noise term in addition to the fixed
-            per-observation variances. Without per-point uncertainties, this
-            falls back to :class:`gpytorch.likelihoods.GaussianLikelihood`,
-            whose noise parameter is already learned.
+            If a string, it must be ``"learn"`` or ``"fixed"``.
+            ``"learn"`` explicitly enables the automatically selected
+            likelihood with learned additional noise. ``"fixed"`` explicitly
+            restores the legacy fixed-noise-only behaviour when per-point
+            uncertainties are available. Without per-point uncertainties, both
+            automatic modes use :class:`gpytorch.likelihoods.GaussianLikelihood`,
+            whose single noise parameter is learned.
 
             If an instance of a :class:`~gpytorch.likelihoods.likelihood.Likelihood`
             object is passed, that object is used directly. If a Constraint
@@ -7215,21 +7213,44 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             the square of the fitted y-axis scale before being passed to the
             likelihood; without a y-transform they are passed through
             unchanged.
-        learn_additional_noise : bool, optional
-            If ``True`` and per-point uncertainties are available, use
-            :class:`gpytorch.likelihoods.FixedNoiseGaussianLikelihood` with
-            ``learn_additional_noise=True`` so the model can infer an
-            additional homoscedastic variance term on top of the supplied
-            measurement variances. If no per-point uncertainties are available,
-            this flag simply selects the standard
+        learn_additional_noise : bool or None, optional
+            Controls the additive homoscedastic variance used with supplied
+            per-point uncertainties. ``None`` (default) enables learned
+            additional noise for the automatic likelihood path. ``True``
+            explicitly enables it and ``False`` explicitly selects fixed
+            per-observation variances only. The learned variance is initialized
+            near 10% of the median supplied variance, subject to the likelihood's
+            live noise constraint. If no per-point uncertainties are available,
+            the automatic path uses
             :class:`gpytorch.likelihoods.GaussianLikelihood`, whose single
             noise term is already learned.
         """
 
-        if likelihood == "learn":
-            likelihood = None
-            learn_additional_noise = True
-        elif learn_additional_noise and likelihood is not None:
+        if isinstance(likelihood, str):
+            likelihood_mode = likelihood.strip().lower()
+            if likelihood_mode == "learn":
+                likelihood = None
+                learn_additional_noise = True
+            elif likelihood_mode == "fixed":
+                if learn_additional_noise is not None and bool(
+                    learn_additional_noise
+                ):
+                    raise ValueError(
+                        "likelihood='fixed' conflicts with "
+                        "learn_additional_noise=True."
+                    )
+                likelihood = None
+                learn_additional_noise = False
+            else:
+                raise ValueError(
+                    "String likelihood values must be 'learn' or 'fixed', "
+                    f"got {likelihood!r}."
+                )
+        elif (
+            learn_additional_noise is not None
+            and bool(learn_additional_noise)
+            and likelihood is not None
+        ):
             raise ValueError(
                 "learn_additional_noise can only be used with the automatic "
                 "likelihood path (likelihood=None) or with likelihood='learn'. "
@@ -7237,6 +7258,8 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 "likelihood behaviour is required."
             )
 
+        if learn_additional_noise is None:
+            learn_additional_noise = likelihood is None
         learn_additional_noise = bool(learn_additional_noise)
 
         # Prepare the noise tensor: gpytorch likelihoods expect variances.
@@ -7251,11 +7274,57 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 else self._yerr_transformed ** 2
             )
 
+        self._initial_additional_noise_variance = None
         if _has_noise and likelihood is None:
             self.likelihood = gpytorch.likelihoods.FixedNoiseGaussianLikelihood(
                 noise,
                 learn_additional_noise=learn_additional_noise,
             )
+            self._move_module_to_data_dtype(self.likelihood)
+            if learn_additional_noise:
+                second_noise_covar = self.likelihood.second_noise_covar
+                initial_additional_noise = 0.1 * torch.median(noise.detach())
+                raw_constraint = getattr(
+                    second_noise_covar, "raw_noise_constraint", None
+                )
+                if raw_constraint is not None:
+                    lower_bound = torch.as_tensor(
+                        raw_constraint.lower_bound,
+                        dtype=noise.dtype,
+                        device=noise.device,
+                    ).max()
+                    upper_bound = torch.as_tensor(
+                        raw_constraint.upper_bound,
+                        dtype=noise.dtype,
+                        device=noise.device,
+                    ).min()
+                    scale = torch.maximum(
+                        torch.abs(lower_bound),
+                        torch.ones(
+                            (),
+                            dtype=noise.dtype,
+                            device=noise.device,
+                        ),
+                    )
+                    spacing = torch.finfo(noise.dtype).eps * scale
+                    if torch.isfinite(lower_bound):
+                        initial_additional_noise = torch.maximum(
+                            initial_additional_noise,
+                            lower_bound + spacing,
+                        )
+                    if torch.isfinite(upper_bound):
+                        initial_additional_noise = torch.minimum(
+                            initial_additional_noise,
+                            upper_bound - spacing,
+                        )
+                with torch.no_grad():
+                    second_noise_covar.noise = initial_additional_noise
+                realized_additional_noise = (
+                    second_noise_covar.noise.detach().reshape(-1)[0]
+                )
+                self._initial_additional_noise_variance = float(
+                    realized_additional_noise.cpu().item()
+                )
         elif "Constraint" in [t.__name__ for t in type(likelihood).__mro__]:
             # In this case, the likelihood has been passed a constraint, which
             # means we want a constrained GaussianLikelihood
@@ -7293,7 +7362,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         likelihood=None,
         num_mixtures=None,
         variance=False,
-        learn_additional_noise=False,
+        learn_additional_noise=None,
         **kwargs,
     ):
         """Set the model for the lightcurve
@@ -7351,10 +7420,11 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             uncertainties are treated as errors and squared before being used
             as noise variances.  Set to True if the stored uncertainties
             already represent variances.
-        learn_additional_noise : bool, optional
-            Passed to `set_likelihood()`. If True and per-point uncertainties
-            are available, learn an additional homoscedastic noise variance on
-            top of the supplied fixed per-observation variances.
+        learn_additional_noise : bool or None, optional
+            Passed to :meth:`set_likelihood`. ``None`` (default) enables
+            learned additional noise for a newly created automatic likelihood
+            while preserving any likelihood already configured on the
+            lightcurve. Pass ``False`` or ``likelihood="fixed"`` to opt out.
         **kwargs : dict, optional
             Any other keyword arguments to be passed to the model constructor.
         """
@@ -7404,8 +7474,10 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             "2DPowerLawMean": PowerLawMeanGPModel,
         }
 
-        _noise_setting_changed = bool(learn_additional_noise) != bool(
-            getattr(self, "_learn_additional_noise", False)
+        _noise_setting_changed = (
+            learn_additional_noise is not None
+            and bool(learn_additional_noise)
+            != bool(getattr(self, "_learn_additional_noise", True))
         )
         if not hasattr(self, "likelihood"):
             self.set_likelihood(
@@ -11316,7 +11388,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         lr=0.1,
         stopavg=30,
         variance=False,
-        learn_additional_noise=False,
+        learn_additional_noise=None,
         fit_strategy=None,
         verbose=False,
         **kwargs,
@@ -11476,12 +11548,12 @@ class Lightcurve(InputHelpers, gpytorch.Module):
             (standard deviations) and are squared before being used as noise
             variances in the likelihood.  Set to True if the stored
             uncertainties already represent variances.
-        learn_additional_noise : bool, optional
-            If True and per-point uncertainties are available, the automatic
-            likelihood learns an additional homoscedastic noise variance on top
-            of the fixed per-observation variances. If no uncertainties are
-            available, the standard Gaussian likelihood already learns its
-            single noise term.
+        learn_additional_noise : bool or None, optional
+            ``None`` (default) learns an additional homoscedastic variance when
+            per-point uncertainties are supplied. Pass ``False`` or
+            ``likelihood="fixed"`` to retain fixed per-observation variances
+            without an additive learned term. Existing explicitly configured
+            likelihood behaviour is preserved when this argument is omitted.
         fit_strategy : {"consensus", "consensus_multicomp",
                         "consensus_relaxed"} or None, optional
             Optional fitting-strategy selector.  The default ``None`` keeps the
@@ -11576,8 +11648,10 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 **kwargs,
             )
 
-        _noise_setting_changed = bool(learn_additional_noise) != bool(
-            getattr(self, "_learn_additional_noise", False)
+        _noise_setting_changed = (
+            learn_additional_noise is not None
+            and bool(learn_additional_noise)
+            != bool(getattr(self, "_learn_additional_noise", True))
         )
         if not hasattr(self, "likelihood"):
             self.set_likelihood(
@@ -11613,6 +11687,16 @@ class Lightcurve(InputHelpers, gpytorch.Module):
         #     raise ValueError("""You must provide a likelihood function""")
         # elif likelihood is not None:
         #     self.set_likelihood(likelihood, **kwargs)
+
+        _effective_learn_additional_noise = bool(
+            getattr(
+                self,
+                "_learn_additional_noise",
+                True
+                if learn_additional_noise is None
+                else bool(learn_additional_noise),
+            )
+        )
 
         # Validate explicitly-provided num_mixtures early.
         if num_mixtures is not None:
@@ -11918,7 +12002,9 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 self.set_likelihood(
                     likelihood,
                     variance=variance,
-                    learn_additional_noise=learn_additional_noise,
+                    learn_additional_noise=(
+                        _effective_learn_additional_noise
+                    ),
                     **kwargs,
                 )
                 if hasattr(_stored_instance, "set_train_data"):
@@ -11944,7 +12030,9 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                     likelihood,
                     num_mixtures=_effective_num_mixtures,
                     variance=variance,
-                    learn_additional_noise=learn_additional_noise,
+                    learn_additional_noise=(
+                        _effective_learn_additional_noise
+                    ),
                     **kwargs,
                 )
             else:
@@ -11955,7 +12043,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 likelihood,
                 num_mixtures=num_mixtures,
                 variance=variance,
-                learn_additional_noise=learn_additional_noise,
+                learn_additional_noise=_effective_learn_additional_noise,
                 **kwargs,
             )
 
@@ -18892,7 +18980,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 fit_kwargs.get("likelihood"),
                 num_mixtures=fit_kwargs.get("num_mixtures"),
                 variance=fit_kwargs.get("variance", False),
-                learn_additional_noise=fit_kwargs.get("learn_additional_noise", False),
+                learn_additional_noise=fit_kwargs.get("learn_additional_noise"),
                 **set_model_kwargs,
             )
         fit_kwargs["model"] = None
@@ -19674,7 +19762,7 @@ class Lightcurve(InputHelpers, gpytorch.Module):
                 fit_kwargs.get("likelihood"),
                 num_mixtures=fit_kwargs.get("num_mixtures"),
                 variance=fit_kwargs.get("variance", False),
-                learn_additional_noise=fit_kwargs.get("learn_additional_noise", False),
+                learn_additional_noise=fit_kwargs.get("learn_additional_noise"),
                 **set_model_kwargs,
             )
         fit_kwargs["model"] = None

--- a/tests/test_learned_additional_noise.py
+++ b/tests/test_learned_additional_noise.py
@@ -4,15 +4,23 @@ import unittest
 
 import gpytorch
 import torch
+from gpytorch.constraints import Interval
 
 from pgmuvi.lightcurve import Lightcurve
 
 
 class TestLearnedAdditionalNoise(unittest.TestCase):
     def setUp(self):
-        self.x = torch.linspace(0.0, 9.0, 10)
-        self.y = torch.sin(self.x)
-        self.yerr = torch.full_like(self.y, 0.1)
+        self.x = torch.linspace(0.0, 10.0, 32, dtype=torch.float64)
+        self.y = 2.0 + 0.2 * torch.sin(self.x)
+        self.yerr = torch.full_like(self.y, 0.2)
+
+    def _make_lightcurve(self, *, with_yerr=True):
+        return Lightcurve(
+            self.x,
+            self.y,
+            yerr=self.yerr if with_yerr else None,
+        )
 
     def _assert_has_learned_additional_noise(self, likelihood):
         self.assertIsInstance(
@@ -22,64 +30,201 @@ class TestLearnedAdditionalNoise(unittest.TestCase):
         self.assertTrue(hasattr(likelihood, "second_noise_covar"))
         named_parameters = dict(likelihood.named_parameters())
         self.assertTrue(
-            any(name.startswith("second_noise_covar") for name in named_parameters),
-            msg=(
-                "FixedNoiseGaussianLikelihood should expose learned additional "
-                "noise parameters under second_noise_covar."
+            any(
+                name.startswith("second_noise_covar")
+                for name in named_parameters
             ),
+            "FixedNoiseGaussianLikelihood should expose learned additional "
+            "noise parameters under second_noise_covar.",
         )
 
-    def test_fixed_noise_can_learn_additional_noise(self):
-        lc = Lightcurve(self.x, self.y, yerr=self.yerr)
+    def _assert_has_no_learned_additional_noise(self, likelihood):
+        self.assertIsInstance(
+            likelihood,
+            gpytorch.likelihoods.FixedNoiseGaussianLikelihood,
+        )
+        named_parameters = dict(likelihood.named_parameters())
+        self.assertFalse(
+            any(
+                name.startswith("second_noise_covar")
+                for name in named_parameters
+            )
+        )
 
+    def test_default_with_yerr_learns_additional_noise(self):
+        lc = self._make_lightcurve()
+        lc.set_likelihood()
+        self._assert_has_learned_additional_noise(lc.likelihood)
+        self.assertTrue(lc._learn_additional_noise)
+
+    def test_fixed_noise_can_explicitly_learn_additional_noise(self):
+        lc = self._make_lightcurve()
         lc.set_likelihood(learn_additional_noise=True)
-
         self._assert_has_learned_additional_noise(lc.likelihood)
         self.assertTrue(lc._learn_additional_noise)
 
     def test_likelihood_learn_alias_enables_additional_noise(self):
-        lc = Lightcurve(self.x, self.y, yerr=self.yerr)
-
+        lc = self._make_lightcurve()
         lc.set_likelihood(likelihood="learn")
-
         self._assert_has_learned_additional_noise(lc.likelihood)
         self.assertTrue(lc._learn_additional_noise)
 
-    def test_likelihood_learn_without_yerr_uses_gaussian_likelihood(self):
-        lc = Lightcurve(self.x, self.y)
+    def test_likelihood_fixed_alias_restores_fixed_noise_only(self):
+        lc = self._make_lightcurve()
+        lc.set_likelihood(likelihood="fixed")
+        self._assert_has_no_learned_additional_noise(lc.likelihood)
+        self.assertFalse(lc._learn_additional_noise)
+        self.assertIsNone(lc._initial_additional_noise_variance)
 
-        lc.set_likelihood(likelihood="learn")
-
-        self.assertIsInstance(lc.likelihood, gpytorch.likelihoods.GaussianLikelihood)
-        self.assertTrue(lc._learn_additional_noise)
-
-    def test_set_model_forwards_learn_additional_noise(self):
-        lc = Lightcurve(self.x, self.y, yerr=self.yerr)
-
-        lc.set_model("1D", num_mixtures=1, learn_additional_noise=True)
-
-        self._assert_has_learned_additional_noise(lc.likelihood)
-        self.assertTrue(lc._learn_additional_noise)
-
-    def test_reconfigures_existing_automatic_likelihood(self):
-        lc = Lightcurve(self.x, self.y, yerr=self.yerr)
-        lc.set_likelihood()
+    def test_explicit_false_restores_fixed_noise_only(self):
+        lc = self._make_lightcurve()
+        lc.set_likelihood(learn_additional_noise=False)
+        self._assert_has_no_learned_additional_noise(lc.likelihood)
         self.assertFalse(lc._learn_additional_noise)
 
-        lc.set_likelihood(learn_additional_noise=True)
+    def test_default_initializes_additional_variance_from_fixed_noise(self):
+        lc = self._make_lightcurve()
+        lc.set_likelihood()
+        fixed_noise = lc.likelihood.noise_covar.noise.detach()
+        expected = 0.1 * torch.median(fixed_noise)
+        actual = (
+            lc.likelihood.second_noise_covar.noise.detach().reshape(-1)[0]
+        )
+        self.assertTrue(torch.isfinite(actual))
+        torch.testing.assert_close(
+            actual,
+            expected,
+            rtol=1.0e-6,
+            atol=1.0e-12,
+        )
+        self.assertAlmostEqual(
+            lc._initial_additional_noise_variance,
+            float(actual.cpu().item()),
+            places=12,
+        )
 
+    def test_default_noise_receives_live_interval_constraint(self):
+        lc = self._make_lightcurve()
+        lc.set_model("1DMatern")
+        lc.set_default_constraints()
+        constraint = lc.likelihood.second_noise_covar.raw_noise_constraint
+        self.assertIsInstance(constraint, Interval)
+        learned_noise = (
+            lc.likelihood.second_noise_covar.noise.detach().reshape(-1)[0]
+        )
+        lower = torch.as_tensor(
+            constraint.lower_bound,
+            dtype=learned_noise.dtype,
+            device=learned_noise.device,
+        ).max()
+        upper = torch.as_tensor(
+            constraint.upper_bound,
+            dtype=learned_noise.dtype,
+            device=learned_noise.device,
+        ).min()
+        self.assertGreaterEqual(float(learned_noise), float(lower))
+        self.assertLessEqual(float(learned_noise), float(upper))
+
+    def test_default_without_yerr_uses_gaussian_likelihood(self):
+        lc = self._make_lightcurve(with_yerr=False)
+        lc.set_likelihood()
+        self.assertIsInstance(
+            lc.likelihood,
+            gpytorch.likelihoods.GaussianLikelihood,
+        )
+        self.assertTrue(lc._learn_additional_noise)
+        self.assertIsNone(lc._initial_additional_noise_variance)
+
+    def test_likelihood_learn_without_yerr_uses_gaussian_likelihood(self):
+        lc = self._make_lightcurve(with_yerr=False)
+        lc.set_likelihood(likelihood="learn")
+        self.assertIsInstance(
+            lc.likelihood,
+            gpytorch.likelihoods.GaussianLikelihood,
+        )
+        self.assertTrue(lc._learn_additional_noise)
+
+    def test_set_model_defaults_to_learned_additional_noise(self):
+        lc = self._make_lightcurve()
+        lc.set_model("1DMatern")
         self._assert_has_learned_additional_noise(lc.likelihood)
         self.assertTrue(lc._learn_additional_noise)
 
-    def test_rejects_explicit_likelihood_with_learn_additional_noise_flag(self):
-        lc = Lightcurve(self.x, self.y, yerr=self.yerr)
-        explicit_likelihood = gpytorch.likelihoods.GaussianLikelihood()
+    def test_set_model_preserves_explicit_fixed_configuration(self):
+        lc = self._make_lightcurve()
+        lc.set_likelihood(likelihood="fixed")
+        lc.set_model("1DMatern")
+        self._assert_has_no_learned_additional_noise(lc.likelihood)
+        self.assertFalse(lc._learn_additional_noise)
 
+    def test_fit_defaults_to_learned_additional_noise(self):
+        lc = self._make_lightcurve()
+        lc.fit(
+            model="1DMatern",
+            training_iter=1,
+            miniter=1,
+            lr=0.01,
+            use_parameter_workflow=False,
+        )
+        self._assert_has_learned_additional_noise(lc.likelihood)
+        self.assertTrue(lc._learn_additional_noise)
+        learned_noise = lc.likelihood.second_noise_covar.noise.detach()
+        self.assertTrue(torch.isfinite(learned_noise).all())
+
+    def test_fit_fixed_alias_opts_out(self):
+        lc = self._make_lightcurve()
+        lc.fit(
+            model="1DMatern",
+            likelihood="fixed",
+            training_iter=1,
+            miniter=1,
+            lr=0.01,
+            use_parameter_workflow=False,
+        )
+        self._assert_has_no_learned_additional_noise(lc.likelihood)
+        self.assertFalse(lc._learn_additional_noise)
+
+    def test_reconfigures_existing_automatic_likelihood(self):
+        lc = self._make_lightcurve()
+        lc.set_likelihood()
+        self.assertTrue(lc._learn_additional_noise)
+        lc.set_likelihood(learn_additional_noise=False)
+        self._assert_has_no_learned_additional_noise(lc.likelihood)
+        self.assertFalse(lc._learn_additional_noise)
+        lc.set_likelihood()
+        self._assert_has_learned_additional_noise(lc.likelihood)
+        self.assertTrue(lc._learn_additional_noise)
+
+    def test_custom_likelihood_is_accepted_when_flag_is_omitted(self):
+        lc = self._make_lightcurve()
+        explicit_likelihood = gpytorch.likelihoods.GaussianLikelihood()
+        lc.set_likelihood(likelihood=explicit_likelihood)
+        self.assertIs(lc.likelihood, explicit_likelihood)
+        self.assertFalse(lc._learn_additional_noise)
+
+    def test_rejects_explicit_likelihood_with_learn_additional_noise_flag(
+        self,
+    ):
+        lc = self._make_lightcurve()
+        explicit_likelihood = gpytorch.likelihoods.GaussianLikelihood()
         with self.assertRaisesRegex(ValueError, "learn_additional_noise"):
             lc.set_likelihood(
                 likelihood=explicit_likelihood,
                 learn_additional_noise=True,
             )
+
+    def test_rejects_conflicting_fixed_alias_and_true_flag(self):
+        lc = self._make_lightcurve()
+        with self.assertRaisesRegex(ValueError, "conflicts"):
+            lc.set_likelihood(
+                likelihood="fixed",
+                learn_additional_noise=True,
+            )
+
+    def test_rejects_unknown_string_likelihood(self):
+        lc = self._make_lightcurve()
+        with self.assertRaisesRegex(ValueError, "'learn' or 'fixed'"):
+            lc.set_likelihood(likelihood="mystery")
 
 
 if __name__ == "__main__":

--- a/tests/test_transformed_uncertainties.py
+++ b/tests/test_transformed_uncertainties.py
@@ -140,7 +140,12 @@ class TestLightcurveTransformedUncertainties(unittest.TestCase):
 
         lc.set_likelihood(variance=True)
 
-        self.assertTrue(torch.allclose(lc.likelihood.noise, variances / 36.0))
+        self.assertTrue(
+            torch.allclose(
+                lc.likelihood.noise_covar.noise,
+                variances / 36.0,
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -131,8 +131,7 @@ class TestLightCurve(unittest.TestCase):
         self.assertTrue(torch.equal(self.lightcurve._yerr_transformed, self.test_yerr_transformed))
 
     def test_set_likelihood_squares_errors_by_default(self):
-        """set_likelihood should pass squared errors (variances) to
-        FixedNoiseGaussianLikelihood by default (variance=False)."""
+        """set_likelihood should pass squared errors to the fixed component."""
         lc = Lightcurve(self.test_xdata, self.test_ydata, yerr=self.test_ydata)
         lc.set_likelihood()
         self.assertIsInstance(
@@ -140,11 +139,15 @@ class TestLightCurve(unittest.TestCase):
             gpytorch.likelihoods.FixedNoiseGaussianLikelihood,
         )
         expected_noise = lc._yerr_transformed ** 2
-        self.assertTrue(torch.allclose(lc.likelihood.noise, expected_noise))
+        self.assertTrue(
+            torch.allclose(
+                lc.likelihood.noise_covar.noise,
+                expected_noise,
+            )
+        )
 
     def test_set_likelihood_uses_errors_as_variances_when_variance_true(self):
-        """When variance=True, set_likelihood should pass errors unchanged to
-        FixedNoiseGaussianLikelihood (i.e. treat them as already-squared)."""
+        """variance=True should preserve values in the fixed component."""
         lc = Lightcurve(self.test_xdata, self.test_ydata, yerr=self.test_ydata)
         lc.set_likelihood(variance=True)
         self.assertIsInstance(
@@ -152,7 +155,12 @@ class TestLightCurve(unittest.TestCase):
             gpytorch.likelihoods.FixedNoiseGaussianLikelihood,
         )
         expected_noise = lc._yerr_transformed
-        self.assertTrue(torch.allclose(lc.likelihood.noise, expected_noise))
+        self.assertTrue(
+            torch.allclose(
+                lc.likelihood.noise_covar.noise,
+                expected_noise,
+            )
+        )
 
 
 class TestFitLS(unittest.TestCase):


### PR DESCRIPTION
## Summary

- learn one additional homoscedastic variance by default when per-point uncertainties are supplied
- retain the supplied per-observation variances as the fixed noise component
- initialize the learned variance near 10% of the median supplied variance
- add explicit `likelihood="fixed"` and `learn_additional_noise=False` opt-outs
- retain the existing `likelihood="learn"` alias
- preserve custom likelihoods and previously configured fixed-noise behavior when the option is omitted
- propagate the same policy through ordinary and consensus fitting paths
- update uncertainty tests and public fitting documentation for the new noise semantics

## Validation

- `python -m unittest discover -s tests -p "test*.py"` — 2,834 tests passed
- `ruff check ./pgmuvi` — passed
- focused Ruff checks for the new/updated standalone tests — passed
- `make -C docs html-strict` — passed
- Python syntax and `git diff --check` — passed

## Scope

This PR changes the default likelihood behavior only. It does not change log-flux handling, observational-channel calibration, or the calibration catalogue.
